### PR TITLE
mrc-575 add util for updating form and update multiselect

### DIFF
--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -74,8 +74,8 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     };
 
     withSuccess = (type: S) => {
-        this._onSuccess = (success: Response) => {
-            this._commit({type: type, payload: freezer.deepFreeze(success.data)});
+        this._onSuccess = (data: any) => {
+            this._commit({type: type, payload: freezer.deepFreeze(data)});
         };
         return this;
     };
@@ -83,10 +83,11 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private _handleAxiosResponse(promise: Promise<AxiosResponse>) {
         return promise.then((response: AxiosResponse) => {
             const success = response && response.data;
+            const data = success.data;
             if (this._onSuccess) {
-                this._onSuccess(success);
+                this._onSuccess(data);
             }
-            return success;
+            return data;
         }).catch((e: AxiosError) => {
             return this._handleError(e)
         });

--- a/src/app/static/src/app/components/forms/DynamicForm.vue
+++ b/src/app/static/src/app/components/forms/DynamicForm.vue
@@ -20,7 +20,7 @@
     import {BForm} from "bootstrap-vue";
     import DynamicFormControlGroup from "./DynamicFormControlGroup.vue";
     import DynamicFormControlSection from "./DynamicFormControlSection.vue";
-    import {Control, DynamicControl, DynamicControlSection, DynamicFormData, DynamicFormMeta, formMeta} from "./types";
+    import {Control, DynamicControl, DynamicControlSection, DynamicFormData, DynamicFormMeta} from "./types";
 
     interface Props {
         formMeta: DynamicFormMeta,

--- a/src/app/static/src/app/components/forms/DynamicFormMultiSelect.vue
+++ b/src/app/static/src/app/components/forms/DynamicFormMultiSelect.vue
@@ -35,7 +35,13 @@
         computed: {
             value: {
                 get() {
-                    return this.formControl.value ? this.formControl.value as string[] : []
+                    if (Array.isArray(this.formControl.value)) {
+                        return this.formControl.value
+                    }
+                    if (typeof this.formControl.value == "string") {
+                        return [this.formControl.value]
+                    }
+                    return []
                 },
                 set(newVal: string[]) {
                     this.$emit("change", {...this.formControl, value: newVal});

--- a/src/app/static/src/app/components/forms/types.ts
+++ b/src/app/static/src/app/components/forms/types.ts
@@ -1,4 +1,3 @@
-
 import {Dict} from "../../types";
 
 export type DynamicControlSection = {

--- a/src/app/static/src/app/components/forms/types.ts
+++ b/src/app/static/src/app/components/forms/types.ts
@@ -1,3 +1,4 @@
+
 import {Dict} from "../../types";
 
 export type DynamicControlSection = {
@@ -36,7 +37,7 @@ export type SelectControl = DynamicControl & {
 
 export type MultiSelectControl = DynamicControl & {
     options: Option[]
-    value?: string[]
+    value?: string[] | string
 }
 
 export type NumberControl = DynamicControl & {

--- a/src/app/static/src/app/store/modelOptions/utils.ts
+++ b/src/app/static/src/app/store/modelOptions/utils.ts
@@ -1,0 +1,45 @@
+import {DynamicControlGroup, DynamicControlSection, DynamicFormMeta} from "../../components/forms/types";
+
+export const updateForm = (oldForm: DynamicFormMeta, newForm: DynamicFormMeta): DynamicFormMeta => {
+    const oldSectionLabels = oldForm.controlSections.map(c => c.label);
+
+    newForm.controlSections.map(s => {
+        const oldIndex = oldSectionLabels.indexOf(s.label);
+        if (oldIndex == -1) {
+            return s
+        } else {
+            return updateSection(oldForm.controlSections[oldIndex], s)
+        }
+    });
+
+    return newForm
+};
+
+function updateSection(oldSection: DynamicControlSection, newSection: DynamicControlSection) {
+
+    const oldGroupLabels = oldSection.controlGroups.map(g => g.label);
+    newSection.controlGroups = newSection.controlGroups.map(g => {
+        const oldGroupIndex = oldGroupLabels.indexOf(g.label);
+        if (oldGroupIndex == -1) {
+            return g
+        } else {
+            return updateGroup(oldSection.controlGroups[oldGroupIndex], g)
+        }
+    });
+
+    return newSection;
+}
+
+function updateGroup(oldGroup: DynamicControlGroup, newGroup: DynamicControlGroup) {
+    const oldControlNames = oldGroup.controls.map(c => c.name);
+    newGroup.controls = newGroup.controls.map(c => {
+        const oldIndex = oldControlNames.indexOf(c.name);
+        if (oldIndex == -1) {
+            return c
+        } else {
+            return oldGroup.controls[oldIndex]
+        }
+    });
+
+    return newGroup
+}

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -70,6 +70,27 @@ describe("ApiService", () => {
         expect(committedPayload).toBe("some error message");
     });
 
+    it("commits the error type if the error detail is missing", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure(null as any));
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+
+        const commit = ({type, payload}: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+
+        await api(commit as any)
+            .withError("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(committedPayload).toBe("OTHER_ERROR");
+    });
+
     it("commits the success response with the specified type", async () => {
 
         mockAxios.onGet(`/baseline/`)
@@ -88,6 +109,19 @@ describe("ApiService", () => {
 
         expect(committedType).toBe("TEST_TYPE");
         expect(committedPayload).toBe(true);
+    });
+
+    it("returns the success response data", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess("TEST"));
+
+        const commit = jest.fn();
+        const response = await api(commit as any)
+            .withSuccess("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(response).toBe("TEST");
     });
 
     it("deep freezes the response object", async () => {

--- a/src/app/static/src/tests/components/forms/dynamicFormMultiSelect.test.ts
+++ b/src/app/static/src/tests/components/forms/dynamicFormMultiSelect.test.ts
@@ -27,7 +27,7 @@ describe('Dynamic form multi-select component', function () {
         expect(treeSelect.props("clearable")).toBe(false);
     });
 
-    it("renders treeselect with starting value", () => {
+    it("renders treeselect with starting array value", () => {
         const rendered = shallowMount(DynamicFormMultiSelect, {
             propsData: {
                 formControl: {...fakeSelect, value: ["opt2"]}
@@ -38,6 +38,19 @@ describe('Dynamic form multi-select component', function () {
         expect(treeSelect.props("value")).toStrictEqual(["opt2"]);
         expect(treeSelect.props("options")).toStrictEqual(fakeSelect.options);
     });
+
+    it("renders treeselect with string starting value", () => {
+        const rendered = shallowMount(DynamicFormMultiSelect, {
+            propsData: {
+                formControl: {...fakeSelect, value: "opt2"}
+            }
+        });
+
+        const treeSelect = rendered.find(TreeSelect);
+        expect(treeSelect.props("value")).toStrictEqual(["opt2"]);
+        expect(treeSelect.props("options")).toStrictEqual(fakeSelect.options);
+    });
+
 
     it("initialises hidden input with value", () => {
         const rendered = shallowMount(DynamicFormMultiSelect, {

--- a/src/app/static/src/tests/modelOptions/utils.test.ts
+++ b/src/app/static/src/tests/modelOptions/utils.test.ts
@@ -1,0 +1,92 @@
+import {DynamicFormMeta, NumberControl} from "../../app/components/forms/types";
+import {updateForm} from "../../app/store/modelOptions/utils";
+
+describe("model options utils", () => {
+
+    const mockControl: NumberControl = {
+        name: "i1",
+        type: "number",
+        required: true
+    };
+
+    it("updated form without overwriting existing form control values", () => {
+
+        const oldForm: DynamicFormMeta = {
+            controlSections: [
+                {
+                    label: "general",
+                    controlGroups: [
+                        {
+                            label: "g1",
+                            controls: [{...mockControl, value: 10}]
+                        },
+                        {
+                            label: "g2",
+                            controls: [{...mockControl, value: 10}]
+                        }
+                    ]
+                }
+            ]
+        };
+        const newForm: DynamicFormMeta = {
+            controlSections: [
+                {
+                    label: "general",
+                    controlGroups: [
+                        {
+                            label: "g1",
+                            controls: [
+                                {...mockControl},
+                                {...mockControl, name: "new_control"}
+                            ]
+                        },
+                        {
+                            label: "new_group",
+                            controls: [{...mockControl}]
+                        }
+                    ]
+                },
+                {
+                    label: "survey",
+                    controlGroups: [
+                        {
+                            label: "g2",
+                            controls: []
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const expected: DynamicFormMeta = {
+            controlSections: [
+                {
+                    label: "general",
+                    controlGroups: [
+                        {
+                            label: "g1",
+                            controls: [
+                                {...mockControl, value: 10},
+                                {...mockControl, name: "new_control"}
+                            ]
+                        }, {
+                            label: "new_group",
+                            controls: [{...mockControl}]
+                        }
+                    ]
+                },
+                {
+                    label: "survey",
+                    controlGroups: [
+                        {
+                            label: "g2",
+                            controls: []
+                        }
+                    ]
+                }
+            ]
+        };
+        const result = updateForm(oldForm, newForm);
+        expect(result).toStrictEqual(expected);
+    });
+});


### PR DESCRIPTION
* adds util for updating a form without overwriting existing control values
* allow vue multiselect to accept default value of a single string as well as an array