### PR TITLE
mrc-602 performance

### DIFF
--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -8,6 +8,7 @@ import {
     SurveyResponse, AncResponse, ProgrammeResponse, PopulationResponse, ShapeResponse, PjnzResponse
 } from "./generated";
 import {Commit} from "vuex";
+import {freezer} from "./utils";
 
 type ResponseData =
     ValidateInputResponse
@@ -74,7 +75,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
 
     withSuccess = (type: S) => {
         this._onSuccess = (success: Response) => {
-            this._commit({type: type, payload: success.data});
+            this._commit({type: type, payload: freezer.deepFreeze(success.data)});
         };
         return this;
     };

--- a/src/app/static/src/app/components/plots/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/Choropleth.vue
@@ -41,7 +41,7 @@
 
     interface FilteredDataComputed {
         selectedDataType: DataType | null
-        selectedRegions: NestedFilterOption[]
+        selectedRegions: string[]
     }
 
     interface FilteredDataGetters {
@@ -161,7 +161,7 @@
             },
             selectedRegionFeatures(): Feature[] {
                 if (this.selectedRegions && this.selectedRegions.length > 0) {
-                    return this.selectedRegions.map((r: NestedFilterOption) => this.getFeatureFromAreaId(r.id)!!);
+                    return this.selectedRegions.map((id: string) => this.getFeatureFromAreaId(id)!!);
                 } else if (this.countryFeature) {
                     return [this.countryFeature];
                 }

--- a/src/app/static/src/app/components/plots/ChoroplethFilters.vue
+++ b/src/app/static/src/app/components/plots/ChoroplethFilters.vue
@@ -3,19 +3,19 @@
         <h4>Filters</h4>
         <div class="py-2">
             <filter-select label="Sex"
-                    :multiple="false"
-                    :options="sexFilters.available"
-                    :value="sexFilters.selected"
-                    :disabled="sexFilters.disabled"
-                    @select="selectSex"></filter-select>
+                           :multiple="false"
+                           :options="sexFilters.available"
+                           :value="sexFilters.selected"
+                           :disabled="sexFilters.disabled"
+                           @select="selectSex"></filter-select>
         </div>
         <div class="py-2">
             <filter-select label="Age"
-                    :multiple="false"
-                    :options="ageFilters.available"
-                    :value="ageFilters.selected"
-                    :disabled="ageFilters.disabled"
-                    @select="selectAge"></filter-select>
+                           :multiple="false"
+                           :options="ageFilters.available"
+                           :value="ageFilters.selected"
+                           :disabled="ageFilters.disabled"
+                           @select="selectAge"></filter-select>
         </div>
 
         <div class="py-2" v-if="!isOutput">
@@ -38,11 +38,11 @@
 
         <div class="py-2">
             <filter-select label="Region"
-                    :multiple="true"
-                    :options="regionFilters.available"
-                    :value="regionFilters.selected"
-                    :disabled="regionFilters.disabled"
-                    @select="selectRegion"></filter-select>
+                           :multiple="true"
+                           :options="regionFilters.available"
+                           :value="regionFilters.selected"
+                           :disabled="regionFilters.disabled"
+                           @select="selectRegion"></filter-select>
         </div>
     </div>
 </template>
@@ -50,13 +50,9 @@
 <script lang="ts">
     import Vue from "vue";
     import {mapActions, mapGetters, mapState} from "vuex";
-    import {
-        DataType,
-        FilteredDataState,
-        FilterType
-    } from "../../store/filteredData/filteredData";
+    import {DataType, FilteredDataState, FilterType} from "../../store/filteredData/filteredData";
     import FilterSelect from "./FilterSelect.vue";
-    import {FilterOption, NestedFilterOption} from "../../generated";
+    import {FilterOption} from "../../generated";
 
     const namespace: string = 'filteredData';
 
@@ -69,37 +65,35 @@
     export default Vue.extend({
         name: "ChoroplethFilters",
         computed: {
-            ...mapGetters(namespace, ["selectedDataFilterOptions", "flattenedRegionOptions",
-                                        "flattenedSelectedRegionFilters"]),
+            ...mapGetters(namespace, ["selectedDataFilterOptions", "flattenedSelectedRegionFilters"]),
             ...mapState<FilteredDataState>(namespace, {
                 selectedDataType: state => state.selectedDataType,
                 selectedChoroplethFilters: state => state.selectedChoroplethFilters,
-
-                sexFilters: function (state): ChoroplethFiltersForType {
+                sexFilters: function (): ChoroplethFiltersForType {
                     return this.buildViewFiltersForType(this.selectedDataFilterOptions.sex,
                         this.selectedChoroplethFilters.sex)
                 },
 
-                ageFilters: function (state): ChoroplethFiltersForType {
+                ageFilters: function (): ChoroplethFiltersForType {
                     return this.buildViewFiltersForType(this.selectedDataFilterOptions.age,
                         this.selectedChoroplethFilters.age);
                 },
 
-                surveyFilters: function (state): ChoroplethFiltersForType {
+                surveyFilters: function (): ChoroplethFiltersForType {
                     return this.buildViewFiltersForType(this.selectedDataFilterOptions.surveys,
                         this.selectedChoroplethFilters.survey);
                 },
 
-                quarterFilters: function (state): ChoroplethFiltersForType {
+                quarterFilters: function (): ChoroplethFiltersForType {
                     return this.buildViewFiltersForType(this.selectedDataFilterOptions.quarter,
                         this.selectedChoroplethFilters.quarter);
                 },
 
-                regionFilters: function (state): ChoroplethFiltersForType {
+                regionFilters: function (): ChoroplethFiltersForType {
                     return this.buildRegionFilters();
                 },
 
-                hasFilters: function (state) {
+                hasFilters: function () {
                     return this.selectedChoroplethFilters != null && this.selectedDataFilterOptions != null;
                 },
 
@@ -113,51 +107,45 @@
                 filterUpdated: 'filteredData/choroplethFilterUpdated',
             }),
             buildViewFiltersForType(availableFilterOptions: FilterOption[],
-                                    selectedFilterOption?: FilterOption) {
+                                    selectedFilterOption?: string) {
                 return {
                     available: availableFilterOptions ? availableFilterOptions : [],
-                    selected: selectedFilterOption ? selectedFilterOption.id : null,
+                    selected: selectedFilterOption ? selectedFilterOption : null,
                     disabled: availableFilterOptions == undefined
                 }
             },
             buildRegionFilters() {
-                const selectedRegions = (this.selectedChoroplethFilters.regions ?
-                    this.selectedChoroplethFilters.regions : []) as FilterOption[];
+                const selectedRegions = this.selectedChoroplethFilters.regions ?
+                    this.selectedChoroplethFilters.regions : [];
 
                 return {
                     available: this.selectedDataFilterOptions.regions,
-                    selected: selectedRegions.map(r => r.id),
+                    selected: selectedRegions,
                     disabled: false
                 }
             },
-            selectFilterOption(filterType: FilterType, id: string, available: FilterOption[]) {
-                const newFilter = available.filter(o => o.id == id)[0];
-
-                this.filterUpdated([filterType, newFilter]);
+            selectFilterOption(filterType: FilterType, id: string) {
+                this.filterUpdated([filterType, id]);
             },
             selectSex(id: string) {
-                this.selectFilterOption(FilterType.Sex, id, this.sexFilters.available);
+                this.selectFilterOption(FilterType.Sex, id);
             },
             selectAge(id: string) {
-                this.selectFilterOption(FilterType.Age, id, this.ageFilters.available);
+                this.selectFilterOption(FilterType.Age, id);
             },
             selectSurvey(id: string) {
-                this.selectFilterOption(FilterType.Survey, id, this.surveyFilters.available);
+                this.selectFilterOption(FilterType.Survey, id);
             },
             selectQuarter(id: string) {
-                this.selectFilterOption(FilterType.Quarter, id, this.quarterFilters.available);
+                this.selectFilterOption(FilterType.Quarter, id);
             },
             selectRegion(ids: string[]) {
-                const newFilter = ids.map(id => this.flattenedRegionOptions[id]);
-                this.filterUpdated([FilterType.Region, newFilter]);
+                this.filterUpdated([FilterType.Region, ids]);
             },
             getNewSelectedFilterOption(filterName: string, available: FilterOption[]) {
                 //if the selected data type has changed, we should update the choropleth filters if the dataset of that
                 //type does not include any of the selected filters as values. Set the filter to the first available value
-                const selectedChoroplethFilters = this.selectedChoroplethFilters;
-
-                const currentValue = selectedChoroplethFilters[filterName] ?
-                    selectedChoroplethFilters[filterName].id : null;
+                const currentValue = this.selectedChoroplethFilters[filterName] || null;
 
                 if (available && available.length > 0 //leave unchanged if none available - control will be disabled anyway
                     && ((!currentValue) || available.filter(f => f.id == currentValue).length == 0)) {
@@ -165,7 +153,7 @@
                 }
                 return null;
             },
-            refreshSelectedChoroplethFilters(){
+            refreshSelectedChoroplethFilters() {
                 if (this.hasFilters) {
                     const newSexFilter = this.getNewSelectedFilterOption("sex", this.sexFilters.available);
                     if (newSexFilter) {

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -2,13 +2,16 @@ import {Module} from 'vuex';
 import {actions} from './actions';
 import {mutations} from './mutations';
 import {ReadyState, RootState} from "../../root";
-import {PjnzResponse, PopulationResponse, ShapeResponse} from "../../generated";
+import {NestedFilterOption, PjnzResponse, PopulationResponse, ShapeResponse} from "../../generated";
+import {Dict} from "../../types";
 
 export interface BaselineState extends ReadyState {
     pjnzError: string
     country: string
     pjnz: PjnzResponse | null
     shape: ShapeResponse | null
+    regionFilters: NestedFilterOption[]
+    flattenedRegionFilters: Dict<NestedFilterOption>
     shapeError: string
     population: PopulationResponse | null,
     populationError: string
@@ -19,6 +22,8 @@ export const initialBaselineState: BaselineState = {
     pjnzError: "",
     pjnz: null,
     shape: null,
+    regionFilters: [],
+    flattenedRegionFilters: {},
     shapeError: "",
     population: null,
     populationError: "",

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -27,7 +27,7 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
         const data = action.payload;
         if (data) {
             state.country = data.data.country;
-            state.pjnz = Object.freeze(data);
+            state.pjnz = data;
         } else {
             state.country = "";
             state.pjnz = null;
@@ -38,7 +38,7 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
     ShapeUpdated(state: BaselineState, action: PayloadWithType<ShapeResponse>) {
         state.shape = Object.freeze(action.payload);
         if (action.payload && action.payload.filters.regions){
-            state.regionFilters = Object.freeze(action.payload.filters.regions.children) as NestedFilterOption[];
+            state.regionFilters = action.payload.filters.regions.children as NestedFilterOption[];
             state.flattenedRegionFilters = Object.freeze(flattenOptions(state.regionFilters));
         }
         state.shapeError = "";
@@ -54,7 +54,7 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
     },
 
     PopulationUploadError(state: BaselineState, action: PayloadWithType<string>) {
-        state.populationError = Object.freeze(action.payload);
+        state.populationError = action.payload;
     },
 
     ...readyStateMutations

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -1,8 +1,9 @@
 import {Mutation, MutationTree} from 'vuex';
 import {BaselineState} from "./baseline";
-import {PjnzResponse, PopulationResponse, ShapeResponse} from "../../generated";
+import {NestedFilterOption, PjnzResponse, PopulationResponse, ShapeResponse} from "../../generated";
 import {PayloadWithType} from "../../types";
 import {readyStateMutations} from "../shared/readyStateMutations";
+import {flattenOptions} from "../filteredData/utils";
 
 type BaselineMutation = Mutation<BaselineState>
 
@@ -26,7 +27,7 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
         const data = action.payload;
         if (data) {
             state.country = data.data.country;
-            state.pjnz = data;
+            state.pjnz = Object.freeze(data);
         } else {
             state.country = "";
             state.pjnz = null;
@@ -35,7 +36,11 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
     },
 
     ShapeUpdated(state: BaselineState, action: PayloadWithType<ShapeResponse>) {
-        state.shape = action.payload;
+        state.shape = Object.freeze(action.payload);
+        if (action.payload && action.payload.filters.regions){
+            state.regionFilters = Object.freeze(action.payload.filters.regions.children) as NestedFilterOption[];
+            state.flattenedRegionFilters = Object.freeze(flattenOptions(state.regionFilters));
+        }
         state.shapeError = "";
     },
 
@@ -49,7 +54,7 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
     },
 
     PopulationUploadError(state: BaselineState, action: PayloadWithType<string>) {
-        state.populationError = action.payload;
+        state.populationError = Object.freeze(action.payload);
     },
 
     ...readyStateMutations

--- a/src/app/static/src/app/store/filteredData/filteredData.ts
+++ b/src/app/static/src/app/store/filteredData/filteredData.ts
@@ -3,54 +3,35 @@ import { actions } from './actions';
 import { mutations } from './mutations';
 import { getters } from './getters';
 import { RootState} from "../../root";
-import {FilterOption, NestedFilterOption} from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
 
 export enum DataType { ANC, Program, Survey, Output }
 export enum FilterType { Sex, Age, Region, Survey, Quarter }
 
-export interface SelectedFilters {
-    sex: FilterOption[],
-    age: FilterOption[],
-    region: FilterOption[],
-    surveys: FilterOption[],
-    quarter: FilterOption[]
-}
-
 export interface SelectedChoroplethFilters {
-    sex: FilterOption | null,
-    age: FilterOption | null,
-    survey: FilterOption | null,
-    quarter: FilterOption | null,
-    regions: NestedFilterOption[] | null
+    sex: string,
+    age: string,
+    survey: string,
+    quarter: string,
+    regions: string[]
 }
 
 export interface FilteredDataState {
     selectedDataType: DataType | null
-    selectedFilters: SelectedFilters
     selectedChoroplethFilters: SelectedChoroplethFilters
     regionIndicators: {[k: string]: any};
 }
 
-export const initialSelectedFilters: SelectedFilters = {
-    sex: [],
-    age: [],
-    region: [],
-    surveys: [],
-    quarter: []
-};
-
 export const initialSelectedChoroplethFilters: SelectedChoroplethFilters = {
-    sex: null,
-    age: null,
-    survey: null,
-    regions: null,
-    quarter: null
+    sex: "",
+    age: "",
+    survey: "",
+    regions: [],
+    quarter: ""
 };
 
 export const initialFilteredDataState: FilteredDataState = {
    selectedDataType: null,
-   selectedFilters: initialSelectedFilters,
    selectedChoroplethFilters: initialSelectedChoroplethFilters,
    regionIndicators: {}
 };

--- a/src/app/static/src/app/store/filteredData/getters.ts
+++ b/src/app/static/src/app/store/filteredData/getters.ts
@@ -2,7 +2,7 @@ import {RootState} from "../../root";
 import {DataType, FilteredDataState} from "./filteredData";
 import {FilterOption} from "../../generated";
 import {Dict, IndicatorValuesDict} from "../../types";
-import {getIdsAndChildrenIds, getColor, getUnfilteredData, sexFilterOptions} from "./utils";
+import {flattenToIdSet, getColor, getUnfilteredData, sexFilterOptions} from "./utils";
 
 export const getters = {
     selectedDataFilterOptions: (state: FilteredDataState, getters: any, rootState: RootState): Dict<FilterOption[] | undefined> | null => {
@@ -131,5 +131,5 @@ export const getters = {
 
 export const flattenedSelectedRegionFilters = (state: FilteredDataState, rootState: RootState): Set<string> => {
     const selectedRegions = state.selectedChoroplethFilters.regions ? state.selectedChoroplethFilters.regions : [];
-    return getIdsAndChildrenIds(selectedRegions, rootState.baseline.flattenedRegionFilters);
+    return flattenToIdSet(selectedRegions, rootState.baseline.flattenedRegionFilters);
 };

--- a/src/app/static/src/app/store/filteredData/getters.ts
+++ b/src/app/static/src/app/store/filteredData/getters.ts
@@ -1,19 +1,13 @@
 import {RootState} from "../../root";
-import {DataType, FilteredDataState, SelectedChoroplethFilters, SelectedFilters} from "./filteredData";
-
-import {IndicatorMetadata, NestedFilterOption} from "../../generated";
-import {IndicatorValues, IndicatorValuesDict} from "../../types";
-import {Dict} from "../../types";
+import {DataType, FilteredDataState} from "./filteredData";
 import {FilterOption} from "../../generated";
-import {flattenOptions} from "./utils";
-import {getColor, getUnfilteredData, sexFilterOptions} from "./utils";
-import * as d3ScaleChromatic from "d3-scale-chromatic";
-import {Indicators} from "../../../tests/mocks";
+import {Dict, IndicatorValuesDict} from "../../types";
+import {flattenIds, getColor, getUnfilteredData, sexFilterOptions} from "./utils";
 
 export const getters = {
     selectedDataFilterOptions: (state: FilteredDataState, getters: any, rootState: RootState): Dict<FilterOption[] | undefined> | null => {
         const sapState = rootState.surveyAndProgram;
-        const regions = getters.regionOptions;
+        const regions = rootState.baseline.regionFilters;
         switch (state.selectedDataType) {
             case (DataType.ANC):
                 return sapState.anc ?
@@ -52,14 +46,6 @@ export const getters = {
                 return null;
         }
     },
-    regionOptions: (state: FilteredDataState, getters: any, rootState: RootState): NestedFilterOption[] => {
-        const shape = rootState.baseline && rootState.baseline.shape;
-        if (!shape || !shape.filters.regions || !shape.filters.regions.children)
-            return [];
-
-        //We're skipping the top level, country region as it doesn't really contribute to the filtering
-        return shape.filters.regions.children as NestedFilterOption[];
-    },
     regionIndicators: function (state: FilteredDataState, getters: any, rootState: RootState, rootGetters: any): Dict<IndicatorValuesDict> {
 
         const data = getUnfilteredData(state, rootState);
@@ -67,7 +53,6 @@ export const getters = {
             return {};
         }
 
-        const flattenedRegions = getters.flattenedSelectedRegionFilters;
         const result = {} as Dict<IndicatorValuesDict>;
 
         const indicatorsMeta = rootGetters['metadata/choroplethIndicatorsMetadata'];
@@ -111,47 +96,39 @@ export const getters = {
 
         return result;
     },
-    excludeRow: function (state: FilteredDataState, getters: any): (row: any) => boolean {
-        const dataType = state.selectedDataType;
+    excludeRow: function (state: FilteredDataState, getters: any, rootState: RootState): (row: any) => boolean {
+        const dataType = state.selectedDataType!!;
         const selectedFilters = state.selectedChoroplethFilters;
-        const selectedRegionFilters = getters.flattenedSelectedRegionFilters;
+        const selectedRegionFilters = flattenedSelectedRegionFilters(state, rootState);
 
         return (row: any) => {
 
-            if (dataType == null) {
+            if (dataType != DataType.ANC && row.sex != selectedFilters.sex) {
                 return true;
             }
 
-            if (dataType != DataType.ANC && row.sex != selectedFilters.sex!.id) {
+            if (dataType != DataType.ANC && row.age_group_id != selectedFilters.age) {
                 return true;
             }
 
-            if (dataType != DataType.ANC && row.age_group_id != selectedFilters.age!.id) {
+            if (dataType == DataType.Survey && row.survey_id != selectedFilters.survey) {
                 return true;
             }
 
-            if (dataType == DataType.Survey && row.survey_id != selectedFilters.survey!.id) {
+            if (dataType in [DataType.Program, DataType.ANC] && row.quarter_id != selectedFilters.quarter) {
                 return true;
             }
 
-            if (dataType in [DataType.Program, DataType.ANC] && row.quarter_id != selectedFilters.quarter!.id) {
-                return true;
-            }
-
-            const flattenedRegionIds = Object.keys(selectedRegionFilters);
-            if (flattenedRegionIds.length && flattenedRegionIds.indexOf(row.area_id) < 0) {
+            if (selectedRegionFilters.size > 0 && !selectedRegionFilters.has(row.area_id)) {
                 return true
             }
 
             return false;
         }
-    },
-    flattenedRegionOptions: function (state: FilteredDataState, getters: any): Dict<NestedFilterOption> {
-        return flattenOptions(getters.regionOptions);
-    },
-    flattenedSelectedRegionFilters: function (state: FilteredDataState): Dict<NestedFilterOption> {
-        const selectedRegions = state.selectedChoroplethFilters.regions ? state.selectedChoroplethFilters.regions : [];
-        return flattenOptions(selectedRegions);
-    },
+    }
 };
 
+export const flattenedSelectedRegionFilters = (state: FilteredDataState, rootState: RootState): Set<string> => {
+    const selectedRegions = state.selectedChoroplethFilters.regions ? state.selectedChoroplethFilters.regions : [];
+    return flattenIds(selectedRegions, rootState.baseline.flattenedRegionFilters);
+};

--- a/src/app/static/src/app/store/filteredData/getters.ts
+++ b/src/app/static/src/app/store/filteredData/getters.ts
@@ -56,10 +56,11 @@ export const getters = {
         const result = {} as Dict<IndicatorValuesDict>;
 
         const indicatorsMeta = rootGetters['metadata/choroplethIndicatorsMetadata'];
+        const selectedRegionFilters = flattenedSelectedRegionFilters(state, rootState);
 
         for (const row of data) {
 
-            if (getters.excludeRow(row)) {
+            if (getters.excludeRow(row, selectedRegionFilters)) {
                 continue;
             }
 
@@ -96,12 +97,12 @@ export const getters = {
 
         return result;
     },
-    excludeRow: function (state: FilteredDataState, getters: any, rootState: RootState): (row: any) => boolean {
+    excludeRow: function (state: FilteredDataState, getters: any, rootState: RootState):
+        (row: any, selectedRegions: Set<string>) => boolean {
         const dataType = state.selectedDataType!!;
         const selectedFilters = state.selectedChoroplethFilters;
-        const selectedRegionFilters = flattenedSelectedRegionFilters(state, rootState);
 
-        return (row: any) => {
+        return (row: any, selectedRegions: Set<string>) => {
 
             if (dataType != DataType.ANC && row.sex != selectedFilters.sex) {
                 return true;
@@ -119,7 +120,7 @@ export const getters = {
                 return true;
             }
 
-            if (selectedRegionFilters.size > 0 && !selectedRegionFilters.has(row.area_id)) {
+            if (selectedRegions.size > 0 && !selectedRegions.has(row.area_id)) {
                 return true
             }
 

--- a/src/app/static/src/app/store/filteredData/getters.ts
+++ b/src/app/static/src/app/store/filteredData/getters.ts
@@ -2,7 +2,7 @@ import {RootState} from "../../root";
 import {DataType, FilteredDataState} from "./filteredData";
 import {FilterOption} from "../../generated";
 import {Dict, IndicatorValuesDict} from "../../types";
-import {flattenIds, getColor, getUnfilteredData, sexFilterOptions} from "./utils";
+import {getIdsAndChildrenIds, getColor, getUnfilteredData, sexFilterOptions} from "./utils";
 
 export const getters = {
     selectedDataFilterOptions: (state: FilteredDataState, getters: any, rootState: RootState): Dict<FilterOption[] | undefined> | null => {
@@ -131,5 +131,5 @@ export const getters = {
 
 export const flattenedSelectedRegionFilters = (state: FilteredDataState, rootState: RootState): Set<string> => {
     const selectedRegions = state.selectedChoroplethFilters.regions ? state.selectedChoroplethFilters.regions : [];
-    return flattenIds(selectedRegions, rootState.baseline.flattenedRegionFilters);
+    return getIdsAndChildrenIds(selectedRegions, rootState.baseline.flattenedRegionFilters);
 };

--- a/src/app/static/src/app/store/filteredData/mutations.ts
+++ b/src/app/static/src/app/store/filteredData/mutations.ts
@@ -1,7 +1,6 @@
 import {PayloadWithType} from "../../types";
 import {Mutation, MutationTree} from "vuex";
 import {DataType, FilteredDataState, FilterType} from "./filteredData";
-import {FilterOption, NestedFilterOption} from "../../generated";
 
 type FilteredDataMutation = Mutation<FilteredDataState>
 
@@ -14,24 +13,24 @@ export const mutations: MutationTree<FilteredDataState> & SelectedDataMutations 
     SelectedDataTypeUpdated(state: FilteredDataState, action: PayloadWithType<DataType>) {
         state.selectedDataType = action.payload;
     },
-    ChoroplethFilterUpdated(state: FilteredDataState, action: PayloadWithType<[FilterType, FilterOption | NestedFilterOption[]]>) {
+    ChoroplethFilterUpdated(state: FilteredDataState, action: PayloadWithType<[FilterType, string | string[]]>) {
         const value = action.payload[1];
         const filters =  state.selectedChoroplethFilters;
         switch (action.payload[0]) {
             case (FilterType.Age):
-                filters.age = value as FilterOption;
+                filters.age = value as string;
                 break;
             case (FilterType.Sex):
-                filters.sex = value as FilterOption;
+                filters.sex = value as string;
                 break;
             case (FilterType.Survey):
-                filters.survey = value as FilterOption;
+                filters.survey = value as string;
                 break;
             case (FilterType.Quarter):
-                filters.quarter = value as FilterOption;
+                filters.quarter = value as string;
                 break;
             case (FilterType.Region):
-                filters.regions = value as NestedFilterOption[];
+                filters.regions = value as string[];
                 break;
         }
     }

--- a/src/app/static/src/app/store/filteredData/utils.ts
+++ b/src/app/static/src/app/store/filteredData/utils.ts
@@ -2,6 +2,7 @@ import {DataType, FilteredDataState} from "./filteredData";
 import {RootState} from "../../root";
 import {IndicatorMetadata, NestedFilterOption} from "../../generated";
 import * as d3ScaleChromatic from "d3-scale-chromatic";
+import {Dict} from "../../types";
 
 export const sexFilterOptions = [
     {id: "both", label: "both"},
@@ -86,24 +87,24 @@ const flattenOption = (filterOption: NestedFilterOption): NestedFilterOption => 
     return result;
 };
 
-export const flattenIds = (ids: string[], lookup: any): Set<string> => {
+export const getIdsAndChildrenIds = (ids: string[], lookup: Dict<NestedFilterOption>): Set<string> => {
     let result: string[] = [];
     ids.forEach(r =>
         result = [
             ...result,
-            ...flattenId(lookup[r])
+            ...getIdAndChildrenIdsAsFlatArray(lookup[r])
         ]);
     return new Set(result);
 };
 
-const flattenId = (filterOption: NestedFilterOption): string[] => {
+const getIdAndChildrenIdsAsFlatArray = (filterOption: NestedFilterOption): string[] => {
     let result: string[] = [];
     result.push(filterOption.id);
     if (filterOption.children) {
         filterOption.children.forEach(o =>
             result = [
                 ...result,
-                ...flattenId(o as NestedFilterOption)
+                ...getIdAndChildrenIdsAsFlatArray(o as NestedFilterOption)
             ]);
 
     }

--- a/src/app/static/src/app/store/filteredData/utils.ts
+++ b/src/app/static/src/app/store/filteredData/utils.ts
@@ -9,7 +9,7 @@ export const sexFilterOptions = [
     {id: "male", label: "male"}
 ];
 
-export const roundToContext = function(value: number, context: number) {
+export const roundToContext = function (value: number, context: number) {
     //Rounds the value to one more decimal place than is present in the 'context'
     const maxFraction = context.toString().split(".");
     const maxDecPl = maxFraction.length > 1 ? maxFraction[1].length : 0;
@@ -18,9 +18,9 @@ export const roundToContext = function(value: number, context: number) {
     return Math.round(value * roundingNum) / roundingNum;
 };
 
-export const colorFunctionFromName = function(name: string) {
-    let result =  (d3ScaleChromatic as any)[name];
-    if (!result){
+export const colorFunctionFromName = function (name: string) {
+    let result = (d3ScaleChromatic as any)[name];
+    if (!result) {
         //This is trying to be defensive against typos in metadata...
         console.warn(`Unknown color function: ${name}`);
         result = d3ScaleChromatic.interpolateWarm;
@@ -33,7 +33,7 @@ export const getColor = (value: number, metadata: IndicatorMetadata) => {
     const min = metadata.min;
     const colorFunction = colorFunctionFromName(metadata.colour);
 
-    let rangeNum = (max  && (max != min)) ? //Avoid dividing by zero if only one value...
+    let rangeNum = (max && (max != min)) ? //Avoid dividing by zero if only one value...
         max - (min || 0) :
         1;
 
@@ -81,6 +81,30 @@ const flattenOption = (filterOption: NestedFilterOption): NestedFilterOption => 
                 ...result,
                 ...flattenOption(o as NestedFilterOption)
             });
+
+    }
+    return result;
+};
+
+export const flattenIds = (ids: string[], lookup: any): Set<string> => {
+    let result: string[] = [];
+    ids.forEach(r =>
+        result = [
+            ...result,
+            ...flattenId(lookup[r])
+        ]);
+    return new Set(result);
+};
+
+const flattenId = (filterOption: NestedFilterOption): string[] => {
+    let result: string[] = [];
+    result.push(filterOption.id);
+    if (filterOption.children) {
+        filterOption.children.forEach(o =>
+            result = [
+                ...result,
+                ...flattenId(o as NestedFilterOption)
+            ]);
 
     }
     return result;

--- a/src/app/static/src/app/store/filteredData/utils.ts
+++ b/src/app/static/src/app/store/filteredData/utils.ts
@@ -87,24 +87,24 @@ const flattenOption = (filterOption: NestedFilterOption): NestedFilterOption => 
     return result;
 };
 
-export const getIdsAndChildrenIds = (ids: string[], lookup: Dict<NestedFilterOption>): Set<string> => {
+export const flattenToIdSet = (ids: string[], lookup: Dict<NestedFilterOption>): Set<string> => {
     let result: string[] = [];
     ids.forEach(r =>
         result = [
             ...result,
-            ...getIdAndChildrenIdsAsFlatArray(lookup[r])
+            ...flattenToIdArray(lookup[r])
         ]);
     return new Set(result);
 };
 
-const getIdAndChildrenIdsAsFlatArray = (filterOption: NestedFilterOption): string[] => {
+const flattenToIdArray = (filterOption: NestedFilterOption): string[] => {
     let result: string[] = [];
     result.push(filterOption.id);
     if (filterOption.children) {
         filterOption.children.forEach(o =>
             result = [
                 ...result,
-                ...getIdAndChildrenIdsAsFlatArray(o as NestedFilterOption)
+                ...flattenToIdArray(o as NestedFilterOption)
             ]);
 
     }

--- a/src/app/static/src/app/store/surveyAndProgram/mutations.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/mutations.ts
@@ -18,7 +18,7 @@ export interface SurveyAndProgramMutations {
 
 export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgramMutations = {
     SurveyUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<SurveyResponse>) {
-        state.survey = action.payload;
+        state.survey = Object.freeze(action.payload);
         state.surveyError = "";
     },
 
@@ -27,7 +27,7 @@ export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgr
     },
 
     ProgramUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<ProgrammeResponse>) {
-        state.program = action.payload;
+        state.program = Object.freeze(action.payload);
         state.programError = "";
     },
 
@@ -36,7 +36,7 @@ export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgr
     },
 
     ANCUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<AncResponse>) {
-        state.anc = action.payload;
+        state.anc = Object.freeze(action.payload);
         state.ancError = "";
     },
 

--- a/src/app/static/src/app/store/surveyAndProgram/mutations.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/mutations.ts
@@ -18,7 +18,7 @@ export interface SurveyAndProgramMutations {
 
 export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgramMutations = {
     SurveyUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<SurveyResponse>) {
-        state.survey = Object.freeze(action.payload);
+        state.survey = action.payload;
         state.surveyError = "";
     },
 
@@ -27,7 +27,7 @@ export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgr
     },
 
     ProgramUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<ProgrammeResponse>) {
-        state.program = Object.freeze(action.payload);
+        state.program = action.payload;
         state.programError = "";
     },
 
@@ -36,7 +36,7 @@ export const mutations: MutationTree<SurveyAndProgramDataState> & SurveyAndProgr
     },
 
     ANCUpdated(state: SurveyAndProgramDataState, action: PayloadWithType<AncResponse>) {
-        state.anc = Object.freeze(action.payload);
+        state.anc = action.payload;
         state.ancError = "";
     },
 

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -54,3 +54,21 @@ export const verifyCheckSum = (content: string): false | any => {
 
     return valid && JSON.parse(data);
 };
+
+export const freezer = {
+
+    deepFreeze : (data: any): any => {
+        if (Array.isArray(data)) {
+            return Object.freeze(data)
+        }
+        if (data != null && typeof data === "object") {
+            for (let prop in data) {
+                if (data.hasOwnProperty(prop)) {
+                    data[prop] = freezer.deepFreeze(data[prop])
+                }
+            }
+            return Object.freeze(data);
+        }
+        return data;
+    }
+};

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -59,7 +59,7 @@ export const freezer = {
 
     deepFreeze : (data: any): any => {
         if (Array.isArray(data)) {
-            return Object.freeze(data)
+            return Object.freeze(data.map(d => freezer.deepFreeze(d)))
         }
         if (data != null && typeof data === "object") {
             for (let prop in data) {

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -87,6 +87,33 @@ describe("Baseline mutations", () => {
         expect(testState.shapeError).toBe("");
     });
 
+    it("sets region filters and flattened region filters on ShapeUpdated", () => {
+
+        const mockShape = mockShapeResponse({
+            filters: {
+                regions: {
+                    id: "MWI", label: "Malawi", children: [
+                        {
+                            id: "MWI.1", label: "l1"
+                        }
+                    ]
+                }
+            }
+        });
+        const testState = {...initialBaselineState};
+        mutations.ShapeUpdated(testState, {
+            payload: mockShape
+        });
+        expect(testState.regionFilters).toStrictEqual([{
+            id: "MWI.1", label: "l1"
+        }]);
+        expect(testState.flattenedRegionFilters).toStrictEqual({
+            "MWI.1": {
+                id: "MWI.1", label: "l1"
+            }
+        });
+    });
+
     it("sets error on ShapeUploadError", () => {
 
         const testState = {...initialBaselineState};

--- a/src/app/static/src/tests/components/plots/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth.test.ts
@@ -2,25 +2,17 @@ import {createLocalVue, shallowMount} from '@vue/test-utils';
 import Choropleth from "../../../app/components/plots/Choropleth.vue";
 import Vue from "vue";
 import Vuex from "vuex";
-import {
-    mockBaselineState,
-    mockFilteredDataState,
-    mockMetadataState,
-    mockPlottingMetadataResponse,
-    mockShapeResponse
-} from "../../mocks";
+import {mockBaselineState, mockFilteredDataState, mockMetadataState, mockShapeResponse} from "../../mocks";
 import {LGeoJson} from 'vue2-leaflet';
 import MapControl from "../../../app/components/plots/MapControl.vue";
 import {mutations} from "../../../app/store/filteredData/mutations";
 import {
-    DataType, filteredData,
+    DataType,
     FilteredDataState,
     FilterType,
     initialFilteredDataState
 } from "../../../app/store/filteredData/filteredData";
 import {actions} from "../../../app/store/filteredData/actions";
-import {testGetters} from "../../filteredData/getters.test";
-import {store} from "../../../app/main";
 
 const localVue = createLocalVue();
 Vue.use(Vuex);
@@ -57,31 +49,27 @@ describe("Choropleth component", () => {
         "MWI.1.1.1.1": {
             prev: {value: 0.1, color: "rgb(1,1,1)"},
             art: {value: 0.08, color: "rgb(2,2,2)"}
-            },
+        },
         "MWI.1.1.1.2": {
             prev: {value: 0.05, color: "rgb(3,3,3)"},
             art: {value: 0.06, color: "rgb(4,4,4)"}
         },
         "MWI.1.1.1": {
             prev: {value: 0.07, color: "rgb(5,5,5)"},
-            art:{value: 0.2, color: "rgb(6,6,6)" }
+            art: {value: 0.2, color: "rgb(6,6,6)"}
         }
     };
 
     const testGetters = {
         regionIndicators: () => {
             return testRegionIndicators;
-        },
-        colorFunctions: () => {
-            return {
-                prev: jest.fn(),
-                art: jest.fn()
-            }
         }
     };
 
     const testMetadataGetters = {
-        choroplethIndicators: () => {return ["prev", "art"]; },
+        choroplethIndicators: () => {
+            return ["prev", "art"];
+        },
         choroplethIndicatorsMetadata: () => {
             return [
                 {indicator: "prev", name: "Prevalence", min: 0, max: 0.5},
@@ -93,13 +81,6 @@ describe("Choropleth component", () => {
     const testMetadataModule = {
         namespaced: true,
         getters: testMetadataGetters
-    };
-
-    const testColorFunctions = () => {
-        return {
-            prev: jest.fn(),
-            art: jest.fn()
-        }
     };
 
     function getTestStore(filteredDataProps?: Partial<FilteredDataState>) {
@@ -129,11 +110,11 @@ describe("Choropleth component", () => {
                         {
                             selectedDataType: DataType.Survey,
                             selectedChoroplethFilters: {
-                                regions: [{id: "MWI.1.1.1", label: "Test Region"}],
-                                sex: null,
-                                age: null,
-                                survey: null,
-                                quarter: null
+                                regions: ["MWI.1.1.1"],
+                                sex: "",
+                                age: "",
+                                survey: "",
+                                quarter: ""
                             },
                             ...filteredDataProps
                         }),
@@ -298,12 +279,13 @@ describe("Choropleth component", () => {
                 metadata: {
                     namespaced: true,
                     state: mockMetadataState(),
-                    getters:  {
+                    getters: {
                         choroplethIndicatorsMetadata: () => [],
                         choroplethIndicators: () => []
                     }
                 }
-        }});
+            }
+        });
         const wrapper = shallowMount(Choropleth, {store: testStore, localVue});
         const vm = wrapper.vm as any;
         const options = vm.options;
@@ -400,8 +382,10 @@ describe("Choropleth component", () => {
         const mockUpdateBounds = jest.fn();
         vm.updateBounds = mockUpdateBounds;
 
-        testStore.commit({type: "filteredData/ChoroplethFilterUpdated",
-                            payload: [FilterType.Region, [{id: "MWI.1.1.1.2", label: "test area"}]]});
+        testStore.commit({
+            type: "filteredData/ChoroplethFilterUpdated",
+            payload: [FilterType.Region, [{id: "MWI.1.1.1.2", label: "test area"}]]
+        });
 
         setTimeout(() => {
             expect(mockUpdateBounds.mock.calls.length).toBe(1);
@@ -412,11 +396,11 @@ describe("Choropleth component", () => {
     it("selectedRegionFeatures gets selected region features", () => {
         const testStore = getTestStore({
             selectedChoroplethFilters: {
-                regions: [{id: "MWI.1.1.1.1", label: "area1"}, {id: "MWI.1.1.1.2", label: "area2"}],
-                sex: null,
-                age: null,
-                survey: null,
-                quarter: null
+                regions: ["MWI.1.1.1.1", "MWI.1.1.1.2"],
+                sex: "",
+                age: "",
+                survey: "",
+                quarter: ""
             }
         });
 
@@ -431,10 +415,10 @@ describe("Choropleth component", () => {
         const testStore = getTestStore({
             selectedChoroplethFilters: {
                 regions: [],
-                sex: null,
-                age: null,
-                survey: null,
-                quarter: null
+                sex: "",
+                age: "",
+                survey: "",
+                quarter: ""
             }
         });
         const wrapper = shallowMount(Choropleth, {store: testStore, localVue});

--- a/src/app/static/src/tests/components/plots/choroplethFilter.test.ts
+++ b/src/app/static/src/tests/components/plots/choroplethFilter.test.ts
@@ -49,7 +49,7 @@ describe("ChoroplethFilters component", () => {
         ];
         const mockSelectedFilters = {
             ...initialSelectedChoroplethFilters,
-            age: {id: "a1", label: "0-4"}
+            age: "a1"
         };
 
         const mockGetters = {
@@ -69,7 +69,7 @@ describe("ChoroplethFilters component", () => {
     it("computes selected sexFilters", () => {
         const mockSelectedFilters = {
             ...initialSelectedChoroplethFilters,
-            sex: {id: "both", label: "both"}
+            sex: "both"
         };
 
         const wrapper = getWrapper({selectedChoroplethFilters: mockSelectedFilters});
@@ -85,7 +85,7 @@ describe("ChoroplethFilters component", () => {
         ];
         const mockSelectedFilters = {
             ...initialSelectedChoroplethFilters,
-            survey: {id: "s1", label: "survey 1"}
+            survey: "s1"
         };
 
         const mockState = {selectedChoroplethFilters: mockSelectedFilters};
@@ -111,7 +111,7 @@ describe("ChoroplethFilters component", () => {
         ];
         const mockSelectedFilters = {
             ...initialSelectedChoroplethFilters,
-            quarter: {id: "1", label: "Jan-Mar 2019"}
+            quarter: "1"
         };
 
         const mockState = {selectedChoroplethFilters: mockSelectedFilters};
@@ -141,7 +141,7 @@ describe("ChoroplethFilters component", () => {
             }];
         const mockSelectedFilters = {
             ...initialSelectedChoroplethFilters,
-            regions: [{id: "a2", label: "sub-region"}]
+            regions: ["a2"]
         };
         const mockGetters = {
             selectedDataFilterOptions: () => {
@@ -179,10 +179,7 @@ describe("ChoroplethFilters component", () => {
         const newFilter = "female";
         vm.selectSex(newFilter);
 
-        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Sex, {
-            id: "female",
-            label: "female"
-        }]);
+        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Sex, "female"]);
     });
 
     it("invokes store actions when survey filter is edited", () => {
@@ -209,10 +206,7 @@ describe("ChoroplethFilters component", () => {
         const newFilter = "s1";
         vm.selectSurvey(newFilter);
 
-        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Survey, {
-            id: "s1",
-            label: "survey 1"
-        }]);
+        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Survey, "s1"]);
     });
 
     it("invokes store actions when age filter is edited", () => {
@@ -238,7 +232,7 @@ describe("ChoroplethFilters component", () => {
         const newFilter = "a2";
         vm.selectAge(newFilter);
 
-        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Age, {id: "a2", label: "5-9"}]);
+        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Age, "a2"]);
     });
 
     it("invokes store actions when quarter filter is edited", () => {
@@ -265,7 +259,7 @@ describe("ChoroplethFilters component", () => {
         vm.selectQuarter(newFilter);
 
         expect(mockFilterUpdated.mock.calls[callCount][1])
-            .toStrictEqual([FilterType.Quarter, {id: "2", label: "Apr-Jun 2019"}]);
+            .toStrictEqual([FilterType.Quarter, "2"]);
     });
 
     it("invokes store actions when region filter is edited", () => {
@@ -307,10 +301,7 @@ describe("ChoroplethFilters component", () => {
 
         vm.selectRegion(["a2"]);
 
-        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Region, [{
-            id: "a2",
-            label: "area1.1"
-        }]]);
+        expect(mockFilterUpdated.mock.calls[callCount][1]).toStrictEqual([FilterType.Region, ["a2"]]);
     });
 
     it("refreshSelectedChoroplethFilters leaves selected filters unchanged if they are available for new data type", () => {
@@ -327,11 +318,11 @@ describe("ChoroplethFilters component", () => {
             {id: "2", label: "Apr-Jun 2019"}
         ];
         const mockSelectedFilters = {
-            age: {id: "a2", label: "5-9"},
-            survey: {id: "s1", label: "Survey 1"},
-            sex: {id: "female", label: "female"},
-            quarter: {id: "1", label: "Jan-Mar 2019"},
-            regions: null
+            age: "a2",
+            survey: "s1",
+            sex: "female",
+            quarter: "1",
+            regions: []
         };
         const mockFilterUpdated = jest.fn();
         const mockState = {
@@ -379,11 +370,11 @@ describe("ChoroplethFilters component", () => {
             }
         ];
         const mockSelectedFilters = {
-            age: {id: "a3", label: "10-15"},
-            survey: {id: "s1", label: "Survey 1"},
-            sex: {id: "male", label: "male"},
-            quarter: {id: "3", label: "Jul-Sep 2019"},
-            regions: null
+            age: "a3",
+            survey: "s1",
+            sex: "male",
+            quarter: "3",
+            regions: []
         };
 
 
@@ -412,9 +403,9 @@ describe("ChoroplethFilters component", () => {
         //Sex should be left unchanged as there are no available sex options for ANC
         expect(mockFilterUpdated.mock.calls.length).toBe(callCount + 2);
         expect(mockFilterUpdated.mock.calls[callCount][1])
-            .toStrictEqual([FilterType.Age, {id: "a1", label: "0-4"}]);
-        expect(mockFilterUpdated.mock.calls[callCount+1][1])
-            .toStrictEqual([FilterType.Quarter, {id: "1", label: "Jan-Mar 2019"}]);
+            .toStrictEqual([FilterType.Age, "a1"]);
+        expect(mockFilterUpdated.mock.calls[callCount + 1][1])
+            .toStrictEqual([FilterType.Quarter, "1"]);
     });
 
     const getWrapper = (state?: Partial<FilteredDataState>,

--- a/src/app/static/src/tests/filteredData/getters_regionIndicators.test.ts
+++ b/src/app/static/src/tests/filteredData/getters_regionIndicators.test.ts
@@ -4,11 +4,13 @@ import {DataType, FilteredDataState, initialFilteredDataState} from "../../app/s
 import {RootState} from "../../app/root";
 import {
     mockAncResponse,
+    mockBaselineState,
+    mockModelResultResponse,
+    mockModelRunState,
     mockProgramResponse,
-    mockSurveyAndProgramState,
-    mockSurveyResponse,
     mockRootState,
-    mockModelRunState, mockModelResultResponse
+    mockSurveyAndProgramState,
+    mockSurveyResponse
 } from "../mocks";
 import {testGetters} from "./getters.test";
 import {interpolateGreys} from "d3-scale-chromatic";
@@ -21,7 +23,7 @@ describe("FilteredData regionIndicator getter", () => {
         }
     };
 
-    function testIndicatorMetadata(indicator: string, value_column: string, indicator_column: string, indicator_value: string){
+    function testIndicatorMetadata(indicator: string, value_column: string, indicator_column: string, indicator_value: string) {
         return {
             indicator: indicator,
             value_column: value_column,
@@ -58,11 +60,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: {id: "s1", label: "Survey 1"},
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "s1",
+                    sex: "both",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -113,6 +115,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -146,11 +151,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: {id: "s1", label: "Survey 1"},
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"}, //should be ignored
-                    regions: null
+                    age: "1",
+                    survey: "s1",
+                    sex: "both",
+                    quarter: "1", //should be ignored
+                    regions: []
                 }
             },
             getters: getters
@@ -202,6 +207,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -225,11 +233,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Program,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "both",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -260,6 +268,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -284,11 +295,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Program,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: {id: "s1", label: "Survey 1"}, //Should be ignored for this data type
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "s1", //Should be ignored for this data type
+                    sex: "both",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -338,6 +349,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -359,11 +373,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: null,
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -395,6 +409,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -422,11 +439,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"}, //should be ignored
-                    survey: null,
-                    sex: {id: "male", label: "male"}, //should be ignored
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1", //should be ignored
+                    survey: "",
+                    sex: "male", //should be ignored
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -472,6 +489,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -500,11 +520,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Output,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "both",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -535,6 +555,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData as any}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
@@ -559,11 +582,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Output,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "both",
+                    quarter: "1",
+                    regions: []
                 }
             },
             getters: getters
@@ -618,11 +641,14 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData as any}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 
         const regionIndicators = getters.regionIndicators(testState, testGetters(testState), testRootState,
-                                    testRootGetters(testOutputIndicatorsMetadata));
+            testRootGetters(testOutputIndicatorsMetadata));
 
         const expected = {
             "area1": {
@@ -642,17 +668,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: {id: "s1", label: "Survey 1"},
-                    sex: {id: "both", label: "both"},
-                    quarter: {id: "1", label: "Jan - Mar  2019"},
-                    regions: [{
-                        id: "area1",
-                        label: "Area 1",
-                        children: [
-                            {id: "area2", label: "Area 2"}
-                        ]
-                    }]
+                    age: "1",
+                    survey: "s1",
+                    sex: "both",
+                    quarter: "1",
+                    regions: ["area1"]
                 }
             }
         };
@@ -712,13 +732,24 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {
+                    "area1": {
+                        id: "area1",
+                        label: "Area 1",
+                        children: [{
+                            id: "area2", label: "Area 2", children: []
+                        }]
+                    },
+                    "area2": {
+                        id: "area2", label: "Area 2", children: []
+                    }
+                }
+            }),
             filteredData: testState
         });
 
-        const testRegionGetters = testGetters(testState, {
-                "area1": {},
-                "area2": {}
-            });
+        const testRegionGetters = testGetters(testState, testRootState);
 
         const regionIndicators = getters.regionIndicators(testState, testRegionGetters, testRootState,
             testRootGetters(testSurveyIndicatorsMetadata));
@@ -742,11 +773,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: null,
-                    quarter: null,
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "",
+                    quarter: "",
+                    regions: []
                 }
             },
             getters: getters
@@ -773,11 +804,11 @@ describe("FilteredData regionIndicator getter", () => {
                 ...initialFilteredDataState,
                 selectedDataType: null,
                 selectedChoroplethFilters: {
-                    age: {id: "1", label: "0-99"},
-                    survey: null,
-                    sex: null,
-                    quarter: null,
-                    regions: null
+                    age: "1",
+                    survey: "",
+                    sex: "",
+                    quarter: "",
+                    regions: []
                 }
             },
             getters: getters
@@ -810,6 +841,9 @@ describe("FilteredData regionIndicator getter", () => {
                         {data: testData}
                     )
                 }),
+            baseline: mockBaselineState({
+                flattenedRegionFilters: {}
+            }),
             filteredData: testState
         });
 

--- a/src/app/static/src/tests/filteredData/mutations.test.ts
+++ b/src/app/static/src/tests/filteredData/mutations.test.ts
@@ -2,26 +2,11 @@ import {mutations} from "../../app/store/filteredData/mutations";
 import {
     DataType,
     FilterType,
-    initialFilteredDataState, SelectedChoroplethFilters,
-    SelectedFilters
+    initialFilteredDataState,
+    SelectedChoroplethFilters
 } from "../../app/store/filteredData/filteredData";
 
 describe("FilteredData mutations", () => {
-
-    const getSelectedFiltersByType = (selectedFilters: SelectedFilters, filterType: FilterType) => {
-        switch (filterType) {
-            case (FilterType.Age):
-                return selectedFilters.age;
-            case (FilterType.Region):
-                return selectedFilters.region;
-            case (FilterType.Sex):
-                return selectedFilters.sex;
-            case (FilterType.Survey):
-                return selectedFilters.surveys;
-            case (FilterType.Quarter):
-                return selectedFilters.quarter;
-        }
-    };
 
     const getSelectedChoroplethFilterByType = (selectedFilters: SelectedChoroplethFilters, filterType: FilterType) => {
         switch (filterType) {
@@ -42,12 +27,18 @@ describe("FilteredData mutations", () => {
         const testState = {...initialFilteredDataState};
 
         //initial sate
-        expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType)).toBeNull();
+        let expected = "" as any;
+        if (filterType == FilterType.Region){
+            expected = [];
+        }
+        expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType))
+            .toStrictEqual(expected);
 
         mutations.ChoroplethFilterUpdated(testState, {
             payload: [filterType, {id: "id", name: "name"}]
         });
-        expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType)).toStrictEqual({id: "id", name: "name"});
+        expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType))
+            .toStrictEqual({id: "id", name: "name"});
     };
 
     it("sets selectedDataType on SelectedDataTypeUpdated", () => {

--- a/src/app/static/src/tests/filteredData/utils.test.ts
+++ b/src/app/static/src/tests/filteredData/utils.test.ts
@@ -1,4 +1,10 @@
-import {colorFunctionFromName, flattenOptions, getColor, roundToContext} from "../../app/store/filteredData/utils";
+import {
+    colorFunctionFromName,
+    flattenIds,
+    flattenOptions,
+    getColor,
+    roundToContext
+} from "../../app/store/filteredData/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 import {NestedFilterOption} from "../../app/generated";
 
@@ -91,5 +97,44 @@ describe("FilteredData getters", () => {
         const result = flattenOptions(testData);
         expect(result["1"]).toStrictEqual(testData[0]);
         expect(result["2"]).toStrictEqual({id: "2", label: "nested", children: []});
+    });
+
+    it("flatten ids returns set of selected ids", () => {
+
+        const dict = {
+            "1": {
+                id: "1",
+                label: "l1",
+                children:
+                    [{
+                        id: "2",
+                        label: "l2",
+                        children: [{
+                            id: "3",
+                            label: "l3"
+                        }]
+                    }]
+            },
+            "2": {
+                id: "2",
+                label: "l2",
+                children: [{
+                    id: "3",
+                    label: "l3"
+                }]
+            },
+            "3": {
+                id: "3",
+                label: "l3"
+            },
+            "4": {
+                id: "3",
+                label: "l3"
+            }
+        };
+
+
+        const result = flattenIds(["1"], dict);
+        expect(result).toStrictEqual(new Set(["1", "2", "3"]));
     });
 });

--- a/src/app/static/src/tests/filteredData/utils.test.ts
+++ b/src/app/static/src/tests/filteredData/utils.test.ts
@@ -1,6 +1,6 @@
 import {
     colorFunctionFromName,
-    flattenIds,
+    getIdsAndChildrenIds,
     flattenOptions,
     getColor,
     roundToContext
@@ -134,7 +134,7 @@ describe("FilteredData getters", () => {
         };
 
 
-        const result = flattenIds(["1"], dict);
+        const result = getIdsAndChildrenIds(["1"], dict);
         expect(result).toStrictEqual(new Set(["1", "2", "3"]));
     });
 });

--- a/src/app/static/src/tests/filteredData/utils.test.ts
+++ b/src/app/static/src/tests/filteredData/utils.test.ts
@@ -1,5 +1,6 @@
-import {colorFunctionFromName, getColor, roundToContext} from "../../app/store/filteredData/utils";
+import {colorFunctionFromName, flattenOptions, getColor, roundToContext} from "../../app/store/filteredData/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
+import {NestedFilterOption} from "../../app/generated";
 
 
 describe("FilteredData getters", () => {
@@ -75,5 +76,20 @@ describe("FilteredData getters", () => {
 
     it ("round to context does not round value if both values and context are integers", () => {
         expect(roundToContext(5, 10)).toBe(5);
+    });
+
+    it("can flatten options", () => {
+
+        const testData: NestedFilterOption[] = [
+            {
+                id: "1", label: "name1", children: [{
+                    id: "2", label: "nested", children: []
+                }]
+            }
+        ];
+
+        const result = flattenOptions(testData);
+        expect(result["1"]).toStrictEqual(testData[0]);
+        expect(result["2"]).toStrictEqual({id: "2", label: "nested", children: []});
     });
 });

--- a/src/app/static/src/tests/filteredData/utils.test.ts
+++ b/src/app/static/src/tests/filteredData/utils.test.ts
@@ -1,6 +1,6 @@
 import {
     colorFunctionFromName,
-    getIdsAndChildrenIds,
+    flattenToIdSet,
     flattenOptions,
     getColor,
     roundToContext
@@ -134,7 +134,7 @@ describe("FilteredData getters", () => {
         };
 
 
-        const result = getIdsAndChildrenIds(["1"], dict);
+        const result = flattenToIdSet(["1"], dict);
         expect(result).toStrictEqual(new Set(["1", "2", "3"]));
     });
 });

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -154,7 +154,7 @@ export const mockShapeResponse = (props: Partial<ShapeResponse> = {}): ShapeResp
         filename: "test.csv",
         filters: {
             level_labels: [{id: 1, area_level_label: "Country", display: true}],
-            regions: {name: "Malawi", id: 1, options : []} as any
+            regions: {label: "Malawi", id: "1", children : []}
         },
         ...props
     }

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -4,8 +4,14 @@ import {ModelStatusResponse} from "../../app/generated";
 
 describe("Model run actions", () => {
 
-    afterEach(() => {
+    beforeEach(() => {
+        // stop apiService logging to console
+        console.log = jest.fn();
         mockAxios.reset();
+    });
+
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
     });
 
     it("commits run id after triggering a model run ", async () => {

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -7,6 +7,16 @@ const FormData = require("form-data");
 
 describe("Survey and programme actions", () => {
 
+    beforeEach(() => {
+        // stop apiService logging to console
+        console.log = jest.fn();
+        mockAxios.reset();
+    });
+
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
+    });
+
     it("sets data after surveys file upload", async () => {
 
         mockAxios.onPost(`/disease/survey/`)

--- a/src/app/static/src/tests/utils.test.ts
+++ b/src/app/static/src/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import {addCheckSum, verifyCheckSum} from "../app/utils";
+import {addCheckSum, freezer, verifyCheckSum} from "../app/utils";
 
 describe("utils", () => {
 
@@ -27,6 +27,28 @@ describe("utils", () => {
 
         const result = verifyCheckSum(corruptedContent);
         expect(result).toBe(false);
+    });
+
+    it("deep freezes an object", () => {
+
+        const data = {
+            nothing: null,
+            time: 10,
+            name: "hello",
+            items: [1, null, "three", {label: "l1"}],
+            child: {
+                name: "child",
+                items: [4, null, "five"]
+            }
+        };
+
+        const frozen = freezer.deepFreeze({...data});
+        expect(frozen).toStrictEqual(data);
+        expect(Object.isFrozen(frozen)).toBe(true);
+        expect(Object.isFrozen(frozen.items)).toBe(true);
+        expect(Object.isFrozen(frozen.child)).toBe(true);
+        expect(Object.isFrozen(frozen.child.items)).toBe(true);
+
     });
 
 });

--- a/src/app/static/src/tests/utils.test.ts
+++ b/src/app/static/src/tests/utils.test.ts
@@ -48,7 +48,16 @@ describe("utils", () => {
         expect(Object.isFrozen(frozen.items)).toBe(true);
         expect(Object.isFrozen(frozen.child)).toBe(true);
         expect(Object.isFrozen(frozen.child.items)).toBe(true);
+    });
 
+    it("deep freezes an array", () => {
+
+        const data = [{id: 1}, {child: {id: 2}}, 1, "hi"];
+
+        const frozen = freezer.deepFreeze([...data]);
+        expect(frozen).toStrictEqual(data);
+        expect(Object.isFrozen(frozen[0])).toBe(true);
+        expect(Object.isFrozen(frozen[1].child)).toBe(true);
     });
 
 });


### PR DESCRIPTION
First PR:

* freezes big objects coming from the API
* moves region options and flattened region options into the state

Also less importantly but makes some minor difference:
* storing selected filters as simple strings or arrays of strings, so we just pass around ids rather than large nested  objects

General principles at work here:
- making large immutable objects immutable so vue doesn't bloat them out by making everything observable
- not using computed properties for things that are not actually dynamic, i.e. will not be re-computed, as computeds have performance overhead associated with them


