### PR TITLE
mrc-696 remove springboot context from cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
       - ./src/gradlew -p src app::test
       - ./src/gradlew -p src userCLI::test
       - ./src/gradlew -p src app::jacocoTestReport
+      - ./src/gradlew -p src userCLI::jacocoTestReport
       - codecov -f src/app/coverage/test/*.xml
       - codecov -f src/userCLI/coverage/test/*.xml
       - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       - ./src/gradlew -p src userCLI::test
       - ./src/gradlew -p src app::jacocoTestReport
       - codecov -f src/app/coverage/test/*.xml
+      - codecov -f src/userCLI/coverage/test/*.xml
       - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - ./src/userCLI/scripts/build
       - ./src/userCLI/scripts/push

--- a/scripts/add-test-user.sh
+++ b/scripts/add-test-user.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 NETWORK=hint_nw
 
-image=mrcide/hint-user-cli:mrc-414 #TODO: change to master when merged
+image=mrcide/hint-user-cli:master
 docker pull $image
-docker run --network=hint_nw $image add-user test.user@example.com password
+docker run -e db_url="jdbc:postgresql://db/hint" --network=hint_nw $image add-user test.user@example.com password

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -3,4 +3,4 @@ NETWORK=hint_nw
 
 git_id=$(git rev-parse --short=7 HEAD)
 image=mrcide/hint-user-cli:${git_id}
-docker run --network=$NETWORK $image "$@"
+docker run -e db_url="jdbc:postgresql://db/hint" --network=$NETWORK $image "$@"

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -6,18 +6,6 @@ apply plugin: 'application'
 
 mainClassName = "org.imperial.mrc.hint.AppStartKt"
 
-jacoco {
-	toolVersion = "0.8.3"
-	reportsDir = file("$projectDir/coverage")
-}
-
-jacocoTestReport {
-	reports {
-		xml.enabled = true
-		csv.enabled = false
-	}
-}
-
 group = 'org.imperial.mrc'
 sourceCompatibility = '1.8'
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/DbConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/DbConfig.kt
@@ -18,4 +18,13 @@ class DbConfig {
         dataSourceBuilder.password(appProperties.dbPassword)
         return dataSourceBuilder.build()
     }
+
+    fun dataSource(url: String, user: String, password: String): DataSource {
+        val dataSourceBuilder = DataSourceBuilder.create()
+        dataSourceBuilder.driverClassName("org.postgresql.Driver")
+        dataSourceBuilder.url(url)
+        dataSourceBuilder.username(user)
+        dataSourceBuilder.password(password)
+        return dataSourceBuilder.build()
+    }
 }

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -23,6 +23,7 @@ jacocoTestReport {
         xml.enabled = true
         csv.enabled = false
     }
+}
 
 dependencies {
     implementation project(":app")

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -13,18 +13,6 @@ apply plugin: 'application'
 apply plugin: 'docker'
 mainClassName = "org.imperial.mrc.hint.userCLI.AppKt"
 
-jacoco {
-    toolVersion = "0.8.3"
-    reportsDir = file("$projectDir/coverage")
-}
-
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        csv.enabled = false
-    }
-}
-
 dependencies {
     implementation project(":app")
     implementation "com.offbytwo:docopt:0.6.0.20150202"

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -13,6 +13,17 @@ apply plugin: 'application'
 apply plugin: 'docker'
 mainClassName = "org.imperial.mrc.hint.userCLI.AppKt"
 
+jacoco {
+    toolVersion = "0.8.3"
+    reportsDir = file("$projectDir/coverage")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        csv.enabled = false
+    }
+
 dependencies {
     implementation project(":app")
     implementation "com.offbytwo:docopt:0.6.0.20150202"

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -17,12 +17,9 @@ dependencies {
     implementation project(":app")
     implementation "com.offbytwo:docopt:0.6.0.20150202"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude module: 'junit'
-    }
-    implementation 'org.springframework:spring-tx:5.1.8.RELEASE'
     implementation "org.pac4j:pac4j-core:3.7.0"
     implementation "org.slf4j:slf4j-nop:1.7.26"
+    implementation 'org.pac4j:pac4j-sql:3.3.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation "org.assertj:assertj-core:3.6.2"

--- a/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
+++ b/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
@@ -3,8 +3,8 @@ package org.imperial.mrc.hint.userCLI
 import org.docopt.Docopt
 import org.imperial.mrc.hint.db.DbConfig
 import org.imperial.mrc.hint.db.DbProfileServiceUserRepository
+import org.imperial.mrc.hint.security.HintDbProfileService
 import org.imperial.mrc.hint.security.SecurePasswordEncoder
-import org.pac4j.sql.profile.service.DbProfileService
 import javax.sql.DataSource
 import kotlin.system.exitProcess
 
@@ -45,7 +45,7 @@ fun main(args: Array<String>) {
 
 class UserCLI(dataSource: DataSource) {
 
-    private val profileService = DbProfileService(dataSource, SecurePasswordEncoder())
+    private val profileService = HintDbProfileService(dataSource, SecurePasswordEncoder())
     private val userRepository = DbProfileServiceUserRepository(profileService)
 
     fun addUser(options: Map<String, Any>): String {

--- a/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/DatabaseProperties.kt
+++ b/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/DatabaseProperties.kt
@@ -1,0 +1,33 @@
+package org.imperial.mrc.hint.userCLI
+
+import org.imperial.mrc.hint.HintProperties
+import org.imperial.mrc.hint.getResource
+
+open class Environment {
+    open fun get(name: String): String? {
+        return System.getenv(name)
+    }
+}
+
+class DatabaseProperties(private val environment: Environment = Environment()) {
+
+    private val properties = HintProperties().apply {
+        load(getResource("config.properties").openStream())
+    }
+
+    private fun fromEnvOrDefault(propName: String): String {
+        return environment.get(propName) ?: properties[propName].toString()
+    }
+
+    val user: String get() {
+        return fromEnvOrDefault("db_user")
+    }
+
+    val password: String get() {
+        return fromEnvOrDefault("db_password")
+    }
+
+    val url: String get() {
+        return fromEnvOrDefault("db_url")
+    }
+}

--- a/src/userCLI/src/main/resources/application-test.properties
+++ b/src/userCLI/src/main/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.datasource.jdbc-url=jdbc:postgresql://localhost/hint
-spring.datasource.auto-commit=false

--- a/src/userCLI/src/main/resources/application.properties
+++ b/src/userCLI/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-spring.datasource.jdbc-url=jdbc:postgresql://db/hint
-spring.datasource.username=hintuser
-spring.datasource.password=changeme
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-logging.level.root=ERROR

--- a/src/userCLI/src/main/resources/config.properties
+++ b/src/userCLI/src/main/resources/config.properties
@@ -1,0 +1,3 @@
+db_user=hintuser
+db_password=changeme
+db_url=jdbc:postgresql://localhost/hint

--- a/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
+++ b/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
@@ -1,43 +1,49 @@
 package org.imperial.mrc.hint.userCLI
 
-import org.imperial.mrc.hint.exceptions.UserException
 import org.assertj.core.api.Assertions
+import org.imperial.mrc.hint.db.DbConfig
+import org.imperial.mrc.hint.exceptions.UserException
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationContext
 
 //The hint db container must be running to run these tests
-@ActiveProfiles(profiles=["test"])
-@SpringBootTest
-@ExtendWith(SpringExtension::class)
-@Transactional
-class AppTests
-{
+class AppTests {
+
     companion object {
         const val TEST_EMAIL = "test@test.com"
+
+        val props = DatabaseProperties()
+        val dataSource = DbConfig().dataSource(props.url, props.user, props.password)
+        val sut = UserCLI(dataSource)
+
+        @AfterAll
+        @JvmStatic
+        fun cleanup() {
+            dataSource.connection.close()
+        }
     }
 
-    @Autowired
-    private lateinit var context: ApplicationContext
+    @BeforeEach
+    fun `remove user if exists`() {
+        try {
+            sut.removeUser(mapOf("<email>" to TEST_EMAIL))
+        }
+        catch (e: Exception) {
+
+        }
+    }
 
     @Test
-    fun `can add user`()
-    {
-        val sut = UserCLI(context)
+    fun `can add user`() {
         sut.addUser(mapOf("<email>" to TEST_EMAIL, "<password>" to "testpassword"))
 
         Assertions.assertThat(sut.userExists(mapOf("<email>" to TEST_EMAIL))).isEqualTo("true")
     }
 
     @Test
-    fun `can remove user`()
-    {
-        val sut = UserCLI(context)
+    fun `can remove user`() {
+        val sut = UserCLI(dataSource)
         sut.addUser(mapOf("<email>" to TEST_EMAIL, "<password>" to "testpassword"))
 
         sut.removeUser(mapOf("<email>" to TEST_EMAIL))
@@ -45,9 +51,8 @@ class AppTests
     }
 
     @Test
-    fun `cannot add same user twice`()
-    {
-        val sut = UserCLI(context)
+    fun `cannot add same user twice`() {
+        val sut = UserCLI(dataSource)
         sut.addUser(mapOf("<email>" to TEST_EMAIL, "<password>" to "testpassword"))
 
         Assertions.assertThatThrownBy { sut.addUser(mapOf("<email>" to TEST_EMAIL, "<password>" to "testpassword")) }
@@ -57,10 +62,8 @@ class AppTests
     }
 
     @Test
-    fun `cannot remove nonexistent user`()
-    {
-        val sut = UserCLI(context)
-        Assertions.assertThatThrownBy{ sut.removeUser(mapOf("<email>" to "notaperson.@email.com")) }
+    fun `cannot remove nonexistent user`() {
+        Assertions.assertThatThrownBy { sut.removeUser(mapOf("<email>" to "notaperson.@email.com")) }
                 .isInstanceOf(UserException::class.java)
                 .hasMessageContaining("User does not exist")
 

--- a/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/DatabasePropertiesTests.kt
+++ b/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/DatabasePropertiesTests.kt
@@ -1,0 +1,25 @@
+package org.imperial.mrc.hint.userCLI
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class DatabasePropertiesTests {
+
+    @Test
+    fun `can get prop from env var`() {
+        val mockEnvironment = mock<Environment> {
+            on { get("db_user") } doReturn ("test_user")
+        }
+        val user = DatabaseProperties(mockEnvironment).user
+
+        assertThat(user).isEqualTo("test_user")
+    }
+
+    @Test
+    fun `falls back to config if env var is missing`() {
+        val user = DatabaseProperties().user
+        assertThat(user).isEqualTo("hintuser")
+    }
+}


### PR DESCRIPTION
2 motivations for these changes:
1. It has been pointed out that the cli is really slow, which will be tedious when adding many real users. This is because it's booting up the whole app, which is slow to start up.
2. To get production db password into the cli would currently have to mount something at `/etc/hint/config` (as we do in Montagu). Passing extra bit of config as environment variables is more lightweight.