### PR TITLE
mrc-550 endless loading spinner bug fix

### DIFF
--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -27,6 +27,9 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
         if (data) {
             state.country = data.data.country;
             state.pjnzFilename = data.filename;
+        } else {
+            state.country = "";
+            state.pjnzFilename = "";
         }
         state.pjnzError = "";
     },

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -69,9 +69,9 @@ describe("Baseline mutations", () => {
         expect(testState.pjnzError).toBe("");
     });
 
-    it("does nothing on PJNZUpdated if no data present", () => {
+    it("clears country and filename on PJNZUpdated if no data present", () => {
 
-        const testState = {...initialBaselineState, pjnzError: ""};
+        const testState = {...initialBaselineState, pjnzError: "", country: "test", pjnzFilename: "test"};
         mutations.PJNZUpdated(testState, {payload: null});
         expect(testState.pjnzFilename).toBe("");
         expect(testState.country).toBe("");


### PR DESCRIPTION
When uploading a new pjnz file, first clear any existing country and filename. 