### PR TITLE
mrc-515_reload: save state from file to local storage then reload page

### DIFF
--- a/src/app/static/src/app/components/UserHeader.vue
+++ b/src/app/static/src/app/components/UserHeader.vue
@@ -82,7 +82,7 @@
 
     interface SurveyAndProgramFiles {
         survey: LocalSessionFile | null,
-        program: LocalSessionFile | null,
+        programme: LocalSessionFile | null,
         anc: LocalSessionFile | null
     }
 
@@ -115,7 +115,7 @@
             surveyAndProgramFiles: mapStateProp<SurveyAndProgramDataState, SurveyAndProgramFiles>("surveyAndProgram", state => {
                 return {
                     survey: localSessionFile(state.survey),
-                    program: localSessionFile(state.program),
+                    programme: localSessionFile(state.program),
                     anc: localSessionFile(state.anc)
                 }
             })

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -15,6 +15,10 @@ export class LocalStorageManager {
 
     saveState = (state: RootState) => {
         const partialState = serialiseState(state);
+        this.savePartialState(partialState);
+    };
+
+    savePartialState = (partialState: Partial<RootState>) => {
         window.localStorage.setItem(appStateKey, JSON.stringify(partialState));
     };
 

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -4,6 +4,7 @@ import {RootState} from "../../root";
 import {api} from "../../apiService";
 import {verifyCheckSum} from "../../utils";
 import {Dict, LocalSessionFile} from "../../types";
+import {localStorageManager} from "../../localStorageManager";
 
 export type LoadActionTypes = "SettingFiles" | "UpdatingState" | "LoadSucceeded" | "ClearLoadError"
 export type LoadErrorActionTypes = "LoadFailed"
@@ -49,7 +50,11 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
     },
 
     async updateStoreState({commit, dispatch, state}, savedState) {
-        //TODO: In another PR - hashes have now been set for session in backend, so  update the state from the saved state and get file data from backend
+        //File hashes have now been set for session in backend so we save the state from the file we're loading into local
+        //storage then reload the page, to follow exactly the same fetch and reload procedure as session page refresh
+        //NB load state is not included in the saved state so we will default back to NotLoading on page reload.
+        localStorageManager.savePartialState(savedState);
+        location.reload();
     },
 
     async clearLoadState({commit}) {

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -18,7 +18,7 @@ import {mutations} from "../../../app/store/filteredData/mutations";
 const localVue = createLocalVue();
 Vue.use(Vuex);
 
-describe("Survey and program component", () => {
+describe("Survey and programme component", () => {
 
     testUploadComponent("surveys", 0);
     testUploadComponent("program", 1);
@@ -102,7 +102,7 @@ describe("Survey and program component", () => {
         expectTabEnabled({survey: mockSurveyResponse()}, "Survey", 0);
     });
 
-    it("programme (ART) tab is enabled when program data is present", () => {
+    it("programme (ART) tab is enabled when programme data is present", () => {
         expectTabEnabled({program: mockProgramResponse()}, "ART", 1);
     });
 

--- a/src/app/static/src/tests/components/userHeader.test.ts
+++ b/src/app/static/src/tests/components/userHeader.test.ts
@@ -115,7 +115,7 @@ describe("user header", () => {
                 population: {hash: "1csv", filename: "1.csv"},
                 shape: {hash: "3csv", filename: "3.csv"},
                 survey: {hash: "4csv", filename: "4.csv"},
-                program: {hash: "5csv", filename: "5.csv"},
+                programme: {hash: "5csv", filename: "5.csv"},
                 anc: {hash: "6csv", filename: "6.csv"}
             }
         });

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -5,7 +5,7 @@ import {login} from "./integrationTest";
 const fs = require("fs");
 const FormData = require("form-data");
 
-describe("Survey and program actions", () => {
+describe("Survey and programme actions", () => {
 
     beforeAll(async () => {
         await login();
@@ -33,7 +33,7 @@ describe("Survey and program actions", () => {
             .toBe("survey.csv")
     });
 
-    it("can upload program", async () => {
+    it("can upload programme", async () => {
 
         const commit = jest.fn();
 

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -1,7 +1,8 @@
-import {mockAxios, mockLoadState, mockSuccess, mockFailure} from "../mocks";
+import {mockAxios, mockLoadState, mockSuccess, mockFailure, mockRootState} from "../mocks";
 import {actions} from "../../app/store/load/actions";
 import {LoadingState} from "../../app/store/load/load";
 import {addCheckSum} from "../../app/utils";
+import {localStorageManager} from "../../app/localStorageManager";
 
 const FormData = require("form-data");
 
@@ -87,5 +88,20 @@ describe("Load actions", () => {
 
         //should not hand on to updateState action
         expect(dispatch.mock.calls.length).toEqual(0);
+    });
+
+    it("updateStoreState saves file state to local storage and reloads page", async () => {
+        const mockSaveToLocalStorage = jest.fn();
+        localStorageManager.savePartialState = mockSaveToLocalStorage;
+
+        const mockLocationReload = jest.fn();
+        delete window.location;
+        window.location = { reload: mockLocationReload } as any;
+
+        const testState = mockRootState();
+        await actions.updateStoreState({} as any, testState);
+
+        expect(mockSaveToLocalStorage.mock.calls[0][0]).toBe(testState);
+        expect(mockLocationReload.mock.calls.length).toBe(1);
     });
 });

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -5,7 +5,7 @@ import {DataType} from "../../app/store/filteredData/filteredData";
 
 const FormData = require("form-data");
 
-describe("Survey and program actions", () => {
+describe("Survey and programme actions", () => {
 
     it("sets data after surveys file upload", async () => {
 
@@ -51,7 +51,7 @@ describe("Survey and program actions", () => {
         expect(commit.mock.calls.length).toEqual(2);
     });
 
-    it("sets data after program file upload", async () => {
+    it("sets data after programme file upload", async () => {
 
         mockAxios.onPost(`/disease/programme/`)
             .reply(200, mockSuccess("TEST"));
@@ -74,7 +74,7 @@ describe("Survey and program actions", () => {
         expect(commit.mock.calls[2][1]).toStrictEqual({type: "SelectedDataTypeUpdated", payload: DataType.Program});
     });
 
-    it("sets error message after failed program upload", async () => {
+    it("sets error message after failed programme upload", async () => {
 
         mockAxios.onPost(`/disease/programme/`)
             .reply(500, mockFailure("error message"));

--- a/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
@@ -7,7 +7,7 @@ import {mockModelRunState, mockRootState, mockSurveyResponse} from "../mocks";
 import {Module} from "vuex";
 import {RootState} from "../../app/root";
 
-describe("Survey and program mutations", () => {
+describe("Survey and programme mutations", () => {
 
     const testData = [{
         iso3: "MWI",
@@ -36,7 +36,7 @@ describe("Survey and program mutations", () => {
         expect(testState.surveyError).toBe("Some error");
     });
 
-    it("sets program data and filename and clears error on ProgramUpdated", () => {
+    it("sets programme data and filename and clears error on ProgramUpdated", () => {
         const testState = {...initialSurveyAndProgramDataState, programError: "test"};
         mutations.ProgramUpdated(testState, testPayload);
         expect(testState.program!!.data).toStrictEqual(testData);


### PR DESCRIPTION
Also fixes a bug where program data was not being reloaded because the type needed to be 'programme'  for the backend to save hash correctly