### PR TITLE
MRC-556: wait-for-config startup option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ ADD ./src/app/build/distributions/app-boot.tar /
 ARG SPRING_PROFILES_ACTIVE
 ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
 
+# This path is needed for the eventual configuration
+CMD mkdir -p /etc/hint
+
 ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ RUN mkdir /static/public -p
 
 COPY ./src/app/static/public /static/public
 COPY ./src/app/templates /templates
+COPY ./docker/entrypoint /entrypoint
 
 ADD ./src/app/build/distributions/app-boot.tar /
 
 ARG SPRING_PROFILES_ACTIVE
 ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
 
-ENTRYPOINT ["/app-boot/bin/app"]
+ENTRYPOINT ["/entrypoint"]

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+PATH_CONFIG=/etc/hint/config.properties
+if [ ! -f $PATH_CONFIG ]; then
+    echo "Waiting for configuration at '$PATH_CONFIG'"
+    while [ ! -f $PATH_CONFIG ]; do
+        sleep 1
+        echo "...still waiting"
+    done
+    echo "Found configuration"
+fi
+
+echo "Starting app"
+/app-boot/bin/app

--- a/scripts/pull-and-run.sh
+++ b/scripts/pull-and-run.sh
@@ -18,6 +18,6 @@ docker run --rm -d \
   --name $HINT \
   -p 8080:8080 \
   -v $HERE/../src/app/uploads:/uploads \
-  -v $TEST_CONFIG:/etc/hint/config.properties \
   $HINT_IMAGE
 
+docker cp $TEST_CONFIG $HINT:/etc/hint/config.properties

--- a/scripts/pull-and-run.sh
+++ b/scripts/pull-and-run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -ex
+
+HERE=$(readlink -f "$(dirname $0)")
+NETWORK=hint_nw
+HINT=hint
+$HERE/run-dependencies.sh
+
+. $HERE/common # sets GIT_BRANCH
+
+TEST_CONFIG=$HERE/../src/app/static/scripts/test.properties
+HINT_IMAGE=mrcide/$HINT:$GIT_BRANCH
+
+docker pull $HINT_IMAGE
+
+docker run --rm -d \
+  --network=$NETWORK \
+  --name $HINT \
+  -p 8080:8080 \
+  -v $HERE/../src/app/uploads:/uploads \
+  -v $TEST_CONFIG:/etc/hint/config.properties \
+  $HINT_IMAGE
+

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -37,7 +37,7 @@ docker run --rm -d \
   $HINTR_IMAGE
 
 # Need to give the database a little time to initialise before we can run the migration
-sleep 10s
+docker exec -it $DB wait-for-db
 docker run --rm --network=$NETWORK \
   $DB_MIGRATE_IMAGE \
   -url=jdbc:postgresql://$DB/hint


### PR DESCRIPTION
This PR will wait until the configuration at `/etc/hint/config.properties` exists, and will poll for it if not. 

I've included @r-ash's demo startup script which now uses this approach for starting the container and updated the `run-dependncies` script to use the db wait script from https://github.com/mrc-ide/hint-db/pull/7
