### PR TITLE
mrc-549 state not being reset bug fix

### DIFF
--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -28,6 +28,7 @@ export interface ReadyState {
 
 const persistState = (store: Store<RootState>) => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
+        console.log(mutation.type);
         localStorageManager.saveState(state);
     })
 };
@@ -42,13 +43,7 @@ export const emptyState = {
     stepper: initialStepperState
 };
 
-export const initialState = {
-    ...emptyState,
-    ...localStorageManager.getState()
-};
-
 export const storeOptions: StoreOptions<RootState> = {
-    state: initialState,
     modules: {
         baseline,
         metadata,

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -37,7 +37,7 @@ const namespaced: boolean = true;
 
 export const baseline: Module<BaselineState, RootState> = {
     namespaced,
-    state: initialBaselineState,
+    state: {...initialBaselineState},
     getters,
     actions,
     mutations

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -32,6 +32,12 @@ export const initialModelRunState: ModelRunState = {
     ready: false
 };
 
+export const modelRunGetters = {
+    complete: (state: ModelRunState) => {
+        return state.success && state.errors.length == 0
+    }
+};
+
 const namespaced: boolean = true;
 const existingState = localStorageManager.getState();
 
@@ -39,5 +45,6 @@ export const modelRun: Module<ModelRunState, RootState> = {
     namespaced,
     state: {...initialModelRunState, ...existingState && existingState.modelRun},
     actions,
+    getters: modelRunGetters,
     mutations
 };

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -8,5 +8,8 @@ export interface RootMutations {
 export const mutations: MutationTree<RootState> & RootMutations = {
     Reset(state: RootState) {
         Object.assign(state, emptyState);
+        state.surveyAndProgram.ready = true;
+        state.baseline.ready = true;
+        state.modelRun.ready = true;
     }
 };

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -16,7 +16,7 @@ export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
             1: rootGetters['baseline/complete'] && rootGetters['metadata/complete'],
             2: rootGetters['surveyAndProgram/complete'],
             3: rootGetters['surveyAndProgram/complete'], // for now just mark as complete as soon as it's ready
-            4: rootState.modelRun.success,
+            4: rootState.modelRun.success && rootState.modelRun.errors.length == 0,
             5: false
         }
     }

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -16,7 +16,7 @@ export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
             1: rootGetters['baseline/complete'] && rootGetters['metadata/complete'],
             2: rootGetters['surveyAndProgram/complete'],
             3: rootGetters['surveyAndProgram/complete'], // for now just mark as complete as soon as it's ready
-            4: rootState.modelRun.success && rootState.modelRun.errors.length == 0,
+            4: rootGetters['modelRun/complete'],
             5: false
         }
     }

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -33,7 +33,7 @@ const namespaced: boolean = true;
 
 export const surveyAndProgram: Module<SurveyAndProgramDataState, RootState> = {
     namespaced,
-    state: initialSurveyAndProgramDataState,
+    state: {...initialSurveyAndProgramDataState},
     getters: surveyAndProgramGetters,
     actions,
     mutations

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -4,7 +4,7 @@ import Vuex, {Store} from 'vuex';
 import {baselineGetters, BaselineState} from "../../app/store/baseline/baseline";
 import {
     mockBaselineState, mockMetadataState,
-    mockModelRunState,
+    mockModelRunState, mockPlottingMetadataResponse,
     mockPopulationResponse,
     mockShapeResponse, mockStepperState,
     mockSurveyAndProgramState
@@ -24,6 +24,7 @@ import {actions} from "../../app/store/stepper/actions";
 import {getters} from "../../app/store/stepper/getters";
 import {StepperState} from "../../app/store/stepper/stepper";
 import {actions as rootActions} from "../../app/store/root/actions"
+import {mutations as rootMutations} from "../../app/store/root/mutations"
 import {metadataGetters, MetadataState} from "../../app/store/metadata/metadata";
 
 const localVue = createLocalVue();
@@ -38,6 +39,7 @@ describe("Stepper component", () => {
 
         return new Vuex.Store({
             actions: rootActions,
+            mutations: rootMutations,
             modules: {
                 baseline: {
                     namespaced: true,
@@ -86,7 +88,7 @@ describe("Stepper component", () => {
     });
 
     it("does not render loading spinner once states are ready", () => {
-        const store = createSut({ready: true}, {ready: true}, {},{ready: true});
+        const store = createSut({ready: true}, {ready: true}, {}, {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
         expect(wrapper.findAll(".content").length).toBe(1);
@@ -171,10 +173,10 @@ describe("Stepper component", () => {
 
     it("updates active step when jump event is emitted", () => {
         const store = createSut({
-            country: "testCountry",
-            shape: mockShapeResponse(),
-            population: mockPopulationResponse(),
-            ready: true
+                country: "testCountry",
+                shape: mockShapeResponse(),
+                population: mockPopulationResponse(),
+                ready: true
             },
             {ready: true},
             {plottingMetadata: "TEST DATA" as any},
@@ -246,7 +248,7 @@ describe("Stepper component", () => {
             country: "Malawi",
             shape: mockShapeResponse(),
             population: mockPopulationResponse()
-        }, {}, {}, {ready: true}, {activeStep: 2});
+        }, {}, {plottingMetadata: mockPlottingMetadataResponse()}, {ready: true}, {activeStep: 2});
 
         const wrapper = shallowMount(Stepper, {store, localVue});
         let steps = wrapper.findAll(Step);
@@ -260,13 +262,13 @@ describe("Stepper component", () => {
     it("complete steps only shown as complete once state becomes ready", async () => {
 
         const store = createSut({
-            ready: true,
-            country: "Malawi",
-            shape: mockShapeResponse(),
-            population: mockPopulationResponse()
-        }, {}, {
-            plottingMetadata: "TEST DATA" as any
-        },
+                ready: true,
+                country: "Malawi",
+                shape: mockShapeResponse(),
+                population: mockPopulationResponse()
+            }, {}, {
+                plottingMetadata: "TEST DATA" as any
+            },
             {ready: true});
         const wrapper = shallowMount(Stepper, {store, localVue});
         let steps = wrapper.findAll(Step);
@@ -280,11 +282,11 @@ describe("Stepper component", () => {
     it("steps only shown as enabled once state becomes ready", async () => {
 
         const store = createSut({
-            ready: true,
-            country: "Malawi",
-            shape: mockShapeResponse(),
-            population: mockPopulationResponse()
-        },
+                ready: true,
+                country: "Malawi",
+                shape: mockShapeResponse(),
+                population: mockPopulationResponse()
+            },
             {},
             {plottingMetadata: "TEST DATA" as any},
             {ready: true});
@@ -310,6 +312,14 @@ describe("Stepper component", () => {
 
     it("model run step is not complete without success", () => {
         const store = createSut({ready: true}, {ready: true}, {}, {ready: true, success: false});
+        const wrapper = shallowMount(Stepper, {store, localVue});
+        const steps = wrapper.findAll(Step);
+        expect(steps.at(3).props().complete).toBe(false);
+    });
+
+    it("model run step is not complete with errors", () => {
+        const store = createSut({ready: true}, {ready: true}, {},
+            {ready: true, success: true, errors: ["TEST" as any]});
         const wrapper = shallowMount(Stepper, {store, localVue});
         const steps = wrapper.findAll(Step);
         expect(steps.at(3).props().complete).toBe(false);

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -15,7 +15,7 @@ import {mutations as surveyAndProgramMutations} from '../../app/store/surveyAndP
 import {mutations as modelRunMutations} from '../../app/store/modelRun/mutations';
 import {mutations as stepperMutations} from '../../app/store/stepper/mutations';
 
-import {ModelRunState} from "../../app/store/modelRun/modelRun";
+import {modelRunGetters, ModelRunState} from "../../app/store/modelRun/modelRun";
 
 import Stepper from "../../app/components/Stepper.vue";
 import Step from "../../app/components/Step.vue";
@@ -56,7 +56,8 @@ describe("Stepper component", () => {
                 modelRun: {
                     namespaced: true,
                     state: mockModelRunState(modelRunState),
-                    mutations: modelRunMutations
+                    mutations: modelRunMutations,
+                    getters: modelRunGetters
                 },
                 stepper: {
                     namespaced: true,


### PR DESCRIPTION
When the auto-saved state is invalid for some reason and so gets reset, the baseline and survey/program module states weren't being reset. This was due to the initial state object being passed as a reference instead of copied into the module.