### PR TITLE
mrc-529 move stepper state to module

### DIFF
--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -46,7 +46,6 @@
     import Step from "./Step.vue";
     import Baseline from "./baseline/Baseline.vue";
     import SurveyAndProgram from "./surveyAndProgram/SurveyAndProgram.vue";
-    import {localStorageManager} from "../localStorageManager";
     import LoadingSpinner from "./LoadingSpinner.vue";
     import ModelRun from "./modelRun/ModelRun.vue";
     import {StepDescription, StepperState} from "../store/stepper/stepper";
@@ -79,7 +78,9 @@
         },
         methods: {
             ...mapActions(namespace, {
-                jump: 'jump'
+                jump: 'jump',
+                next: 'next',
+                load: 'load'
             }),
             active(num: number) {
                 return this.activeStep == num;
@@ -88,11 +89,6 @@
                 return this.steps.slice(0, num)
                     .filter((s: { number: number }) => this.complete[s.number])
                     .length >= num - 1
-            },
-            next() {
-                if (this.complete[this.activeStep]) {
-                    this.jump(this.activeStep + 1);
-                }
             }
         },
         components: {
@@ -105,18 +101,7 @@
         watch: {
             ready: function (newVal) {
                 if (newVal) {
-                    const activeStep = localStorageManager.getInt("activeStep");
-
-                    if (activeStep) {
-                        const invalidSteps = this.steps.map((s: StepDescription) => s.number)
-                            .filter((i: number) => i < activeStep && !this.complete[i]);
-
-                        if (invalidSteps.length == 0) {
-                            this.jump(activeStep)
-                        } else {
-                            localStorageManager.removeItem("activeStep");
-                        }
-                    }
+                    this.load()
                 }
             }
         }

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -7,13 +7,15 @@ import {
     SurveyAndProgramDataState
 } from "./store/surveyAndProgram/surveyAndProgram";
 import {initialModelRunState, modelRun, ModelRunState} from "./store/modelRun/modelRun";
+import {initialStepperState, stepper, StepperState} from "./store/stepper/stepper";
 
 export interface RootState {
     version: string;
     baseline: BaselineState,
     surveyAndProgram: SurveyAndProgramDataState,
     filteredData: FilteredDataState,
-    modelRun: ModelRunState
+    modelRun: ModelRunState,
+    stepper: StepperState
 }
 
 export interface ReadyState {
@@ -26,12 +28,14 @@ export const storeOptions: StoreOptions<RootState> = {
         baseline: initialBaselineState,
         surveyAndProgram: initialSurveyAndProgramDataState,
         filteredData: initialFilteredDataState,
-        modelRun: initialModelRunState
+        modelRun: initialModelRunState,
+        stepper: initialStepperState
     },
     modules: {
         baseline,
         surveyAndProgram,
         filteredData,
-        modelRun
+        modelRun,
+        stepper
     }
 };

--- a/src/app/static/src/app/store/stepper/actions.ts
+++ b/src/app/static/src/app/store/stepper/actions.ts
@@ -1,13 +1,38 @@
 import {ActionContext, ActionTree} from "vuex";
 import {RootState} from "../../root";
-import {StepperState} from "./stepper";
+import {StepDescription, StepperState} from "./stepper";
+import {localStorageManager} from "../../localStorageManager";
 
 export interface StepperActions {
-    jump: (store: ActionContext<StepperState, RootState>, step: number) => void
+    jump: (store: ActionContext<StepperState, RootState>, step: number) => void,
+    next: (store: ActionContext<StepperState, RootState>) => void
 }
 
 export const actions: StepperActions & ActionTree<StepperState, RootState> = {
     jump({commit}, step) {
         commit({type: "Jump", payload: step});
+    },
+
+    next(store) {
+        const {state, getters} = store;
+        if (getters.complete[state.activeStep]) {
+            actions.jump(store, state.activeStep + 1);
+        }
+    },
+
+    load(store) {
+        const {state, getters} = store;
+        const activeStep = localStorageManager.getInt("activeStep");
+
+        if (activeStep) {
+            const invalidSteps = state.steps.map((s: StepDescription) => s.number)
+                .filter((i: number) => i < activeStep && !getters.complete[i]);
+
+            if (invalidSteps.length == 0) {
+                actions.jump(store, activeStep);
+            } else {
+                localStorageManager.removeItem("activeStep");
+            }
+        }
     }
 };

--- a/src/app/static/src/app/store/stepper/actions.ts
+++ b/src/app/static/src/app/store/stepper/actions.ts
@@ -1,0 +1,13 @@
+import {ActionContext, ActionTree} from "vuex";
+import {RootState} from "../../root";
+import {StepperState} from "./stepper";
+
+export interface StepperActions {
+    jump: (store: ActionContext<StepperState, RootState>, step: number) => void
+}
+
+export const actions: StepperActions & ActionTree<StepperState, RootState> = {
+    jump({commit}, step) {
+        commit({type: "Jump", payload: step});
+    }
+};

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -1,0 +1,23 @@
+import {RootState} from "../../root";
+import {Getter, GetterTree} from "vuex";
+import {StepperState} from "./stepper";
+
+interface StepperGetters {
+    ready: Getter<StepperState, RootState>,
+    complete: Getter<StepperState, RootState>
+}
+
+export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
+    ready: (state: StepperState, getters: any, rootState: RootState) => {
+        return rootState.baseline.ready && rootState.surveyAndProgram.ready
+    },
+    complete: (state: StepperState, getters: any, rootState: RootState, rootGetters: any) => {
+        return {
+            1: rootGetters['baseline/complete'],
+            2: rootGetters['surveyAndProgram/complete'],
+            3: rootGetters['surveyAndProgram/complete'], // for now just mark as complete as soon as it's ready
+            4: rootState.modelRun.success,
+            5: false
+        }
+    }
+};

--- a/src/app/static/src/app/store/stepper/mutations.ts
+++ b/src/app/static/src/app/store/stepper/mutations.ts
@@ -1,0 +1,17 @@
+import {StepperState} from "./stepper";
+import {Mutation, MutationTree} from "vuex";
+import {PayloadWithType} from "../../types";
+import {localStorageManager} from "../../localStorageManager";
+
+type StepperMutation = Mutation<StepperState>
+
+export interface StepperMutations {
+    Jump: StepperMutation
+}
+
+export const mutations: StepperMutations & MutationTree<StepperState> = {
+    Jump(state: StepperState, action: PayloadWithType<number>) {
+        state.activeStep = action.payload;
+        localStorageManager.setItem("activeStep", action.payload);
+    }
+};

--- a/src/app/static/src/app/store/stepper/stepper.ts
+++ b/src/app/static/src/app/store/stepper/stepper.ts
@@ -1,0 +1,51 @@
+import {Module} from "vuex";
+import {RootState} from "../../root";
+import {getters} from "./getters";
+import {actions} from "./actions";
+import {mutations} from "./mutations";
+
+export interface StepDescription {
+    number: number,
+    text: string
+}
+
+export interface StepperState {
+    activeStep: number
+    steps: StepDescription[]
+}
+
+export const initialStepperState: StepperState = {
+    activeStep: 1,
+    steps: [
+        {
+            number: 1,
+            text: "Upload baseline data"
+        },
+        {
+            number: 2,
+            text: "Upload survey and programme data"
+        },
+        {
+            number: 3,
+            text: "Review uploads"
+        },
+        {
+            number: 4,
+            text: "Run model"
+        },
+        {
+            number: 5,
+            text: "Review output"
+        }]
+};
+
+
+const namespaced: boolean = true;
+
+export const stepper: Module<StepperState, RootState> = {
+    namespaced,
+    state: initialStepperState,
+    getters,
+    actions,
+    mutations
+};

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -6,18 +6,22 @@ import {
     mockBaselineState,
     mockModelRunState,
     mockPopulationResponse,
-    mockShapeResponse,
+    mockShapeResponse, mockStepperState,
     mockSurveyAndProgramState
 } from "../mocks";
 import {SurveyAndProgramDataState, surveyAndProgramGetters} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {mutations} from '../../app/store/baseline/mutations';
 import {mutations as surveyAndProgramMutations} from '../../app/store/surveyAndProgram/mutations';
 import {mutations as modelRunMutations} from '../../app/store/modelRun/mutations';
+import {mutations as stepperMutations} from '../../app/store/stepper/mutations';
+
 import {ModelRunState} from "../../app/store/modelRun/modelRun";
 
 import Stepper from "../../app/components/Stepper.vue";
 import Step from "../../app/components/Step.vue";
 import LoadingSpinner from "../../app/components/LoadingSpinner.vue";
+import {actions} from "../../app/store/stepper/actions";
+import {getters} from "../../app/store/stepper/getters";
 
 const localVue = createLocalVue();
 Vue.use(Vuex);
@@ -45,6 +49,13 @@ describe("Stepper component", () => {
                     namespaced: true,
                     state: mockModelRunState(modelRunState),
                     mutations: modelRunMutations
+                },
+                stepper: {
+                    namespaced: true,
+                    state: mockStepperState(),
+                    mutations: stepperMutations,
+                    actions: actions,
+                    getters
                 }
             }
         })

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -19,6 +19,7 @@ import {
 import {FilteredDataState, initialFilteredDataState} from "../app/store/filteredData/filteredData";
 import {initialModelRunState, ModelRunState} from "../app/store/modelRun/modelRun";
 import {RootState} from "../app/root";
+import {initialStepperState, StepperState} from "../app/store/stepper/stepper";
 
 
 export const mockAxios = new MockAdapter(axios);
@@ -51,6 +52,13 @@ export const mockModelRunState = (props?: Partial<ModelRunState>) => {
     }
 };
 
+export const mockStepperState = (props?: Partial<StepperState>) => {
+    return {
+        ...initialStepperState,
+        ...props
+    }
+};
+
 export const mockFilteredDataState = (props?: Partial<FilteredDataState>) => {
     return {
         ...initialFilteredDataState,
@@ -65,6 +73,7 @@ export const mockRootState = (props?: Partial<RootState>): RootState => {
         baseline: mockBaselineState(),
         surveyAndProgram: mockSurveyAndProgramState(),
         modelRun: mockModelRunState(),
+        stepper: mockStepperState(),
         ...props
     }
 };


### PR DESCRIPTION
For now this just moves stepper state into it's own module. 

Later PR will change over the save/restore to/from local storage logic to save/load a partial global state object instead of just the active step.

I've not actually added any unit tests for the mutations/actions cos everything is still under test via the component tests. Do you think worth adding unit tests as well?