### PR TITLE
mrc-547_state Fetch model run result

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
@@ -12,6 +12,7 @@ interface APIClient {
     fun validateSurveyAndProgramme(path: String, shapePath: String, type: FileType): ResponseEntity<String>
     fun submit(data: Map<String, String>, parameters: ModelRunParameters): ResponseEntity<String>
     fun getStatus(id: String): ResponseEntity<String>
+    fun getResult(id: String): ResponseEntity<String>
     fun getPlottingMetadata(country: String): ResponseEntity<String>
 }
 
@@ -70,6 +71,14 @@ class HintrAPIClient(
 
     override fun getStatus(id: String): ResponseEntity<String> {
         return "$baseUrl/model/status/${id}"
+                .httpGet()
+                .response()
+                .second
+                .asResponseEntity()
+    }
+
+    override fun getResult(id: String): ResponseEntity<String> {
+        return "$baseUrl/model/result/${id}"
                 .httpGet()
                 .response()
                 .second

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
@@ -22,4 +22,10 @@ class ModelRunController(val fileManager: FileManager, val apiClient: APIClient)
     fun status(@PathVariable("id")id: String): ResponseEntity<String> {
         return apiClient.getStatus(id)
     }
+
+    @GetMapping("/result/{id}")
+    @ResponseBody
+    fun result(@PathVariable("id")id: String): ResponseEntity<String> {
+        return apiClient.getResult(id)
+    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintrAPIClientTests.kt
@@ -49,6 +49,18 @@ class HintrApiClientTests {
     }
 
     @Test
+    fun `can get model run result`() {
+        val sut = HintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
+        val submitResult = sut.submit(mapOf(), ModelRunParameters(1, 1, 1, mapOf()))
+
+        val id = ObjectMapper().readValue<JsonNode>(submitResult.body!!)["data"]["id"].textValue()
+
+        val result = sut.getResult(id)
+        assertThat(result.statusCodeValue).isEqualTo(400)
+        JSONValidator().validateError(result.body!!, "FAILED_TO_RETRIEVE_RESULT")
+    }
+
+    @Test
     fun `can get plotting metadata`() {
         val sut = HintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
         val metadataResult = sut.getPlottingMetadata("Malawi");

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.integration
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.models.ModelRunParameters
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -45,5 +46,27 @@ class ModelRunTests : SecureIntegrationTests() {
 
         val responseEntity = testRestTemplate.getForEntity<String>("/model/status/${id}")
         assertSecureWithSuccess(isAuthorized, responseEntity, "ModelStatusResponse")
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
+    fun `can get model run result`(isAuthorized: IsAuthorized) {
+
+        val id = when(isAuthorized){
+            IsAuthorized.TRUE -> {
+                val entity = getJsonEntity()
+                val runResult = testRestTemplate.postForEntity<String>("/model/run/", entity)
+                ObjectMapper().readValue<JsonNode>(runResult.body!!)["data"]["id"].textValue()
+            }
+            IsAuthorized.FALSE -> "nonsense"
+        }
+
+        do {
+            Thread.sleep(500)
+            val statusResponse = testRestTemplate.getForEntity<String>("/model/status/${id}")
+        } while (statusResponse.body!!.contains("\"status\":\"RUNNING\""))
+
+        val responseEntity = testRestTemplate.getForEntity<String>("/model/result/${id}")
+        assertSecureWithSuccess(isAuthorized, responseEntity, "ModelResultResponse")
     }
 }

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -1,6 +1,7 @@
 import axios, {AxiosError, AxiosResponse} from "axios";
 import {
     Response,
+    ModelResultResponse,
     ModelSubmitResponse,
     ModelStatusResponse,
     ValidateInputResponse,
@@ -12,6 +13,7 @@ type ResponseData =
     ValidateInputResponse
     | ModelSubmitResponse
     | ModelStatusResponse
+    | ModelResultResponse
     | AncResponse
     | PjnzResponse
     | PopulationResponse

--- a/src/app/static/src/app/index.ts
+++ b/src/app/static/src/app/index.ts
@@ -12,11 +12,13 @@ export const app = new Vue({
     render: h => h(Stepper),
     methods: {
         ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
-        ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'})
+        ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'}),
+        ...mapActions({loadModelRun: 'modelRun/getResult'})
     },
     beforeMount: function () {
         this.loadBaseline();
         this.loadSurveyAndProgram();
+        this.loadModelRun();
     }
 });
 

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -4,7 +4,7 @@ const appStateKey = "appState";
 
 export const serialiseState = (rootState: RootState): Partial<RootState> => {
     return {
-        modelRun: {...rootState.modelRun, statusPollId: -1},
+        modelRun: {...rootState.modelRun, statusPollId: -1, result: null},
         filteredData: rootState.filteredData,
         stepper: rootState.stepper,
         metadata: rootState.metadata

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -44,7 +44,6 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
                 .withSuccess("RunResultFetched")
                 .withError("RunResultError")
                 .get<ModelResultResponse>(`/model/result/${state.modelRunId}`)
-
         }
         commit({type: "Ready", payload: true});
     }

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -2,10 +2,10 @@ import {ActionContext, ActionTree} from "vuex";
 import {ModelRunState} from "./modelRun";
 import {RootState} from "../../root";
 import {api} from "../../apiService";
-import {ModelStatusResponse, ModelSubmitParameters, ModelSubmitResponse} from "../../generated";
+import {ModelResultResponse, ModelStatusResponse, ModelSubmitParameters, ModelSubmitResponse} from "../../generated";
 
-export type ModelRunActionTypes = "ModelRunStarted" | "RunStatusUpdated" | "PollingForStatusStarted"
-export type ModelRunErrorTypes = "ModelRunError" | "RunStatusError"
+export type ModelRunActionTypes = "ModelRunStarted" | "RunStatusUpdated" | "PollingForStatusStarted" | "RunResultFetched"
+export type ModelRunErrorTypes = "ModelRunError" | "RunStatusError" | "RunResultError"
 
 export interface ModelRunActions {
     run: (store: ActionContext<ModelRunState, RootState>, modelRunParams: ModelSubmitParameters) => void
@@ -21,14 +21,28 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
             .postAndReturn<ModelSubmitResponse>("/model/run/", modelRunParams)
     },
 
-    poll({commit, state}, runId) {
+    poll({commit, state, dispatch}, runId) {
         const id = setInterval(() => {
             api<ModelRunActionTypes, ModelRunErrorTypes>(commit)
                 .withSuccess("RunStatusUpdated")
                 .withError("RunStatusError")
-                .get<ModelStatusResponse>(`/model/status/${runId}`);
+                .get<ModelStatusResponse>(`/model/status/${runId}`)
+                .then(() => {
+                    if (state.success) {
+                        dispatch("getResult", runId);
+                    }
+                });
         }, 2000);
 
         commit({type: "PollingForStatusStarted", payload: id})
+    },
+
+    async getResult({commit, state}) {
+        if (state.modelRunId && state.success) {
+            await api<ModelRunActionTypes, ModelRunErrorTypes>(commit)
+                .withSuccess("RunResultFetched")
+                .withError("RunResultError")
+                .get<ModelResultResponse>(`/model/result/${state.modelRunId}`)
+        }
     }
 };

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -10,6 +10,7 @@ export type ModelRunErrorTypes = "ModelRunError" | "RunStatusError" | "RunResult
 export interface ModelRunActions {
     run: (store: ActionContext<ModelRunState, RootState>, modelRunParams: ModelSubmitParameters) => void
     poll: (store: ActionContext<ModelRunState, RootState>, runId: number) => void
+    getResult: (store: ActionContext<ModelRunState, RootState>) => void
 }
 
 export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -44,6 +44,8 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
                 .withSuccess("RunResultFetched")
                 .withError("RunResultError")
                 .get<ModelResultResponse>(`/model/result/${state.modelRunId}`)
+
         }
+        commit({type: "Ready", payload: true});
     }
 };

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -1,11 +1,11 @@
 import {Module} from "vuex";
-import {RootState} from "../../root";
+import {ReadyState, RootState} from "../../root";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
 import {localStorageManager} from "../../localStorageManager";
 import {ModelResultResponse} from "../../generated";
 
-export interface ModelRunState {
+export interface ModelRunState extends ReadyState {
     modelRunId: string
     status: ModelRunStatus,
     statusPollId: number,
@@ -28,7 +28,8 @@ export const initialModelRunState: ModelRunState = {
     errors: [],
     status: ModelRunStatus.NotStarted,
     statusPollId: -1,
-    result: null
+    result: null,
+    ready: false
 };
 
 const namespaced: boolean = true;

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -3,13 +3,15 @@ import {RootState} from "../../root";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
 import {localStorageManager} from "../../localStorageManager";
+import {ModelResultResponse} from "../../generated";
 
 export interface ModelRunState {
     modelRunId: string
     status: ModelRunStatus,
     statusPollId: number,
     success: boolean,
-    errors: any[]
+    errors: any[],
+    result: ModelResultResponse | null
 }
 
 export enum ModelRunStatus {
@@ -25,7 +27,8 @@ export const initialModelRunState: ModelRunState = {
     success: false,
     errors: [],
     status: ModelRunStatus.NotStarted,
-    statusPollId: -1
+    statusPollId: -1,
+    result: null
 };
 
 const namespaced: boolean = true;

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -3,6 +3,8 @@ import {localStorageKey, ModelRunState, ModelRunStatus} from "./modelRun";
 import {PayloadWithType} from "../../types";
 import {ModelResultResponse, ModelStatusResponse, ModelSubmitResponse} from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
+import {readyStateMutations} from "../shared/readyStateMutations";
+import {FilteredDataState} from "../filteredData/filteredData";
 
 type ModelRunMutation = Mutation<ModelRunState>
 
@@ -11,7 +13,8 @@ export interface ModelRunMutations {
     RunStatusUpdated: ModelRunMutation,
     PollingForStatusStarted: ModelRunMutation,
     RunResultFetched: ModelRunMutation,
-    RunResultError: ModelRunMutation
+    RunResultError: ModelRunMutation,
+    Ready: ModelRunMutation
 }
 
 export const mutations: MutationTree<ModelRunState> & ModelRunMutations = {
@@ -43,5 +46,7 @@ export const mutations: MutationTree<ModelRunState> & ModelRunMutations = {
 
     RunResultError(state: ModelRunState, action: PayloadWithType<string>) {
         state.errors.push(action.payload);
-    }
+    },
+
+    ...readyStateMutations
 };

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -1,7 +1,7 @@
 import {Mutation, MutationTree} from "vuex";
 import {localStorageKey, ModelRunState, ModelRunStatus} from "./modelRun";
 import {PayloadWithType} from "../../types";
-import {ModelStatusResponse, ModelSubmitResponse} from "../../generated";
+import {ModelResultResponse, ModelStatusResponse, ModelSubmitResponse} from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
 
 type ModelRunMutation = Mutation<ModelRunState>
@@ -9,7 +9,9 @@ type ModelRunMutation = Mutation<ModelRunState>
 export interface ModelRunMutations {
     ModelRunStarted: ModelRunMutation
     RunStatusUpdated: ModelRunMutation,
-    PollingForStatusStarted: ModelRunMutation
+    PollingForStatusStarted: ModelRunMutation,
+    RunResultFetched: ModelRunMutation,
+    RunResultError: ModelRunMutation
 }
 
 export const mutations: MutationTree<ModelRunState> & ModelRunMutations = {
@@ -33,6 +35,13 @@ export const mutations: MutationTree<ModelRunState> & ModelRunMutations = {
 
     PollingForStatusStarted(state: ModelRunState, action: PayloadWithType<number>) {
         state.statusPollId = action.payload;
-    }
+    },
 
+    RunResultFetched(state: ModelRunState, action: PayloadWithType<ModelResultResponse>) {
+        state.result = action.payload;
+    },
+
+    RunResultError(state: ModelRunState, action: PayloadWithType<string>) {
+        state.errors.push(action.payload);
+    }
 };

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -9,7 +9,7 @@ interface StepperGetters {
 
 export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
     ready: (state: StepperState, getters: any, rootState: RootState) => {
-        return rootState.baseline.ready && rootState.surveyAndProgram.ready
+        return rootState.baseline.ready && rootState.surveyAndProgram.ready && rootState.modelRun.ready
     },
     complete: (state: StepperState, getters: any, rootState: RootState, rootGetters: any) => {
         return {

--- a/src/app/static/src/tests/components/modelRun/modelRun.test.ts
+++ b/src/app/static/src/tests/components/modelRun/modelRun.test.ts
@@ -1,7 +1,7 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, {Store} from 'vuex';
-import {mockAxios, mockModelRunState, mockModelStatusResponse, mockSuccess} from "../../mocks";
+import {mockAxios, mockModelResultResponse, mockModelRunState, mockModelStatusResponse, mockSuccess} from "../../mocks";
 import ModelRun from "../../../app/components/modelRun/ModelRun.vue";
 import {actions} from "../../../app/store/modelRun/actions";
 import {mutations} from "../../../app/store/modelRun/mutations";
@@ -34,6 +34,10 @@ describe("Model run component", () => {
 
     mockAxios.onGet(`/model/status/1234`)
         .reply(200, mockSuccess(mockModelStatusResponse()));
+
+    mockAxios.onGet(`/model/result/1234`)
+        .reply(200, mockSuccess(mockModelResultResponse()));
+
 
     it("run models and polls for status", (done) => {
 

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -86,7 +86,7 @@ describe("Stepper component", () => {
     });
 
     it("does not render loading spinner once states are ready", () => {
-        const store = createSut({ready: true}, {ready: true});
+        const store = createSut({ready: true}, {ready: true}, {},{ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
         expect(wrapper.findAll(".content").length).toBe(1);
@@ -94,7 +94,7 @@ describe("Stepper component", () => {
     });
 
     it("renders steps", () => {
-        const store = createSut({ready: true}, {ready: true});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
 
@@ -126,7 +126,7 @@ describe("Stepper component", () => {
     });
 
     it("all steps except baseline are disabled initially", () => {
-        const store = createSut({ready: true}, {ready: true});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(0).props().enabled).toBe(true);
@@ -141,7 +141,8 @@ describe("Stepper component", () => {
                 ready: true
             },
             {ready: true},
-            {plottingMetadata: "TEST DATA" as any});
+            {plottingMetadata: "TEST DATA" as any},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(0).props().enabled).toBe(true);
@@ -158,7 +159,8 @@ describe("Stepper component", () => {
                 ready: true
             },
             {ready: true},
-            {plottingMetadata: null});
+            {plottingMetadata: null},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(0).props().enabled).toBe(true);
@@ -175,7 +177,8 @@ describe("Stepper component", () => {
             ready: true
             },
             {ready: true},
-            {plottingMetadata: "TEST DATA" as any});
+            {plottingMetadata: "TEST DATA" as any},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         steps.at(1).vm.$emit("jump", 2);
@@ -184,7 +187,7 @@ describe("Stepper component", () => {
     });
 
     it("cannot continue when the active step is not complete", () => {
-        const store = createSut({country: "", ready: true}, {ready: true});
+        const store = createSut({country: "", ready: true}, {ready: true}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const continueLink = wrapper.find("#continue");
         expect(continueLink.classes()).toContain("disabled");
@@ -203,7 +206,8 @@ describe("Stepper component", () => {
                 ready: true
             },
             {ready: true},
-            {plottingMetadata: "TEST DATA" as any});
+            {plottingMetadata: "TEST DATA" as any},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const continueLink = wrapper.find("#continue");
         expect(continueLink.classes()).not.toContain("disabled");
@@ -217,7 +221,8 @@ describe("Stepper component", () => {
         const baselineState = {country: "Malawi", population: mockPopulationResponse(), ready: true};
         const store = createSut(baselineState,
             {ready: true},
-            {plottingMetadata: "TEST DATA" as any});
+            {plottingMetadata: "TEST DATA" as any},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const continueLink = wrapper.find("#continue");
         expect(continueLink.classes()).toContain("disabled");
@@ -241,7 +246,7 @@ describe("Stepper component", () => {
             country: "Malawi",
             shape: mockShapeResponse(),
             population: mockPopulationResponse()
-        }, {}, {}, {}, {activeStep: 2});
+        }, {}, {}, {ready: true}, {activeStep: 2});
 
         const wrapper = shallowMount(Stepper, {store, localVue});
         let steps = wrapper.findAll(Step);
@@ -261,7 +266,8 @@ describe("Stepper component", () => {
             population: mockPopulationResponse()
         }, {}, {
             plottingMetadata: "TEST DATA" as any
-        });
+        },
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         let steps = wrapper.findAll(Step);
         expect(steps.filter(s => s.props().complete).length).toBe(0);
@@ -278,9 +284,10 @@ describe("Stepper component", () => {
             country: "Malawi",
             shape: mockShapeResponse(),
             population: mockPopulationResponse()
-        }, {}, {
-            plottingMetadata: "TEST DATA" as any
-        });
+        },
+            {},
+            {plottingMetadata: "TEST DATA" as any},
+            {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         let steps = wrapper.findAll(Step);
         expect(steps.filter(s => s.props().enabled).length).toBe(0);
@@ -302,21 +309,21 @@ describe("Stepper component", () => {
     }
 
     it("model run step is not complete without success", () => {
-        const store = createSut({ready: true}, {ready: true}, {}, {success: false});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true, success: false});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(3).props().complete).toBe(false);
     });
 
     it("model run step is complete on success", () => {
-        const store = createSut({ready: true}, {ready: true}, {}, {success: true});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true, success: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(3).props().complete).toBe(true);
     });
 
     it("model run step becomes complete on success", async () => {
-        const store = createSut({ready: true}, {ready: true});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
 
         store.commit("modelRun/RunStatusUpdated", {
@@ -340,7 +347,7 @@ describe("Stepper component", () => {
 
     it("validates state once ready", async () => {
         const spy = jest.spyOn(rootActions as any, "validate");
-        const store = createSut({ready: true});
+        const store = createSut({ready: true}, {}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         expect(spy).not.toHaveBeenCalled();
 

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -19,7 +19,7 @@ import {
     PopulationResponse,
     ModelStatusResponse,
     PlottingMetadataResponse,
-    PrevalenceAndArtCoverageIndicators
+    PrevalenceAndArtCoverageIndicators, ModelResultResponse
 } from "../app/generated";
 import {FilteredDataState, initialFilteredDataState} from "../app/store/filteredData/filteredData";
 import {initialModelRunState, ModelRunState} from "../app/store/modelRun/modelRun";
@@ -209,6 +209,12 @@ export const mockModelStatusResponse = (props: Partial<ModelStatusResponse> = {}
         queue: 1,
         id: "1234",
         status: "finished",
+        ...props
+    }
+};
+
+export const mockModelResultResponse = (props: Partial<ModelResultResponse> = {}): ModelResultResponse => {
+    return {
         ...props
     }
 };

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -25,7 +25,7 @@ describe("Model run actions", () => {
 
     });
 
-    it("invokes getResult when poll updates state to success", (done) => {
+    it("fetches model run result when poll gets success status", (done) => {
 
         mockAxios.onGet(`/model/status/1234`)
             .reply(200, mockSuccess({}));
@@ -44,7 +44,7 @@ describe("Model run actions", () => {
 
     });
 
-    it("does not invoke getResult when poll updates state to success", (done) => {
+    it("does not fetch model run result when poll gets no success status", (done) => {
 
         mockAxios.onGet(`/model/status/1234`)
             .reply(200, mockSuccess({}));

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -1,4 +1,4 @@
-import {mockAxios, mockSuccess} from "../mocks";
+import {mockAxios, mockFailure, mockModelRunState, mockSuccess} from "../mocks";
 import {actions} from "../../app/store/modelRun/actions";
 
 describe("Model run actions", () => {
@@ -23,6 +23,73 @@ describe("Model run actions", () => {
             payload: {id: "12345"}
         });
 
+    });
+
+    it("invokes getResult when poll updates state to success", (done) => {
+
+        mockAxios.onGet(`/model/status/1234`)
+            .reply(200, mockSuccess({}));
+
+        const state = mockModelRunState({success: true});
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+
+        actions.poll({commit, state, dispatch} as any,1234);
+        setInterval(() => {
+            expect(dispatch.mock.calls[0][0]).toStrictEqual("getResult");
+            expect(dispatch.mock.calls[0][1]).toStrictEqual(1234);
+            done();
+        }, 2100);
+
+
+    });
+
+    it("does not invoke getResult when poll updates state to success", (done) => {
+
+        mockAxios.onGet(`/model/status/1234`)
+            .reply(200, mockSuccess({}));
+
+        const state = mockModelRunState({success: false});
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+
+        actions.poll({commit, state, dispatch} as any,1234);
+        setInterval(() => {
+            expect(dispatch.mock.calls.length).toEqual(0);
+            done();
+        }, 2100);
+
+
+    });
+
+    it("getResult commits result when successfully fetched", async () => {
+        mockAxios.onGet(`/model/result/1234`)
+            .reply(200, mockSuccess("TEST DATA"));
+
+        const commit = jest.fn();
+        const state = mockModelRunState({success: true, modelRunId: "1234"});
+
+        await actions.getResult({commit, state} as any);
+
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "RunResultFetched",
+            payload: "TEST DATA"
+        });
+    });
+
+    it("getResult commits error when unsuccessful fetch", async () => {
+        mockAxios.onGet(`/model/result/1234`)
+            .reply(500, mockFailure("Test Error"));
+
+        const commit = jest.fn();
+        const state = mockModelRunState({success: true, modelRunId: "1234"});
+
+        await actions.getResult({commit, state} as any);
+
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "RunResultError",
+            payload: "Test Error"
+        });
     });
 
 });

--- a/src/app/static/src/tests/modelRun/mutations.test.ts
+++ b/src/app/static/src/tests/modelRun/mutations.test.ts
@@ -1,5 +1,6 @@
 import {initialModelRunState, ModelRunStatus} from "../../app/store/modelRun/modelRun";
 import {mutations} from "../../app/store/modelRun/mutations";
+import {mockModelResultResponse} from "../mocks";
 
 describe("Model run mutations", () => {
 
@@ -39,6 +40,19 @@ describe("Model run mutations", () => {
         const testState = {...initialModelRunState};
         mutations.PollingForStatusStarted(testState, {payload: 2});
         expect(testState.statusPollId).toBe(2);
+    });
+
+    it("sets result", () => {
+        const testState = {...initialModelRunState};
+        const testResponse = mockModelResultResponse();
+        mutations.RunResultFetched(testState, {payload: testResponse});
+        expect(testState.result).toBe(testResponse);
+    });
+
+    it("sets result error", () => {
+        const testState = {...initialModelRunState};
+        mutations.RunResultError(testState, {payload: "Test Error"});
+        expect(testState.errors).toStrictEqual(["Test Error"]);
     });
 
 });


### PR DESCRIPTION
This PR fetches the model run result when the run finishes, and saves it to the state. Also reloads the state on page reload. 

A future PR will show the output data in a choropleth.