### PR TITLE
mrc-372 Use DB user profiles for login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ matrix:
       script:
       - ./src/gradlew -p src app::test
       - ./src/gradlew -p src userCLI::test
-      after_success:
       - ./src/gradlew -p src app::jacocoTestReport
       - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - (cd src; ./src/userCLI/scripts/build; ./src/userCLI/scripts/push)
+      after_success:
       - codecov -f src/app/coverage/test/*.xml
       - ./scripts/travis.sh
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       - ./src/gradlew -p src userCLI::test
       - ./src/gradlew -p src app::jacocoTestReport
       - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-      - (cd src; ./src/userCLI/scripts/build; ./src/userCLI/scripts/push)
+      - (cd src; ./userCLI/scripts/build; ./userCLI/scripts/push)
       after_success:
       - codecov -f src/app/coverage/test/*.xml
       - ./scripts/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ matrix:
       after_success:
       - ./src/gradlew -p src app::jacocoTestReport
       - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-      - ./src/userCLI/scripts/build
-      - ./src/userCLI/scripts/push
+      - (cd src; ./src/userCLI/scripts/build; ./src/userCLI/scripts/push)
       - codecov -f src/app/coverage/test/*.xml
       - ./scripts/travis.sh
       services:

--- a/scripts/add-test-user.sh
+++ b/scripts/add-test-user.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 NETWORK=hint_nw
 
-image=mrcide/hint-user-cli:mrc-373_userrepo #TODO: change this to master after merge
+image=mrcide/hint-user-cli:mrc-372 #TODO: change to master when merged
+docker pull $image
 docker run --network=hint_nw $image add-user test.user@example.com password

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -24,4 +24,7 @@ docker run --rm --network=$NETWORK \
   mrcide/hint-db-migrate:latest \
   -url=jdbc:postgresql://$CONTAINER/hint
 
+HERE=$(dirname "$0")
+"$HERE"/add-test-user.sh
+
 

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -67,5 +67,11 @@ task compileFrontEnd() {
 	}
 }
 
+//Run bootRun with eg -PspringProfile=prod to run with a different active profile from default 'dev' 
+//defined in gradle.properties
+bootRun {
+	bootRun.systemProperty 'spring.profiles.active', springProfile
+}
+
 processResources.dependsOn 'compileFrontEnd'
 

--- a/src/app/gradle.properties
+++ b/src/app/gradle.properties
@@ -1,0 +1,1 @@
+springProfile=dev

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/Pac4jConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/Pac4jConfig.kt
@@ -5,6 +5,8 @@ import org.pac4j.core.config.Config
 import org.pac4j.core.context.session.J2ESessionStore
 import org.pac4j.http.client.indirect.FormClient
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator
+import org.pac4j.sql.profile.service.DbProfileService
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -12,9 +14,12 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ComponentScan(basePackages = ["org.pac4j.springframework.web", "org.pac4j.springframework.component"])
 open class Pac4jConfig {
+
+   @Autowired lateinit var profileService: DbProfileService
+
    @Bean
     open fun getConfig(): Config {
-        val formClient = FormClient("/login", SimpleTestUsernamePasswordAuthenticator())
+        val formClient = FormClient("/login", profileService)
         val clients = Clients("/callback", formClient)
         return Config(clients).apply {
             sessionStore = J2ESessionStore()

--- a/src/app/src/main/resources/application-dev.properties
+++ b/src/app/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+spring.datasource.jdbc-url=jdbc:postgresql://localhost/hint

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
@@ -5,9 +5,15 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.exchange
 import org.springframework.boot.test.web.client.getForEntity
-import org.springframework.http.HttpStatus
+import org.springframework.boot.test.web.client.postForEntity
+import org.springframework.http.*
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.util.LinkedMultiValueMap
 
+
+@ActiveProfiles(profiles=["test"])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class HintApplicationTests(@Autowired val restTemplate: TestRestTemplate) {
 
@@ -20,6 +26,50 @@ class HintApplicationTests(@Autowired val restTemplate: TestRestTemplate) {
         val entity = restTemplate.getForEntity<String>("/")
         assertThat(entity.body!!).contains("Log In")
         assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `can login with correct credentials`() {
+        val map = LinkedMultiValueMap<String, String>()
+        map.add("username", "test.user@example.com")
+        map.add("password", "password")
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+
+        val entity = restTemplate.postForEntity<String>("/callback/", HttpEntity(map, headers))
+
+        //test get redirected to '/'
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.FOUND)
+        assertThat(entity.headers["Location"]!!.first()).isEqualTo("/")
+
+        val cookies = entity.headers["Set-Cookie"]!!.first().split(";")
+        val sessionCookie = cookies.first{it.startsWith("JSESSIONID")}.split("=")[1]
+
+        //Assert can access '/' using the cookie
+        val rootHeaders = HttpHeaders()
+        rootHeaders.put("Cookie", listOf("JSESSIONID=" + sessionCookie))
+        val getRootEntity = HttpEntity(null, rootHeaders)
+        val rootEntity = restTemplate.exchange("/", HttpMethod.GET, getRootEntity, String::class.java)
+
+        assertThat(rootEntity.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `redirect back to login page on login with incorrect correct credentials`() {
+        val map = LinkedMultiValueMap<String, String>()
+        map.add("username", "test.user@example.com")
+        map.add("password", "badpassword")
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+
+        val entity = restTemplate.postForEntity<String>("/callback/", HttpEntity(map, headers))
+
+        //test get redirected back to login page
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.FOUND)
+        assertThat(entity.headers["Location"]!!.first())
+                .isEqualTo("/login?username=test.user%40example.com&error=BadCredentialsException")
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
@@ -5,13 +5,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.boot.test.web.client.exchange
 import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.boot.test.web.client.postForEntity
 import org.springframework.http.*
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.util.LinkedMultiValueMap
-
 
 @ActiveProfiles(profiles=["test"])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -46,7 +44,7 @@ class HintApplicationTests(@Autowired val restTemplate: TestRestTemplate) {
         val cookies = entity.headers["Set-Cookie"]!!.first().split(";")
         val sessionCookie = cookies.first{it.startsWith("JSESSIONID")}.split("=")[1]
 
-        //Assert can access '/' using the cookie
+        //Assert can access '/' using the returned cookie
         val rootHeaders = HttpHeaders()
         rootHeaders.put("Cookie", listOf("JSESSIONID=" + sessionCookie))
         val getRootEntity = HttpEntity(null, rootHeaders)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.security.Pac4jConfig
 import org.junit.jupiter.api.extension.ExtendWith
 import org.pac4j.core.client.BaseClient
+import org.pac4j.core.context.session.J2ESessionStore
 import org.pac4j.http.client.indirect.FormClient
 import org.pac4j.sql.profile.service.DbProfileService
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,6 +26,7 @@ class Pac4jConfigTests
 
         Assertions.assertThat(config.clients.callbackUrl).isEqualTo("/callback")
         Assertions.assertThat(config.clients.clients.count()).isEqualTo(1)
+
         val client = config.clients.clients.first()
         Assertions.assertThat(client).isInstanceOf(FormClient::class.java)
         Assertions.assertThat((client as FormClient).loginUrl).isEqualTo("/login")
@@ -32,5 +34,7 @@ class Pac4jConfigTests
         val field = BaseClient::class.java.getDeclaredField("authenticator")
         field.isAccessible = true
         Assertions.assertThat(field.get(client)).isInstanceOf(DbProfileService::class.java)
+
+        Assertions.assertThat(config.sessionStore).isInstanceOf(J2ESessionStore::class.java)
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
@@ -1,7 +1,7 @@
 package org.imperial.mrc.hint.unit.security
 
 import org.junit.jupiter.api.Test
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.security.Pac4jConfig
 import org.junit.jupiter.api.extension.ExtendWith
 import org.pac4j.core.client.BaseClient
@@ -20,21 +20,27 @@ class Pac4jConfigTests
     private lateinit var sut: Pac4jConfig
 
     @Test
+    fun `config properties are initialized`()
+    {
+        assertThat(sut.profileService).isInstanceOf(DbProfileService::class.java)
+    }
+
+    @Test
     fun `can get config`()
     {
         val config = sut.getConfig()
 
-        Assertions.assertThat(config.clients.callbackUrl).isEqualTo("/callback")
-        Assertions.assertThat(config.clients.clients.count()).isEqualTo(1)
+        assertThat(config.clients.callbackUrl).isEqualTo("/callback")
+        assertThat(config.clients.clients.count()).isEqualTo(1)
 
         val client = config.clients.clients.first()
-        Assertions.assertThat(client).isInstanceOf(FormClient::class.java)
-        Assertions.assertThat((client as FormClient).loginUrl).isEqualTo("/login")
+        assertThat(client).isInstanceOf(FormClient::class.java)
+        assertThat((client as FormClient).loginUrl).isEqualTo("/login")
 
         val field = BaseClient::class.java.getDeclaredField("authenticator")
         field.isAccessible = true
-        Assertions.assertThat(field.get(client)).isInstanceOf(DbProfileService::class.java)
+        assertThat(field.get(client)).isInstanceOf(DbProfileService::class.java)
 
-        Assertions.assertThat(config.sessionStore).isInstanceOf(J2ESessionStore::class.java)
+        assertThat(config.sessionStore).isInstanceOf(J2ESessionStore::class.java)
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
@@ -3,14 +3,24 @@ package org.imperial.mrc.hint.unit.security
 import org.junit.jupiter.api.Test
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.security.Pac4jConfig
+import org.junit.jupiter.api.extension.ExtendWith
+import org.pac4j.core.client.BaseClient
 import org.pac4j.http.client.indirect.FormClient
+import org.pac4j.sql.profile.service.DbProfileService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
+@SpringBootTest
+@ExtendWith(SpringExtension::class)
 class Pac4jConfigTests
 {
+    @Autowired
+    private lateinit var sut: Pac4jConfig
+
     @Test
     fun `can get config`()
     {
-        val sut = Pac4jConfig()
         val config = sut.getConfig()
 
         Assertions.assertThat(config.clients.callbackUrl).isEqualTo("/callback")
@@ -18,5 +28,9 @@ class Pac4jConfigTests
         val client = config.clients.clients.first()
         Assertions.assertThat(client).isInstanceOf(FormClient::class.java)
         Assertions.assertThat((client as FormClient).loginUrl).isEqualTo("/login")
+
+        val field = BaseClient::class.java.getDeclaredField("authenticator")
+        field.isAccessible = true
+        Assertions.assertThat(field.get(client)).isInstanceOf(DbProfileService::class.java)
     }
 }

--- a/src/settings.gradle
+++ b/src/settings.gradle
@@ -6,3 +6,4 @@ pluginManagement {
 
 rootProject.name = 'hint'
 include 'app', 'userCLI'
+

--- a/src/settings.gradle
+++ b/src/settings.gradle
@@ -6,4 +6,3 @@ pluginManagement {
 
 rootProject.name = 'hint'
 include 'app', 'userCLI'
-


### PR DESCRIPTION
Login form now uses the DbProfileService for the user db. The run-dependencies scripts adds the test user, so can now log in locally with user = test.user@example.com, password = password