### PR TITLE
mrc-507 run integration test using session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ COPY ./src/app/static/public /static/public
 COPY ./src/app/templates /templates
 
 ADD ./src/app/build/distributions/app-boot.tar /
+
+ARG SPRING_PROFILES_ACTIVE
+ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
+
 ENTRYPOINT ["/app-boot/bin/app"]

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -8,5 +8,5 @@ export NODE_ENV=production
 
 $HERE/../src/gradlew -p $HERE/../src :app:bootDistTar
 
-docker build $HERE/.. --tag $APP_DOCKER_COMMIT_TAG \
+docker build --build-arg SPRING_PROFILES_ACTIVE=$1 $HERE/.. --tag $APP_DOCKER_COMMIT_TAG \
     && docker tag $APP_DOCKER_COMMIT_TAG $APP_DOCKER_BRANCH_TAG

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -20,7 +20,6 @@ interface AppProperties {
     val uploadDirectory: String
     val dbUser: String
     val dbPassword: String
-    val useAuth: Boolean
 }
 
 //prevent auto-wiring of default Properties
@@ -41,7 +40,6 @@ class ConfiguredAppProperties(private val props: HintProperties = properties): A
     override val uploadDirectory = propString("upload_dir")
     override val dbUser: String = propString("db_user")
     override val dbPassword: String = propString("db_password")
-    override val useAuth = propString("use_auth").toBoolean()
 
     companion object {
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -31,10 +31,8 @@ class MvcConfig(val config: Config, val appProperties: AppProperties) : WebMvcCo
     }
 
     override fun addInterceptors(registry: InterceptorRegistry) {
-        if (appProperties.useAuth) {
-            registry.addInterceptor(SecurityInterceptor(config, "FormClient"))
-                    .addPathPatterns("/**")
-                    .excludePathPatterns("/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")
-        }
+        registry.addInterceptor(SecurityInterceptor(config, "FormClient"))
+                .addPathPatterns("/**")
+                .excludePathPatterns("/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")
     }
 }

--- a/src/app/src/main/resources/application-node.properties
+++ b/src/app/src/main/resources/application-node.properties
@@ -1,0 +1,1 @@
+server.servlet.session.cookie.http-only=false

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -11,4 +11,3 @@ token_issuer=mrc-ide
 hintr_url=http://localhost:8888
 db_user=hintuser
 db_password=changeme
-use_auth=true

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -2022,6 +2022,12 @@
         }
       }
     },
+    "axios-middleware": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/axios-middleware/-/axios-middleware-0.3.1.tgz",
+      "integrity": "sha512-DuPLxZgqBYnRgEhEUulNzPspf0j9jlH5iWOJHEfuLFfsxWLc7vjeOxR903dp+G+nrU3TYWbg2COLZ4PDUwh87g==",
+      "dev": true
+    },
     "axios-mock-adapter": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -23,6 +23,7 @@
     "@types/qs": "^6.5.3",
     "@vue/test-utils": "^1.0.0-beta.29",
     "axios": "^0.19.0",
+    "axios-middleware": "^0.3.1",
     "axios-mock-adapter": "^1.16.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",

--- a/src/app/static/scripts/run-dependencies-for-integration-tests.sh
+++ b/src/app/static/scripts/run-dependencies-for-integration-tests.sh
@@ -7,7 +7,7 @@ HINT=hint
 $HERE/../../../../scripts/run-dependencies.sh
 
 . $HERE/../../../../scripts/common # sets GIT_BRANCH
-$HERE/../../../../scripts/build-app.sh
+$HERE/../../../../scripts/build-app.sh node
 
 TEST_CONFIG=$HERE/test.properties
 HINT_IMAGE=mrcide/$HINT:$GIT_BRANCH

--- a/src/app/static/scripts/test.properties
+++ b/src/app/static/scripts/test.properties
@@ -1,3 +1,2 @@
-use_auth=false
 hintr_url=http://hintr:8888
 upload_dir=/uploads

--- a/src/app/static/src/app/declare.d.ts
+++ b/src/app/static/src/app/declare.d.ts
@@ -1,2 +1,3 @@
 // modules without typings are added here
 declare module "@riophae/vue-treeselect"
+declare module "axios-middleware"

--- a/src/app/static/src/tests/integration/baseline.itest.ts
+++ b/src/app/static/src/tests/integration/baseline.itest.ts
@@ -1,9 +1,14 @@
 import {actions} from "../../app/store/baseline/actions";
+import {login} from "./integrationTest";
 
 const fs = require("fs");
 const FormData = require("form-data");
 
 describe("Baseline actions", () => {
+
+    beforeAll(async () => {
+        await login();
+    });
 
     it("can upload PJNZ file", async () => {
         const commit = jest.fn();
@@ -13,7 +18,10 @@ describe("Baseline actions", () => {
         formData.append('file', file);
 
         await actions.uploadPJNZ({commit} as any, formData);
+
         expect(commit.mock.calls[1][0]["type"]).toBe("PJNZUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("Botswana2018.PJNZ");
     });
 
     it("can get baseline data", (done) => {
@@ -36,7 +44,10 @@ describe("Baseline actions", () => {
         formData.append('file', file);
 
         await actions.uploadShape({commit} as any, formData);
+
         expect(commit.mock.calls[1][0]["type"]).toBe("ShapeUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("malawi.geojson");
 
     }, 10000);
 
@@ -47,7 +58,11 @@ describe("Baseline actions", () => {
         formData.append('file', file);
 
         await actions.uploadPopulation({commit} as any, formData);
+
         expect(commit.mock.calls[1][0]["type"]).toBe("PopulationUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("population.csv");
+
     });
 
 });

--- a/src/app/static/src/tests/integration/integrationTest.ts
+++ b/src/app/static/src/tests/integration/integrationTest.ts
@@ -1,0 +1,33 @@
+import axios, {AxiosRequestConfig} from 'axios';
+import {Service} from 'axios-middleware';
+
+const FormData = require("form-data");
+
+const service = new Service(axios);
+
+export const login = async () => {
+    const formData = new FormData();
+    formData.append('username', "test.user@example.com");
+    formData.append('password', "password");
+
+    const res = await axios.post("http://localhost:8080/callback/",
+        formData,
+        {
+            headers: formData.getHeaders(),
+            maxRedirects: 0,
+            validateStatus: (status) => status == 302
+        });
+
+    const cookie = res.headers["set-cookie"][0].split(";")[0];
+
+    // Register middleware to pass the session cookie with all requests
+    await service.register({
+        onRequest(config: AxiosRequestConfig) {
+            config.headers["Cookie"] = cookie;
+            return config;
+        }
+    } as any);
+
+    // GET the homepage to save the session
+    await axios.get("http://localhost:8080/");
+};

--- a/src/app/static/src/tests/integration/modelRun.itest.ts
+++ b/src/app/static/src/tests/integration/modelRun.itest.ts
@@ -1,6 +1,12 @@
 import {actions} from "../../app/store/modelRun/actions";
+import {login} from "./integrationTest";
 
 describe("Model run actions", () => {
+
+    beforeAll(async () => {
+        await login();
+    });
+
     it("can trigger model run", async () => {
         const commit = jest.fn();
 

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -1,11 +1,24 @@
 import {actions} from "../../app/store/surveyAndProgram/actions";
+import {actions as baselineActions} from "../../app/store/baseline/actions"
+import {login} from "./integrationTest";
 
 const fs = require("fs");
 const FormData = require("form-data");
 
 describe("Survey and program actions", () => {
 
-    it("can upload surveys", async () => {
+    beforeAll(async () => {
+        await login();
+
+        const commit = jest.fn();
+        const file = fs.createReadStream("../testdata/malawi.geojson");
+        const formData = new FormData();
+        formData.append('file', file);
+
+        await baselineActions.uploadShape({commit} as any, formData);
+    });
+
+    it("can upload survey", async () => {
 
         const commit = jest.fn();
 
@@ -15,12 +28,9 @@ describe("Survey and program actions", () => {
 
         await actions.uploadSurvey({commit} as any, formData);
 
-        // Unfortunately we can't test the success path because it relies on a persistent
-        // session between uploading a shape file and a survey file. But the success path is
-        // under test in the unit tests
-        expect(commit.mock.calls[1][0]["type"]).toBe("SurveyError");
-        expect(commit.mock.calls[1][0]["payload"])
-            .toBe("You must upload a shape file before uploading survey or programme data")
+        expect(commit.mock.calls[1][0]["type"]).toBe("SurveyUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("survey.csv")
 
     });
 
@@ -34,12 +44,9 @@ describe("Survey and program actions", () => {
 
         await actions.uploadProgram({commit} as any, formData);
 
-        // Unfortunately we can't test the success path because it relies on a persistent
-        // session between uploading a shape file and a program file. But the success path is
-        // under test in the unit tests
-        expect(commit.mock.calls[1][0]["type"]).toBe("ProgramError");
-        expect(commit.mock.calls[1][0]["payload"])
-            .toBe("You must upload a shape file before uploading survey or programme data")
+        expect(commit.mock.calls[1][0]["type"]).toBe("ProgramUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("programme.csv")
     });
 
     it("can upload anc", async () => {
@@ -52,14 +59,10 @@ describe("Survey and program actions", () => {
 
         await actions.uploadANC({commit} as any, formData);
 
-        // Unfortunately we can't test the success path because it relies on a persistent
-        // session between uploading a shape file and an anc file. But the success path is
-        // under test in the unit tests
-        expect(commit.mock.calls[1][0]["type"]).toBe("ANCError");
-        expect(commit.mock.calls[1][0]["payload"])
-            .toBe("You must upload a shape file before uploading survey or programme data")
+        expect(commit.mock.calls[1][0]["type"]).toBe("ANCUpdated");
+        expect(commit.mock.calls[1][0]["payload"]["filename"])
+            .toBe("anc.csv")
 
     });
-
 
 });


### PR DESCRIPTION
Once we start using the database to index session files the no-auth mode we were using for integration tests just won't work.

This PR adds a new spring profile for running front-end integration tests which allows the cookie to be read by js, then uses axios middleware in the tests to pass the session cookie with every request.

