### PR TITLE
mrc-506 Copy vue-treeselect css map to avoid pac4j session error state

### DIFF
--- a/src/app/static/gulpfile.js
+++ b/src/app/static/gulpfile.js
@@ -17,3 +17,9 @@ gulp.task('sass', function () {
         }))
         .pipe(gulp.dest('public/css'));
 });
+
+gulp.task('cssmap', function () {
+    //Avoid pac4j session error state resulting from DevTools request for this css map
+    return gulp.src('node_modules/@riophae/vue-treeselect/dist/vue-treeselect.css.map')
+        .pipe(gulp.dest('public/css'));
+});

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "sass": "gulp sass",
     "js": "webpack",
-    "build": "webpack && gulp sass",
+    "build": "webpack && gulp sass && gulp cssmap",
     "test": "jest -c jest.config.js",
     "integration-test": "jest -c jest.integration.config.js"
   },


### PR DESCRIPTION
To test:
- Confirm error page shown in master branch when login with devtools open in Chrome or Firefox
- Confirm error page not shown when rebuild and run on this branch