### PR TITLE
mrc-653 Use barchart metadata types generated from hintr. 

### DIFF
--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -31,11 +31,9 @@
     import ChoroplethFilters from "../plots/ChoroplethFilters.vue";
     import Barchart from "../plots/barchart/Barchart.vue";
     import {DataType} from "../../store/filteredData/filteredData";
-    import {mapActionsByNames, mapGettersByNames, mapStateProp, mapStatePropByName} from "../../utils";
-    import {BarchartIndicator, Filter} from "../../types";
-    import {BaselineState} from "../../store/baseline/baseline";
+    import {mapActionsByNames, mapGettersByNames, mapStateProp} from "../../utils";
     import {ModelRunState} from "../../store/modelRun/modelRun";
-    import {ModelResultResponse} from "../../generated";
+    import {BarchartIndicator, Filter} from "../../generated";
 
     const namespace: string = 'filteredData';
 

--- a/src/app/static/src/app/components/plots/barchart/Barchart.vue
+++ b/src/app/static/src/app/components/plots/barchart/Barchart.vue
@@ -47,8 +47,8 @@
     import Treeselect from '@riophae/vue-treeselect';
     import ChartjsBar from "./chartjsBar.vue";
     import FilterSelect from "./FilterSelect.vue";
-    import {BarchartIndicator, Dict, Filter} from "../../../types";
-    import {FilterOption} from "../../../generated";
+    import {Dict} from "../../../types";
+    import {BarchartIndicator, Filter, FilterOption} from "../../../generated";
     import {getProcessedOutputData, toFilterLabelLookup} from "./utils";
 
     interface Props {

--- a/src/app/static/src/app/components/plots/barchart/utils.ts
+++ b/src/app/static/src/app/components/plots/barchart/utils.ts
@@ -1,5 +1,5 @@
-import {BarchartIndicator, Dict, Filter} from "../../../types";
-import {FilterOption} from "../../../generated";
+import {Dict} from "../../../types";
+import {BarchartIndicator, Filter, FilterOption} from "../../../generated";
 
 export const toFilterLabelLookup = (array: Filter[]) => array.reduce((obj, current) => {
     obj[current.id] = current.label;

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -28,6 +28,39 @@ export type AncResponseData = {
   art_coverage?: number;
   [k: string]: any;
 }[];
+export interface BarchartIndicator {
+  indicator: string;
+  value_column: string;
+  indicator_column: string;
+  indicator_value: string;
+  name: string;
+  error_low_column: string;
+  error_high_column: string;
+  [k: string]: any;
+}
+export interface BarchartMetadata {
+  indicators: {
+    indicator: string;
+    value_column: string;
+    indicator_column: string;
+    indicator_value: string;
+    name: string;
+    error_low_column: string;
+    error_high_column: string;
+    [k: string]: any;
+  }[];
+  filters: {
+    id: string;
+    column_id: string;
+    label: string;
+    options: {
+      label: string;
+      id: string;
+    }[];
+    [k: string]: any;
+  }[];
+  [k: string]: any;
+}
 export interface Data {
   placeholder?: boolean;
 }
@@ -38,6 +71,16 @@ export interface Error {
 }
 export type FileName = string;
 export type FilePath = string | null;
+export interface Filter {
+  id: string;
+  column_id: string;
+  label: string;
+  options: {
+    label: string;
+    id: string;
+  }[];
+  [k: string]: any;
+}
 export interface FilterOption {
   label: string;
   id: string;
@@ -206,6 +249,7 @@ export interface NestedFilterOption {
 }
 export interface PjnzResponseData {
   country: string;
+  iso3: string;
 }
 export type ChoroplethMetadata = {
   indicator: string;
@@ -333,6 +377,7 @@ export interface PjnzResponse {
   type: "pjnz";
   data: {
     country: string;
+    iso3: string;
   };
   filters?: null;
 }

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -1,6 +1,6 @@
 import {Module} from "vuex";
 import {RootState} from "../../root";
-import {BarchartIndicator, Filter} from "../../types";
+import {BarchartIndicator, Filter} from "../../generated";
 import {FilterOption} from "../../generated";
 
 const namespaced: boolean = true;

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -29,20 +29,3 @@ export interface LocalSessionFile {
     hash: string
     filename: string
 }
-
-export interface BarchartIndicator {
-    indicator: string,
-    value_column: string,
-    indicator_column: string,
-    indicator_value: string,
-    name: string,
-    error_low_column: string,
-    error_high_column: string
-}
-
-export interface Filter {
-    id: string,
-    column_id: string,
-    label: string,
-    options: FilterOption[]
-}


### PR DESCRIPTION
This just changes hint to use BarchartIndicator and Filter classes as defined in hintr (https://github.com/mrc-ide/hintr/pull/58) rather than defining them itself. Barchart Metadata still not actually coming from hintr yet. 