### PR TITLE
mrc-650 Use iso3 to fetch plotting metadata instead of country name

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
@@ -13,7 +13,7 @@ interface APIClient {
     fun submit(data: Map<String, String>, options: Map<String, Any>): ResponseEntity<String>
     fun getStatus(id: String): ResponseEntity<String>
     fun getResult(id: String): ResponseEntity<String>
-    fun getPlottingMetadata(country: String): ResponseEntity<String>
+    fun getPlottingMetadata(iso3: String): ResponseEntity<String>
 }
 
 @Component
@@ -85,8 +85,8 @@ class HintrAPIClient(
                 .asResponseEntity()
     }
 
-    override fun getPlottingMetadata(country: String): ResponseEntity<String> {
-        return "$baseUrl/meta/plotting/${country}"
+    override fun getPlottingMetadata(iso3: String): ResponseEntity<String> {
+        return "$baseUrl/meta/plotting/${iso3}"
                 .httpGet()
                 .response()
                 .second

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/meta")
 class MetadataController(val apiClient: APIClient) {
 
-    @GetMapping("/plotting/{country}")
+    @GetMapping("/plotting/{iso3}")
     @ResponseBody
-    fun plotting(@PathVariable("country") country: String): ResponseEntity<String> {
-        return apiClient.getPlottingMetadata(country);
+    fun plotting(@PathVariable("iso3") iso3: String): ResponseEntity<String> {
+        return apiClient.getPlottingMetadata(iso3);
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintrAPIClientTests.kt
@@ -65,7 +65,7 @@ class HintrApiClientTests {
     @Test
     fun `can get plotting metadata`() {
         val sut = HintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val metadataResult = sut.getPlottingMetadata("Malawi");
+        val metadataResult = sut.getPlottingMetadata("MWI");
 
         JSONValidator().validateSuccess(metadataResult.body!!, "PlottingMetadataResponse")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/MetadataControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/MetadataControllerTests.kt
@@ -13,11 +13,11 @@ class MetadataControllerTests {
     fun `gets plotting metadata`() {
         val mockResponse = mock<ResponseEntity<String>>()
         val mockAPIClient = mock<APIClient>{
-            on {getPlottingMetadata("Malawi")} doReturn mockResponse
+            on {getPlottingMetadata("MWI")} doReturn mockResponse
         }
 
         val sut = MetadataController(mockAPIClient)
-        val result = sut.plotting("Malawi")
+        val result = sut.plotting("MWI")
         assertThat(result).isSameAs(mockResponse)
     }
 }

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -206,6 +206,7 @@ export interface NestedFilterOption {
 }
 export interface PjnzResponseData {
   country: string;
+  iso3: string;
 }
 export type ChoroplethMetadata = {
   indicator: string;
@@ -333,6 +334,7 @@ export interface PjnzResponse {
   type: "pjnz";
   data: {
     country: string;
+    iso3: string;
   };
   filters?: null;
 }

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -23,7 +23,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             .withError("PJNZUploadError")
             .postAndReturn<PjnzResponse>("/baseline/pjnz/", formData)
             .then(() => {
-                dispatch('metadata/getPlottingMetadata', state.country, {root: true});
+                dispatch('metadata/getPlottingMetadata', state.iso3, {root: true});
             });
     },
 

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -8,6 +8,7 @@ import {Dict} from "../../types";
 export interface BaselineState extends ReadyState {
     pjnzError: string
     country: string
+    iso3: string
     pjnz: PjnzResponse | null
     shape: ShapeResponse | null
     regionFilters: NestedFilterOption[]
@@ -19,6 +20,7 @@ export interface BaselineState extends ReadyState {
 
 export const initialBaselineState: BaselineState = {
     country: "",
+    iso3: "",
     pjnzError: "",
     pjnz: null,
     shape: null,
@@ -32,7 +34,7 @@ export const initialBaselineState: BaselineState = {
 
 export const baselineGetters = {
   complete: (state: BaselineState) => {
-      return !!state.country && !!state.shape && !!state.population
+      return !!state.country && !!state.iso3 && !!state.shape && !!state.population
   }
 };
 

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -27,9 +27,11 @@ export const mutations: MutationTree<BaselineState> & BaselineMutations = {
         const data = action.payload;
         if (data) {
             state.country = data.data.country;
+            state.iso3 = data.data.iso3;
             state.pjnz = data;
         } else {
             state.country = "";
+            state.iso3 = "";
             state.pjnz = null;
         }
         state.pjnzError = "";

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -12,10 +12,10 @@ export interface MetadataActions {
 
 export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
 
-    async getPlottingMetadata({commit}, country) {
+    async getPlottingMetadata({commit}, iso3) {
         await api<MetadataActionTypes, MetadataErrorActionTypes>(commit)
             .withSuccess("PlottingMetadataFetched")
             .withError("PlottingMetadataError")
-            .get(`/meta/plotting/${country}`);
+            .get(`/meta/plotting/${iso3}`);
     }
 };

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -16,18 +16,22 @@ describe("Baseline actions", () => {
         (console.log as jest.Mock).mockClear();
     });
 
-    it("sets country after PJNZ file upload", async () => {
+    it("sets country and iso3 after PJNZ file upload, and fetches plotting metadata", async () => {
 
         mockAxios.onPost(`/baseline/pjnz/`)
-            .reply(200, mockSuccess({data: {country: "Malawi"}}));
+            .reply(200, mockSuccess({data: {country: "Malawi", iso3: "MWI"}}));
 
         const commit = jest.fn();
-        const state = mockBaselineState();
+        const state = mockBaselineState({iso3: "MWI"});
         const dispatch = jest.fn();
         await actions.uploadPJNZ({commit, state, dispatch} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "PJNZUpdated", payload: null});
-        expect(commit.mock.calls[1][0]).toStrictEqual({type: "PJNZUpdated", payload: {data: {country: "Malawi"}}});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: "PJNZUpdated", payload: {data: {country: "Malawi", iso3: "MWI"}}});
+
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getPlottingMetadata");
+        expect(dispatch.mock.calls[0][1]).toBe("MWI");
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
     });
 
     testUploadErrorCommitted("/baseline/pjnz/", "PJNZUploadError", "PJNZUpdated", actions.uploadPJNZ);

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -57,6 +57,16 @@ describe("Baseline mutations", () => {
         expect(testState.pjnzError).toBe("Some error");
     });
 
+    it("sets country and filename and clears error if present on PJNZUpdated", () => {
+        const testState = {...initialBaselineState, pjnzError: "test"};
+        mutations.PJNZUpdated(testState, {
+            payload: mockPJNZResponse({filename: "file.pjnz", data: {country: "Malawi", iso3: "MWI"}})
+        });
+        expect(testState.pjnz!!.filename).toBe("file.pjnz");
+        expect(testState.country).toBe("Malawi");
+        expect(testState.pjnzError).toBe("");
+    });
+
     it("clears country and filename on PJNZUpdated if no data present", () => {
 
         const testState = {...initialBaselineState, pjnzError: "", country: "test", pjnz: "TEST" as any};

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -10,9 +10,10 @@ describe("Baseline mutations", () => {
 
         const testState = {...initialBaselineState};
         mutations.PJNZUpdated(testState, {
-            payload: mockPJNZResponse({data: {country: "Malawi"}, filename: "file.pjnz"})
+            payload: mockPJNZResponse({data: {country: "Malawi", iso3: "MWI"}, filename: "file.pjnz"})
         });
         expect(testState.country).toBe("Malawi");
+        expect(testState.iso3).toBe("MWI");
         expect(testState.pjnz!!.filename).toBe("file.pjnz");
         expect(testState.pjnzError).toBe("");
     });
@@ -28,7 +29,7 @@ describe("Baseline mutations", () => {
 
         mutations.PJNZUpdated(testState, {
             payload:
-                mockPJNZResponse({data: {country: "Malawi"}}), type: "PJNZUpdated"
+                mockPJNZResponse({data: {country: "Malawi", iso3: "MWI"}}), type: "PJNZUpdated"
         });
 
         expect(complete(testState, null, testRootState, null)).toBe(false);
@@ -56,23 +57,13 @@ describe("Baseline mutations", () => {
         expect(testState.pjnzError).toBe("Some error");
     });
 
-    it("sets country and filename and clears error if present on PJNZUpdated", () => {
-
-        const testState = {...initialBaselineState, pjnzError: "test"};
-        mutations.PJNZUpdated(testState, {
-            payload: mockPJNZResponse({filename: "file.pjnz", data: {country: "Malawi"}})
-        });
-        expect(testState.pjnz!!.filename).toBe("file.pjnz");
-        expect(testState.country).toBe("Malawi");
-        expect(testState.pjnzError).toBe("");
-    });
-
     it("clears country and filename on PJNZUpdated if no data present", () => {
 
         const testState = {...initialBaselineState, pjnzError: "", country: "test", pjnz: "TEST" as any};
         mutations.PJNZUpdated(testState, {payload: null});
         expect(testState.pjnz).toBe(null);
         expect(testState.country).toBe("");
+        expect(testState.iso3).toBe("");
         expect(testState.pjnzError).toBe("");
     });
 

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -173,6 +173,7 @@ describe("Stepper component", () => {
     it("upload surveys step is enabled when baseline step is complete", () => {
         const store = createSut({
                 country: "testCountry",
+                iso3: "TTT",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse(),
                 ready: true
@@ -209,6 +210,7 @@ describe("Stepper component", () => {
     it("updates active step when jump event is emitted", () => {
         const store = createSut({
                 country: "testCountry",
+                iso3: "TTT",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse(),
                 ready: true
@@ -238,6 +240,7 @@ describe("Stepper component", () => {
     it("can continue when the active step is complete", () => {
         const store = createSut({
                 country: "testCountry",
+                iso3: "TTT",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse(),
                 ready: true
@@ -255,7 +258,7 @@ describe("Stepper component", () => {
     });
 
     it("updates from completed state when active step data is populated", (done) => {
-        const baselineState = {country: "Malawi", population: mockPopulationResponse(), ready: true};
+        const baselineState = {country: "Malawi", iso3: "MWI", population: mockPopulationResponse(), ready: true};
         const store = createSut(baselineState,
             {ready: true},
             {plottingMetadata: "TEST DATA" as any},
@@ -281,6 +284,7 @@ describe("Stepper component", () => {
         const store = createSut({
             ready: true,
             country: "Malawi",
+            iso3: "MWI",
             shape: mockShapeResponse(),
             population: mockPopulationResponse()
         }, {}, {plottingMetadata: mockPlottingMetadataResponse()}, {ready: true}, {activeStep: 2});
@@ -299,6 +303,7 @@ describe("Stepper component", () => {
         const store = createSut({
                 ready: true,
                 country: "Malawi",
+                iso3: "MWI",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse()
             }, {}, {
@@ -319,6 +324,7 @@ describe("Stepper component", () => {
         const store = createSut({
                 ready: true,
                 country: "Malawi",
+                iso3: "MWI",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse()
             },
@@ -339,6 +345,7 @@ describe("Stepper component", () => {
         const store = createSut({
                 ready: true,
                 country: "Malawi",
+                iso3: "MWI",
                 shape: mockShapeResponse(),
                 population: mockPopulationResponse()
             },

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -135,7 +135,7 @@ export const mockFailure = (errorMessage: string): Response => {
 
 export const mockPJNZResponse = (props: Partial<PjnzResponse> = {}): PjnzResponse => {
     return {
-        data: {country: "Malawi"},
+        data: {country: "Malawi", iso3: "MWI"},
         hash: "1234.csv",
         filename: "test.pjnz",
         type: "pjnz",


### PR DESCRIPTION
Front end changes to get iso3 as well as country name from PJNZ response and send that to the plotting metadata endpoint. 

The backend behaviour hasn't changed, but I renamed country to iso3 so as not to be misleading. 