### PR TITLE
mrc-647 Add modelOutput module with getter for barchart plotting metadata

### DIFF
--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -9,6 +9,7 @@ import {
 import {initialModelRunState, modelRun, ModelRunState} from "./store/modelRun/modelRun";
 import {initialStepperState, stepper, StepperState} from "./store/stepper/stepper";
 import {initialLoadState, load, LoadState} from "./store/load/load";
+import {modelOutput, ModelOutputState} from "./store/modelOutput/modelOutput";
 import {localStorageManager} from "./localStorageManager";
 import {actions} from "./store/root/actions";
 import {mutations} from "./store/root/mutations";
@@ -22,6 +23,7 @@ export interface RootState {
     filteredData: FilteredDataState,
     modelOptions: ModelOptionsState
     modelRun: ModelRunState,
+    modelOutput: ModelOutputState,
     stepper: StepperState,
     load: LoadState
 }
@@ -44,6 +46,7 @@ export const emptyState = {
     surveyAndProgram: initialSurveyAndProgramDataState,
     filteredData: initialFilteredDataState,
     modelOptions: initialModelOptionsState,
+    modelOutput: {},
     modelRun: initialModelRunState,
     stepper: initialStepperState,
     load: initialLoadState,
@@ -57,6 +60,7 @@ export const storeOptions: StoreOptions<RootState> = {
         filteredData,
         modelOptions,
         modelRun,
+        modelOutput,
         stepper,
         load
     },

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -1,0 +1,116 @@
+import {Module} from "vuex";
+import {RootState} from "../../root";
+import {BarchartIndicator, Filter} from "../../types";
+import {FilterOption} from "../../generated";
+
+const namespaced: boolean = true;
+
+export interface ModelOutputState {}
+
+export const modelOutputGetters = {
+    barchartIndicators: (state: ModelOutputState, getters: any, rootState: RootState): BarchartIndicator[] => {
+        //TODO: Get these from metadata in ModelResultResponse
+        return [
+            {
+                "indicator": "art_coverage",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "4",
+                "name": "ART coverage",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "current_art",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "5",
+                "name": "ART number",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "incidence",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "6",
+                "name": "Incidence",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "new_infections",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "7",
+                "name": "New Infections",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "plhiv",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "3",
+                "name": "PLHIV",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "population",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "1",
+                "name": "Population",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            },
+            {
+                "indicator": "prevalence",
+                "value_column": "mean",
+                "indicator_column": "indicator_id",
+                "indicator_value": "2",
+                "name": "Prevalence",
+                "error_low_column": "lower",
+                "error_high_column": "upper"
+            }];
+    },
+    barchartFilters: (state: ModelOutputState, getters: any, rootState: RootState): Filter[] => {
+        //TODO: Get these from ModelResultResponse
+        const filterOptions = rootState.modelRun.result!!.filters!!;
+
+        const ageOptions = filterOptions.age || [];
+
+        const regions: FilterOption[] = rootState.baseline.shape!!.filters!!.regions ?
+                                        [rootState.baseline.shape!!.filters!!.regions] : [];
+
+        return [
+            {
+                "id": "age",
+                "column_id": "age_group",
+                "label": "Age group",
+                "options": ageOptions
+            },
+            {
+                "id": "region",
+                "column_id": "area_id",
+                "label": "Region",
+                "options": regions
+            },
+            {
+                "id": "sex",
+                "column_id": "sex",
+                "label": "Sex",
+                "options": [
+                    {"id": "female", "label": "female"},
+                    {"id": "male", "label": "male"}
+                 ]
+            }
+        ];
+    }
+};
+
+export const modelOutput: Module<ModelOutputState, RootState> = {
+    namespaced,
+    getters: modelOutputGetters
+};

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -1,4 +1,5 @@
 import {Payload} from "vuex";
+import {FilterOption} from "./generated";
 
 export interface PayloadWithType<T> extends Payload {
     payload: T
@@ -27,4 +28,21 @@ export type IndicatorValuesDict= Dict<IndicatorValues>;
 export interface LocalSessionFile {
     hash: string
     filename: string
+}
+
+export interface BarchartIndicator {
+    indicator: string,
+    value_column: string,
+    indicator_column: string,
+    indicator_value: string,
+    name: string,
+    error_low_column: string,
+    error_high_column: string
+}
+
+export interface Filter {
+    id: string,
+    column_id: string,
+    label: string,
+    options: FilterOption[]
 }

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -105,6 +105,7 @@ export const mockRootState = (props?: Partial<RootState>): RootState => {
         stepper: mockStepperState(),
         metadata: mockMetadataState(),
         load: mockLoadState(),
+        modelOutput: {},
         ...props
     }
 };

--- a/src/app/static/src/tests/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/modelOutput/modelOutput.test.ts
@@ -1,0 +1,67 @@
+import {modelOutputGetters} from "../../app/store/modelOutput/modelOutput";
+import {
+    mockBaselineState,
+    mockModelResultResponse, mockModelRunState,
+    mockRootState, mockShapeResponse
+} from "../mocks";
+
+
+describe("modelOutput module", () => {
+    it("gets barchart indicators", async () => {
+        const result = modelOutputGetters.barchartIndicators({}, null, mockRootState());
+        expect(result.length).toEqual(7);
+    });
+
+    it("gets barchart filters", async () => {
+        const rootState = mockRootState({
+            baseline: mockBaselineState({
+                shape: mockShapeResponse({
+                    filters: {
+                        regions: {
+                            label: "label 1",
+                            id: "id1",
+                            children: []
+                        }
+                    }
+                })
+            }),
+            modelRun: mockModelRunState({
+                result: mockModelResultResponse({
+                    filters: {
+                        age: [ {id: "1", label: "0-4"}],
+                        quarter: [],
+                        indicators: []
+                    }
+                })
+            })
+        });
+
+        const result = modelOutputGetters.barchartFilters({}, null, rootState);
+        expect(result.length).toEqual(3);
+        expect (result[0]).toStrictEqual({
+            id: "age",
+            column_id: "age_group",
+            label: "Age group",
+            options: [
+                {id: "1", label: "0-4"}
+            ]
+        });
+        expect (result[1]).toStrictEqual({
+            id: "region",
+            column_id: "area_id",
+            label: "Region",
+            options: [
+                {id: "id1", label: "label 1", children: []}
+            ]
+        });
+        expect (result[2]).toStrictEqual({
+            id: "sex",
+            column_id: "sex",
+            label: "Sex",
+            options: [
+                {id: "female", label: "female"},
+                {id: "male", label: "male"}
+            ]
+        });
+    });
+});


### PR DESCRIPTION
This adds a modelOutput module in order to access the plotting metadata for the barchart (currently hardcoded, but will come from the modelRunResult response). This module doesn't actually have any state of its own, so maybe it doesn't deserve to be a separate module, but it seemed like it belonged separately from the model run stuff...