### PR TITLE
Mrc-621 Show loading spinner when loading from file

### DIFF
--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -81,7 +81,7 @@
                 steps: state => state.steps
             }),
             ...mapStateProps<LoadState, keyof ComputedState>("load", {
-                loadingFromFile: state => ![LoadingState.NotLoading, LoadingState.LoadFailed].includes(state.loadingState)
+                loadingFromFile: state => [LoadingState.SettingFiles, LoadingState.UpdatingState].includes(state.loadingState)
             }),
             ...mapGettersByNames<keyof ComputedGetters>(namespace, ["ready", "complete"]),
             loading: function() {
@@ -92,15 +92,15 @@
             ...mapActions(namespace, ["jump", "next"]),
             ...mapActions(["validate"]),
             isActive(num: number) {
-                return this.ready && this.activeStep == num;
+                return !this.loading && this.activeStep == num;
             },
             isEnabled(num: number) {
-                return this.ready && this.steps.slice(0, num)
+                return !this.loading && this.steps.slice(0, num)
                     .filter((s: { number: number }) => this.complete[s.number])
                     .length >= num - 1
             },
             isComplete(num: number) {
-                return this.ready && this.complete[num];
+                return !this.loading && this.complete[num];
             }
         },
         components: {

--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -16,11 +16,11 @@
             </template>
         </div>
         <hr/>
-        <div v-if="!ready" class="text-center">
+        <div v-if="loading" class="text-center">
             <loading-spinner size="lg"></loading-spinner>
             <h2 id="loading-message">Loading your data</h2>
         </div>
-        <div v-if="ready" class="content">
+        <div v-if="!loading" class="content">
             <div class="pt-4">
                 <baseline v-if="isActive(1)"></baseline>
                 <survey-and-program v-if="isActive(2)"></survey-and-program>
@@ -52,6 +52,7 @@
     import ModelRun from "./modelRun/ModelRun.vue";
     import ModelOutput from "./modelOutput/ModelOutput.vue";
     import {StepDescription, StepperState} from "../store/stepper/stepper";
+    import {LoadingState, LoadState} from "../store/load/load";
     import ModelOptions from "./modelOptions/ModelOptions.vue";
     import {mapGetterByName, mapGettersByNames, mapStateProps} from "../utils";
 
@@ -66,7 +67,9 @@
 
     interface ComputedGetters {
         ready: boolean,
-        complete: boolean
+        complete: boolean,
+        loadingFromFile: boolean
+        loading: boolean
     }
 
     const namespace: string = 'stepper';
@@ -77,7 +80,13 @@
                 activeStep: state => state.activeStep,
                 steps: state => state.steps
             }),
-            ...mapGettersByNames<keyof ComputedGetters>(namespace, ["ready", "complete"])
+            ...mapStateProps<LoadState, keyof ComputedState>("load", {
+                loadingFromFile: state => ![LoadingState.NotLoading, LoadingState.LoadFailed].includes(state.loadingState)
+            }),
+            ...mapGettersByNames<keyof ComputedGetters>(namespace, ["ready", "complete"]),
+            loading: function() {
+                return this.loadingFromFile || !this.ready;
+            }
         },
         methods: {
             ...mapActions(namespace, ["jump", "next"]),
@@ -110,6 +119,6 @@
                 }
             }
         }
-    })
+    });
 
 </script>

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import Vuex, {Store} from 'vuex';
 import {baselineGetters, BaselineState} from "../../app/store/baseline/baseline";
 import {
-    mockBaselineState, mockMetadataState, mockModelOptionsState,
+    mockBaselineState, mockLoadState, mockMetadataState, mockModelOptionsState,
     mockModelRunState, mockPlottingMetadataResponse,
     mockPopulationResponse,
     mockShapeResponse, mockStepperState,
@@ -26,6 +26,7 @@ import {mutations as rootMutations} from "../../app/store/root/mutations"
 import {metadataGetters, MetadataState} from "../../app/store/metadata/metadata";
 import {ModelStatusResponse} from "../../app/generated";
 import {modelOptionsGetters} from "../../app/store/modelOptions/modelOptions";
+import {LoadingState, LoadState} from "../../app/store/load/load";
 
 const localVue = createLocalVue();
 Vue.use(Vuex);
@@ -35,7 +36,8 @@ describe("Stepper component", () => {
                        surveyAndProgramState?: Partial<SurveyAndProgramDataState>,
                        metadataState?: Partial<MetadataState>,
                        modelRunState?: Partial<ModelRunState>,
-                       stepperState?: Partial<StepperState>) => {
+                       stepperState?: Partial<StepperState>,
+                       loadState?: Partial<LoadState>) => {
 
         return new Vuex.Store({
             actions: rootActions,
@@ -75,6 +77,10 @@ describe("Stepper component", () => {
                     namespaced: true,
                     state: mockMetadataState(metadataState),
                     getters: metadataGetters
+                },
+                load: {
+                    namespaced: true,
+                    state: mockLoadState(loadState)
                 }
             }
         })
@@ -88,6 +94,22 @@ describe("Stepper component", () => {
 
         const store = createSut();
         const wrapper = shallowMount(Stepper, {store, localVue});
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
+        expect(wrapper.findAll(".content").length).toBe(0);
+        expect(wrapper.find("#loading-message").text()).toBe("Loading your data");
+    });
+
+    it("renders loading spinner while ready but loadingFromFile", () => {
+
+        const store = createSut(
+            {ready: true},
+            {ready: true},
+            {},
+            {ready: true},
+            {},
+            {loadingState: LoadingState.SettingFiles});
+        const wrapper = shallowMount(Stepper, {store, localVue});
+
         expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
         expect(wrapper.findAll(".content").length).toBe(0);
         expect(wrapper.find("#loading-message").text()).toBe("Loading your data");

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-master
+mrc-604


### PR DESCRIPTION
Contains changes from https://github.com/mrc-ide/hint/pull/110

Show the Stepper spinner when loading from file as well as when getting ready (in practice, when setting the file hashes and saving the local storage, before doing the full page reload). 