### PR TITLE
Mrc 428 Error page if login attempt with blank username or password

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/HintDbProfileService.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/HintDbProfileService.kt
@@ -1,0 +1,27 @@
+package org.imperial.mrc.hint.security
+
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.credentials.UsernamePasswordCredentials
+import org.pac4j.core.credentials.password.PasswordEncoder
+import org.pac4j.core.exception.BadCredentialsException
+import org.pac4j.core.util.CommonHelper
+import org.pac4j.sql.profile.service.DbProfileService
+import javax.sql.DataSource
+
+class HintDbProfileService(dataSource: DataSource, passwordEncoder: PasswordEncoder): DbProfileService(dataSource, passwordEncoder)
+{
+    override fun validate(credentials: UsernamePasswordCredentials, context: WebContext)
+    {
+        //The base class considers a blank username or password to be an error state, and throws a TechnicalException
+        //rather than BadCredentialsException which is what we want - treat blank pw or username same as wrong pw or
+        //username
+        if (!CommonHelper.isBlank(credentials.username) && !CommonHelper.isBlank(credentials.password))
+        {
+            super.validate(credentials, context)
+        }
+        else
+        {
+            throw BadCredentialsException("Username and password must be provided")
+        }
+    }
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -16,8 +16,8 @@ import javax.sql.DataSource
 class Pac4jConfig {
 
     @Bean
-    fun getProfileService(dataSource: DataSource): DbProfileService {
-        return DbProfileService(TransactionAwareDataSourceProxy(dataSource), SecurePasswordEncoder())
+    fun getProfileService(dataSource: DataSource): HintDbProfileService {
+        return HintDbProfileService(TransactionAwareDataSourceProxy(dataSource), SecurePasswordEncoder())
     }
 
     @Bean

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/HintDbProfileServiceTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/HintDbProfileServiceTests.kt
@@ -1,0 +1,62 @@
+package org.imperial.mrc.hint.database
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.imperial.mrc.hint.security.HintDbProfileService
+import org.junit.jupiter.api.Test
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.credentials.UsernamePasswordCredentials
+import org.pac4j.core.exception.BadCredentialsException
+import org.pac4j.core.exception.AccountNotFoundException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@ActiveProfiles(profiles=["test"])
+@SpringBootTest
+@Transactional
+class HintDbProfileServiceTests
+{
+    private val mockContext = mock<WebContext>{}
+
+    @Autowired
+    private lateinit var sut: HintDbProfileService
+
+    @Test
+    fun `throws BadCredentialsException if username is blank`()
+    {
+        val credentials = mock<UsernamePasswordCredentials>{
+            on { getUsername() } doReturn ""
+            on { getPassword() } doReturn "password"
+        }
+
+        assertThatThrownBy{ sut.validate(credentials, mockContext) }.isInstanceOf(BadCredentialsException::class.java)
+                .hasMessage("Username and password must be provided")
+
+    }
+
+    @Test
+    fun `throws BadCredentialsException if password is blank`()
+    {
+        val credentials = mock<UsernamePasswordCredentials>{
+            on { getUsername() } doReturn "username"
+            on { getPassword() } doReturn ""
+        }
+
+        assertThatThrownBy{ sut.validate(credentials, mockContext) }.isInstanceOf(BadCredentialsException::class.java)
+                .hasMessage("Username and password must be provided")
+    }
+
+    @Test
+    fun `validates as base class if username and password are both provided`()
+    {
+        val credentials = mock<UsernamePasswordCredentials>{
+            on { getUsername() } doReturn "username"
+            on { getPassword() } doReturn "password"
+        }
+
+        assertThatThrownBy{ sut.validate(credentials, mockContext) }.isInstanceOf(AccountNotFoundException::class.java)
+                .hasMessage("No account found for: username")
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
@@ -2,6 +2,7 @@ package org.imperial.mrc.hint.unit.security
 
 import org.junit.jupiter.api.Test
 import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.hint.security.HintDbProfileService
 import org.imperial.mrc.hint.security.Pac4jConfig
 import org.imperial.mrc.hint.security.SecurePasswordEncoder
 import org.junit.jupiter.api.extension.ExtendWith
@@ -51,6 +52,7 @@ class Pac4jConfigTests
     fun `can get dbProfileService`()
     {
         val result = sut.getProfileService(wiredDataSource)
+        assertThat(result).isInstanceOf(HintDbProfileService::class.java)
         assertThat(result.dataSource).isInstanceOf(TransactionAwareDataSourceProxy::class.java)
         assertThat((result.dataSource as TransactionAwareDataSourceProxy).targetDataSource).isSameAs(wiredDataSource)
         assertThat(result.passwordEncoder).isInstanceOf(SecurePasswordEncoder::class.java)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
@@ -20,13 +20,19 @@ class LoginTests
         model["title"] = "test title"
         val doc = template.jsoupDocFor(model)
 
+        assertThat(doc.select("form").attr("onsubmit")).isEqualTo("validate(event);")
+
         assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username")
         assertThat(doc.select("form #user-id").attr("value")).isEqualTo("test user")
         assertThat(doc.select("form #user-id").attr("type")).isEqualTo("text")
+        assertThat(doc.select("form #userid-feedback").hasClass("invalid-feedback")).isTrue()
+        assertThat(doc.select("form #userid-feedback").text()).isEqualTo("Please enter your username.")
 
         assertThat(doc.select("form label[for='pw-id']").text()).isEqualTo("Password")
         assertThat(doc.select("form #pw-id").attr("value")).isEqualTo("")
         assertThat(doc.select("form #pw-id").attr("type")).isEqualTo("password")
+        assertThat(doc.select("form #pw-feedback").hasClass("invalid-feedback")).isTrue()
+        assertThat(doc.select("form #pw-feedback").text()).isEqualTo("Please enter your password.")
 
         assertThat(doc.select("form input[type='submit']").attr("value")).isEqualTo("Log In")
         assertThat(doc.select("#error").text()).isEqualTo("test error")

--- a/src/app/templates/login.ftl
+++ b/src/app/templates/login.ftl
@@ -21,12 +21,12 @@
                 <div class="form-group">
                     <label for="user-id">Username</label>
                     <input type="text" size="20" class="form-control" name="username" id="user-id" value="${username}" required>
-                    <div class="invalid-feedback">Please enter your username.</div>
+                    <div id="userid-feedback" class="invalid-feedback">Please enter your username.</div>
                 </div>
                 <div class="form-group">
                     <label for="pw-id">Password</label>
                     <input type="password" size="20" class="form-control" name="password" id="pw-id" required>
-                    <div class="invalid-feedback">Please enter your password.</div>
+                    <div id="pw-feedback" class="invalid-feedback">Please enter your password.</div>
                 </div>
                 <div class="text-center">
                     <input class="btn btn-red" type="submit" value="Log In">

--- a/src/app/templates/login.ftl
+++ b/src/app/templates/login.ftl
@@ -4,18 +4,29 @@
     <title>${title}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" href="/public/css/style.css"/>
+    <script>
+        function validate(event) {
+            const form = document.getElementById("login-form");
+            if (!form.checkValidity()) {
+                event.preventDefault();
+                form.classList.add('was-validated');
+            }
+        }
+    </script>
 </head>
 <body>
     <div id="app" class="card login-form mx-auto mt-5">
         <div class="card-body">
-            <form method="post" action="/callback">
+            <form id="login-form" method="post" action="/callback" class="needs-validation" novalidate onsubmit="validate(event);">
                 <div class="form-group">
                     <label for="user-id">Username</label>
-                    <input type="text" size="20" class="form-control" name="username" id="user-id" value="${username}">
+                    <input type="text" size="20" class="form-control" name="username" id="user-id" value="${username}" required>
+                    <div class="invalid-feedback">Please enter your username.</div>
                 </div>
                 <div class="form-group">
                     <label for="pw-id">Password</label>
-                    <input type="password" size="20" class="form-control" name="password" id="pw-id">
+                    <input type="password" size="20" class="form-control" name="password" id="pw-id" required>
+                    <div class="invalid-feedback">Please enter your password.</div>
                 </div>
                 <div class="text-center">
                     <input class="btn btn-red" type="submit" value="Log In">


### PR DESCRIPTION
The form now requires both inputs to have a value, but I also put in a custom DbProfileservice class to deal with this situation as a BadCredentials exception rather than a TechnicalException (which puts pac4j into an error state)