### PR TITLE
mrc-594: Change jdbc connection name to use db

### DIFF
--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -21,6 +21,7 @@ docker pull $DB_MIGRATE_IMAGE
 docker run --rm -d \
   --network=$NETWORK \
   --name $DB \
+  --network-alias db \
   -p 5432:5432 \
   $DB_IMAGE
 

--- a/src/app/src/main/resources/application.properties
+++ b/src/app/src/main/resources/application.properties
@@ -9,5 +9,5 @@ pac4j.logout.destroySession=true
 pac4j.logout.centralLogout=true
 pac4j.logout.defaultUrl=/login
 
-spring.datasource.jdbc-url=jdbc:postgresql://hint_db/hint
+spring.datasource.jdbc-url=jdbc:postgresql://db/hint
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/src/userCLI/src/main/resources/application.properties
+++ b/src/userCLI/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.jdbc-url=jdbc:postgresql://hint_db/hint
+spring.datasource.jdbc-url=jdbc:postgresql://db/hint
 spring.datasource.username=hintuser
 spring.datasource.password=changeme
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
This PR will change the non-testing jdbc connection to use "db" rather than "hint_db". The deployment scripts have been updated to add a network alias for this.

The motivation here is that `hint_db` is the globally relevant name (on this machine, this is the db for hint) but we might change that prefix. Once on the network, we can refer to it by its *role* which is just db.  This what docker-compose does, adding network aliases and prefixing containers.