### PR TITLE
mrc-737 passing by reference bug

### DIFF
--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -44,7 +44,7 @@ export const emptyState = {
     baseline: initialBaselineState,
     metadata: initialMetadataState,
     surveyAndProgram: initialSurveyAndProgramDataState,
-    filteredData: initialFilteredDataState,
+    filteredData: initialFilteredDataState(),
     modelOptions: initialModelOptionsState,
     modelOutput: {},
     modelRun: initialModelRunState,

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -41,15 +41,15 @@ const persistState = (store: Store<RootState>) => {
 
 export const emptyState = {
     version: '0.0.0',
-    baseline: initialBaselineState,
-    metadata: initialMetadataState,
-    surveyAndProgram: initialSurveyAndProgramDataState,
+    baseline: initialBaselineState(),
+    metadata: initialMetadataState(),
+    surveyAndProgram: initialSurveyAndProgramDataState(),
     filteredData: initialFilteredDataState(),
-    modelOptions: initialModelOptionsState,
+    modelOptions: initialModelOptionsState(),
     modelOutput: {},
-    modelRun: initialModelRunState,
-    stepper: initialStepperState,
-    load: initialLoadState,
+    modelRun: initialModelRunState(),
+    stepper: initialStepperState(),
+    load: initialLoadState(),
 };
 
 export const storeOptions: StoreOptions<RootState> = {

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -1,10 +1,11 @@
 import {MutationPayload, Store, StoreOptions} from "vuex";
 import {baseline, BaselineState, initialBaselineState} from "./store/baseline/baseline";
-import {metadata, MetadataState, initialMetadataState} from "./store/metadata/metadata";
+import {initialMetadataState, metadata, MetadataState} from "./store/metadata/metadata";
 import {filteredData, FilteredDataState, initialFilteredDataState} from "./store/filteredData/filteredData";
 import {
     initialSurveyAndProgramDataState,
-    surveyAndProgram, SurveyAndProgramDataState,
+    surveyAndProgram,
+    SurveyAndProgramDataState,
 } from "./store/surveyAndProgram/surveyAndProgram";
 import {initialModelRunState, modelRun, ModelRunState} from "./store/modelRun/modelRun";
 import {initialStepperState, stepper, StepperState} from "./store/stepper/stepper";
@@ -39,17 +40,19 @@ const persistState = (store: Store<RootState>) => {
     })
 };
 
-export const emptyState = {
-    version: '0.0.0',
-    baseline: initialBaselineState(),
-    metadata: initialMetadataState(),
-    surveyAndProgram: initialSurveyAndProgramDataState(),
-    filteredData: initialFilteredDataState(),
-    modelOptions: initialModelOptionsState(),
-    modelOutput: {},
-    modelRun: initialModelRunState(),
-    stepper: initialStepperState(),
-    load: initialLoadState(),
+export const emptyState = (): RootState => {
+    return {
+        version: '0.0.0',
+        baseline: initialBaselineState(),
+        metadata: initialMetadataState(),
+        surveyAndProgram: initialSurveyAndProgramDataState(),
+        filteredData: initialFilteredDataState(),
+        modelOptions: initialModelOptionsState(),
+        modelOutput: {},
+        modelRun: initialModelRunState(),
+        stepper: initialStepperState(),
+        load: initialLoadState(),
+    }
 };
 
 export const storeOptions: StoreOptions<RootState> = {

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -53,7 +53,7 @@ const namespaced: boolean = true;
 
 export const baseline: Module<BaselineState, RootState> = {
     namespaced,
-    state: {...initialBaselineState()},
+    state: initialBaselineState(),
     getters,
     actions,
     mutations

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -21,28 +21,30 @@ export interface BaselineState extends ReadyState {
     baselineError: string
 }
 
-export const initialBaselineState: BaselineState = {
-    country: "",
-    iso3: "",
-    pjnzError: "",
-    pjnz: null,
-    shape: null,
-    regionFilters: [],
-    flattenedRegionFilters: {},
-    shapeError: "",
-    population: null,
-    populationError: "",
-    ready: false,
-    validating: false,
-    validatedConsistent: false,
-    baselineError: ""
+export const initialBaselineState = (): BaselineState => {
+    return {
+        country: "",
+        iso3: "",
+        pjnzError: "",
+        pjnz: null,
+        shape: null,
+        regionFilters: [],
+        flattenedRegionFilters: {},
+        shapeError: "",
+        population: null,
+        populationError: "",
+        ready: false,
+        validating: false,
+        validatedConsistent: false,
+        baselineError: ""
+    }
 };
 
 export const baselineGetters = {
-  complete: (state: BaselineState) => {
-      return state.validatedConsistent &&
-                !!state.country && !!state.iso3 && !!state.shape && !!state.population
-  }
+    complete: (state: BaselineState) => {
+        return state.validatedConsistent &&
+            !!state.country && !!state.iso3 && !!state.shape && !!state.population
+    }
 };
 
 const getters = baselineGetters;
@@ -51,7 +53,7 @@ const namespaced: boolean = true;
 
 export const baseline: Module<BaselineState, RootState> = {
     namespaced,
-    state: {...initialBaselineState},
+    state: {...initialBaselineState()},
     getters,
     actions,
     mutations

--- a/src/app/static/src/app/store/filteredData/filteredData.ts
+++ b/src/app/static/src/app/store/filteredData/filteredData.ts
@@ -22,18 +22,22 @@ export interface FilteredDataState {
     regionIndicators: {[k: string]: any};
 }
 
-export const initialSelectedChoroplethFilters: SelectedChoroplethFilters = {
-    sex: "",
-    age: "",
-    survey: "",
-    regions: [],
-    quarter: ""
+export const initialSelectedChoroplethFilters = (): SelectedChoroplethFilters => {
+    return {
+        sex: "",
+        age: "",
+        survey: "",
+        regions: [],
+        quarter: ""
+    }
 };
 
-export const initialFilteredDataState: FilteredDataState = {
-   selectedDataType: null,
-   selectedChoroplethFilters: initialSelectedChoroplethFilters,
-   regionIndicators: {}
+export const initialFilteredDataState = (): FilteredDataState => {
+    return {
+        selectedDataType: null,
+        selectedChoroplethFilters: initialSelectedChoroplethFilters(),
+        regionIndicators: {}
+    }
 };
 
 const namespaced: boolean = true;
@@ -41,7 +45,7 @@ const existingState = localStorageManager.getState();
 
 export const filteredData: Module<FilteredDataState, RootState> = {
     namespaced,
-    state: {...initialFilteredDataState, ...existingState && existingState.filteredData},
+    state: {...initialFilteredDataState(), ...existingState && existingState.filteredData},
     actions,
     mutations,
     getters

--- a/src/app/static/src/app/store/filteredData/mutations.ts
+++ b/src/app/static/src/app/store/filteredData/mutations.ts
@@ -36,6 +36,6 @@ export const mutations: MutationTree<FilteredDataState> & SelectedDataMutations 
         }
     },
     Reset(state: FilteredDataState) {
-        Object.assign(state, initialFilteredDataState);
+        Object.assign(state, initialFilteredDataState());
     }
 };

--- a/src/app/static/src/app/store/load/load.ts
+++ b/src/app/static/src/app/store/load/load.ts
@@ -10,16 +10,18 @@ export interface LoadState {
     loadError: string
 }
 
-export const initialLoadState: LoadState = {
-    loadingState: LoadingState.NotLoading,
-    loadError: ""
+export const initialLoadState = (): LoadState => {
+    return {
+        loadingState: LoadingState.NotLoading,
+        loadError: ""
+    }
 };
 
 const namespaced: boolean = true;
 
 export const load: Module<LoadState, RootState> = {
     namespaced,
-    state: {...initialLoadState},
+    state: initialLoadState(),
     actions,
     mutations
 };

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -11,16 +11,18 @@ export interface MetadataState {
     plottingMetadata: PlottingMetadataResponse | null
 }
 
-export const initialMetadataState: MetadataState = {
-    plottingMetadataError: "",
-    plottingMetadata: null
+export const initialMetadataState = (): MetadataState => {
+    return {
+        plottingMetadataError: "",
+        plottingMetadata: null
+    }
 };
 
 export const metadataGetters = {
     complete: (state: MetadataState) => {
         return !!state.plottingMetadata
     },
-    choroplethIndicatorsMetadata: (state: MetadataState,  getters: any, rootState: RootState, rootGetters: any) => {
+    choroplethIndicatorsMetadata: (state: MetadataState, getters: any, rootState: RootState, rootGetters: any) => {
         const plottingMetadata = state.plottingMetadata;
 
         if (!plottingMetadata) {
@@ -30,7 +32,7 @@ export const metadataGetters = {
         const selectedDataType = rootState.filteredData.selectedDataType;
 
         let metadataForType = null;
-        switch(selectedDataType) {
+        switch (selectedDataType) {
             case (DataType.ANC):
                 metadataForType = plottingMetadata.anc;
                 break;
@@ -45,11 +47,11 @@ export const metadataGetters = {
                 break;
         }
 
-        return  (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
+        return (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
     },
-    choroplethIndicators:(state: MetadataState,  getters: any, rootState: RootState, rootGetters: any) => {
+    choroplethIndicators: (state: MetadataState, getters: any, rootState: RootState, rootGetters: any) => {
         const metadata = getters.choroplethIndicatorsMetadata;
-        return  metadata.map((i: IndicatorMetadata) => i.indicator);
+        return metadata.map((i: IndicatorMetadata) => i.indicator);
     }
 };
 
@@ -58,7 +60,7 @@ const existingState = localStorageManager.getState();
 
 export const metadata: Module<MetadataState, RootState> = {
     namespaced,
-    state: {...initialMetadataState, ...existingState && existingState.metadata},
+    state: {...initialMetadataState(), ...existingState && existingState.metadata},
     actions,
     mutations,
     getters: metadataGetters

--- a/src/app/static/src/app/store/modelOptions/modelOptions.ts
+++ b/src/app/static/src/app/store/modelOptions/modelOptions.ts
@@ -12,11 +12,13 @@ export interface ModelOptionsState {
     fetching: boolean
 }
 
-export const initialModelOptionsState: ModelOptionsState = {
-    optionsFormMeta: {controlSections: []},
-    options: {},
-    valid: false,
-    fetching: false
+export const initialModelOptionsState = (): ModelOptionsState => {
+    return {
+        optionsFormMeta: {controlSections: []},
+        options: {},
+        valid: false,
+        fetching: false
+    }
 };
 
 export const modelOptionsGetters = {
@@ -30,7 +32,7 @@ const existingState = localStorageManager.getState();
 
 export const modelOptions: Module<ModelOptionsState, RootState> = {
     namespaced,
-    state: {...initialModelOptionsState, ...existingState && existingState.modelOptions},
+    state: {...initialModelOptionsState(), ...existingState && existingState.modelOptions},
     mutations,
     actions,
     getters: modelOptionsGetters

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -13,13 +13,15 @@ export interface ModelRunState extends ReadyState {
     result: ModelResultResponse | null
 }
 
-export const initialModelRunState: ModelRunState = {
-    modelRunId: "",
-    errors: [],
-    status: {} as ModelStatusResponse,
-    statusPollId: -1,
-    result: null,
-    ready: false
+export const initialModelRunState = (): ModelRunState => {
+    return {
+        modelRunId: "",
+        errors: [],
+        status: {} as ModelStatusResponse,
+        statusPollId: -1,
+        result: null,
+        ready: false
+    }
 };
 
 export const modelRunGetters = {
@@ -36,7 +38,7 @@ const existingState = localStorageManager.getState();
 
 export const modelRun: Module<ModelRunState, RootState> = {
     namespaced,
-    state: {...initialModelRunState, ...existingState && existingState.modelRun},
+    state: {...initialModelRunState(), ...existingState && existingState.modelRun},
     actions,
     getters: modelRunGetters,
     mutations

--- a/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
+++ b/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
@@ -15,16 +15,18 @@ export interface BarchartSelections {
     selectedFilterOptions:  { [key: string]: FilterOption[] }
 }
 
-export const initialBarchartSelections = {
-    indicatorId: "",
-    xAxisId: "",
-    disaggregateById: "",
-    selectedFilterOptions: {}
+export const initialBarchartSelections = (): BarchartSelections => {
+    return {
+        indicatorId: "",
+        xAxisId: "",
+        disaggregateById: "",
+        selectedFilterOptions: {}
+    }
 };
 
 export const initialPlottingSelectionsState = (): PlottingSelectionsState => {
     return {
-        barchart: {...initialBarchartSelections}
+        barchart: initialBarchartSelections()
     }
 };
 

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -1,5 +1,7 @@
 import {Mutation, MutationTree} from "vuex";
 import {emptyState, RootState} from "../../root";
+import {initialSurveyAndProgramDataState} from "../surveyAndProgram/surveyAndProgram";
+import {initialFilteredDataState} from "../filteredData/filteredData";
 
 export interface RootMutations {
     Reset: Mutation<RootState>
@@ -8,15 +10,15 @@ export interface RootMutations {
 
 export const mutations: MutationTree<RootState> & RootMutations = {
     Reset(state: RootState) {
-        Object.assign(state, emptyState);
+        Object.assign(state, emptyState());
         state.surveyAndProgram.ready = true;
         state.baseline.ready = true;
         state.modelRun.ready = true;
     },
 
     ResetInputs(state: RootState) {
-        Object.assign(state.surveyAndProgram, emptyState.surveyAndProgram);
-        Object.assign(state.filteredData, emptyState.filteredData);
+        Object.assign(state.surveyAndProgram, initialSurveyAndProgramDataState());
+        Object.assign(state.filteredData, initialFilteredDataState());
         state.surveyAndProgram.ready = true;
     }
 };

--- a/src/app/static/src/app/store/stepper/stepper.ts
+++ b/src/app/static/src/app/store/stepper/stepper.ts
@@ -15,33 +15,35 @@ export interface StepperState {
     steps: StepDescription[]
 }
 
-export const initialStepperState: StepperState = {
-    activeStep: 1,
-    steps: [
-        {
-            number: 1,
-            text: "Upload baseline data"
-        },
-        {
-            number: 2,
-            text: "Upload survey and programme data"
-        },
-        {
-            number: 3,
-            text: "Model options"
-        },
-        {
-            number: 4,
-            text: "Run model"
-        },
-        {
-            number: 5,
-            text: "Review output"
-        },
-        {
-            number: 6,
-            text: "Download results"
-        }]
+export const initialStepperState = (): StepperState => {
+    return {
+        activeStep: 1,
+        steps: [
+            {
+                number: 1,
+                text: "Upload baseline data"
+            },
+            {
+                number: 2,
+                text: "Upload survey and programme data"
+            },
+            {
+                number: 3,
+                text: "Model options"
+            },
+            {
+                number: 4,
+                text: "Run model"
+            },
+            {
+                number: 5,
+                text: "Review output"
+            },
+            {
+                number: 6,
+                text: "Download results"
+            }]
+    }
 };
 
 
@@ -50,7 +52,7 @@ const existingState = localStorageManager.getState();
 
 export const stepper: Module<StepperState, RootState> = {
     namespaced,
-    state: {...initialStepperState, ...existingState && existingState.stepper},
+    state: {...initialStepperState(), ...existingState && existingState.stepper},
     getters,
     actions,
     mutations

--- a/src/app/static/src/app/store/stepper/stepper.ts
+++ b/src/app/static/src/app/store/stepper/stepper.ts
@@ -16,6 +16,7 @@ export interface StepperState {
 }
 
 export const initialStepperState = (): StepperState => {
+
     return {
         activeStep: 1,
         steps: [

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -1,8 +1,8 @@
-import { Module } from 'vuex';
-import { actions } from './actions';
-import { mutations } from './mutations';
+import {Module} from 'vuex';
+import {actions} from './actions';
+import {mutations} from './mutations';
 import {ReadyState, RootState} from "../../root";
-import {ProgrammeResponse, SurveyResponse, AncResponse} from "../../generated";
+import {AncResponse, ProgrammeResponse, SurveyResponse} from "../../generated";
 
 export interface SurveyAndProgramDataState extends ReadyState {
     survey: SurveyResponse | null
@@ -13,14 +13,16 @@ export interface SurveyAndProgramDataState extends ReadyState {
     ancError: string
 }
 
-export const initialSurveyAndProgramDataState: SurveyAndProgramDataState = {
-    survey: null,
-    surveyError: "",
-    program: null,
-    programError: "",
-    anc: null,
-    ancError: "",
-    ready: false
+export const initialSurveyAndProgramDataState = (): SurveyAndProgramDataState => {
+    return {
+        survey: null,
+        surveyError: "",
+        program: null,
+        programError: "",
+        anc: null,
+        ancError: "",
+        ready: false
+    }
 };
 
 export const surveyAndProgramGetters = {
@@ -33,7 +35,7 @@ const namespaced: boolean = true;
 
 export const surveyAndProgram: Module<SurveyAndProgramDataState, RootState> = {
     namespaced,
-    state: {...initialSurveyAndProgramDataState},
+    state: initialSurveyAndProgramDataState(),
     getters: surveyAndProgramGetters,
     actions,
     mutations

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -1,5 +1,6 @@
 import {mutations} from "../../app/store/baseline/mutations";
 import {
+    mockBaselineState,
     mockPJNZResponse,
     mockPopulationResponse,
     mockRootState,
@@ -14,7 +15,7 @@ describe("Baseline mutations", () => {
 
     it("sets country, filename and error on PJNZUpdated", () => {
 
-        const testState = {...initialBaselineState};
+        const testState = mockBaselineState();
         mutations.PJNZUpdated(testState, {
             payload: mockPJNZResponse({data: {country: "Malawi", iso3: "MWI"}, filename: "file.pjnz"})
         });
@@ -26,7 +27,7 @@ describe("Baseline mutations", () => {
 
     it("state becomes complete once all files are Updated and validatedConsistent are true", () => {
         const testStore: Module<BaselineState, RootState> = {
-            state: {...initialBaselineState},
+            state: mockBaselineState(),
             getters: baselineGetters
         };
         const testState = testStore.state as BaselineState;
@@ -64,13 +65,13 @@ describe("Baseline mutations", () => {
 
     it("sets error on PJNZUploadError", () => {
 
-        const testState = {...initialBaselineState};
+        const testState = mockBaselineState();
         mutations.PJNZUploadError(testState, {payload: "Some error"});
         expect(testState.pjnzError).toBe("Some error");
     });
 
     it("sets country and filename and clears error if present on PJNZUpdated", () => {
-        const testState = {...initialBaselineState, pjnzError: "test"};
+        const testState = mockBaselineState({pjnzError: "test"});
         mutations.PJNZUpdated(testState, {
             payload: mockPJNZResponse({filename: "file.pjnz", data: {country: "Malawi", iso3: "MWI"}})
         });
@@ -81,7 +82,7 @@ describe("Baseline mutations", () => {
 
     it("clears country and filename on PJNZUpdated if no data present", () => {
 
-        const testState = {...initialBaselineState, pjnzError: "", country: "test", pjnz: "TEST" as any};
+        const testState = mockBaselineState({pjnzError: "", country: "test", pjnz: "TEST" as any});
         mutations.PJNZUpdated(testState, {payload: null});
         expect(testState.pjnz).toBe(null);
         expect(testState.country).toBe("");
@@ -92,7 +93,7 @@ describe("Baseline mutations", () => {
     it("sets shape and clears error on ShapeUpdated", () => {
 
         const mockShape = mockShapeResponse();
-        const testState = {...initialBaselineState, shapeError: ""};
+        const testState = mockBaselineState({shapeError: ""});
         mutations.ShapeUpdated(testState, {
             payload: mockShape
         });
@@ -113,7 +114,7 @@ describe("Baseline mutations", () => {
                 }
             }
         });
-        const testState = {...initialBaselineState};
+        const testState = mockBaselineState();
         mutations.ShapeUpdated(testState, {
             payload: mockShape
         });
@@ -129,7 +130,7 @@ describe("Baseline mutations", () => {
 
     it("sets error on ShapeUploadError", () => {
 
-        const testState = {...initialBaselineState};
+        const testState = mockBaselineState();
         mutations.ShapeUploadError(testState, {payload: "Some error"});
         expect(testState.shapeError).toBe("Some error");
     });
@@ -137,7 +138,7 @@ describe("Baseline mutations", () => {
     it("sets response and clears error on PopulationUpdated", () => {
 
         const mockPop = mockPopulationResponse();
-        const testState = {...initialBaselineState, populationError: "test"};
+        const testState = mockBaselineState({populationError: "test"});
         mutations.PopulationUpdated(testState, {
             payload: mockPop
         });
@@ -147,37 +148,37 @@ describe("Baseline mutations", () => {
 
     it("sets error on PopulationUploadError", () => {
 
-        const testState = {...initialBaselineState};
+        const testState = mockBaselineState();
         mutations.PopulationUploadError(testState, {payload: "Some error"});
         expect(testState.populationError).toBe("Some error");
     });
 
     it("sets ready state", () => {
-        const testState = {...initialBaselineState};
+        const testState =  mockBaselineState();
         mutations.Ready(testState);
         expect(testState.ready).toBe(true);
     });
     it("Validated sets validation values", () => {
-        const testState = {...initialBaselineState, baselineError: "test error"};
+        const testState = mockBaselineState({baselineError: "test error"});
         mutations.Validated(testState, {payload: {consistent: true, complete: true}});
         expect(testState.baselineError).toBe("");
         expect(testState.validatedConsistent).toBe(true);
     });
 
     it("Validating resets validation values", () => {
-        const testState = {...initialBaselineState,
+        const testState = mockBaselineState({
             validatedConsistent: true,
             baselineError: "test error"
-        };
+        });
         mutations.Validating(testState);
         expect(testState.baselineError).toBe("");
         expect(testState.validatedConsistent).toBe(false);
     });
 
     it("BaselineError sets baseline error and validation values", () => {
-        const testState = {...initialBaselineState,
+        const testState = mockBaselineState({
             validatedConsistent: true
-        };
+        });
         mutations.BaselineError(testState, {payload: "test error"});
         expect(testState.baselineError).toBe("test error");
         expect(testState.validatedConsistent).toBe(false);

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -3,11 +3,8 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import ModelOutput from "../../../app/components/modelOutput/ModelOutput.vue";
 import {
-    mockAncResponse,
     mockFilteredDataState, mockModelResultResponse,
     mockModelRunState,
-    mockProgramResponse,
-    mockSurveyResponse,
 } from "../../mocks";
 import {DataType} from "../../../app/store/filteredData/filteredData";
 import {actions} from "../../../app/store/filteredData/actions";

--- a/src/app/static/src/tests/components/plots/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth.test.ts
@@ -9,8 +9,7 @@ import {mutations} from "../../../app/store/filteredData/mutations";
 import {
     DataType,
     FilteredDataState,
-    FilterType,
-    initialFilteredDataState
+    FilterType
 } from "../../../app/store/filteredData/filteredData";
 import {actions} from "../../../app/store/filteredData/actions";
 
@@ -232,7 +231,7 @@ describe("Choropleth component", () => {
 
     it("updates indicator if necessary when selectedDataType changes", () => {
         //defaults to prev, should get updated to art on data type change if no prev data
-        const filteredData = {...initialFilteredDataState};
+        const filteredData = mockFilteredDataState()
         const testStore = new Vuex.Store({
             modules: {
                 baseline: {
@@ -295,7 +294,7 @@ describe("Choropleth component", () => {
 
     it("options onEachFeature returns function which generates correct tooltips", () => {
 
-        const filteredData = {...initialFilteredDataState};
+        const filteredData = mockFilteredDataState();
         const testStore = new Vuex.Store({
             modules: {
                 baseline: {

--- a/src/app/static/src/tests/components/plots/choroplethFilter.test.ts
+++ b/src/app/static/src/tests/components/plots/choroplethFilter.test.ts
@@ -48,7 +48,7 @@ describe("ChoroplethFilters component", () => {
             {id: "a2", label: "5-9"}
         ];
         const mockSelectedFilters = {
-            ...initialSelectedChoroplethFilters,
+            ...initialSelectedChoroplethFilters(),
             age: "a1"
         };
 
@@ -68,7 +68,7 @@ describe("ChoroplethFilters component", () => {
 
     it("computes selected sexFilters", () => {
         const mockSelectedFilters = {
-            ...initialSelectedChoroplethFilters,
+            ...initialSelectedChoroplethFilters(),
             sex: "both"
         };
 
@@ -84,7 +84,7 @@ describe("ChoroplethFilters component", () => {
             {id: "s2", label: "survey 2"}
         ];
         const mockSelectedFilters = {
-            ...initialSelectedChoroplethFilters,
+            ...initialSelectedChoroplethFilters(),
             survey: "s1"
         };
 
@@ -110,7 +110,7 @@ describe("ChoroplethFilters component", () => {
             {id: "2", label: "Apr-Jun 2019"}
         ];
         const mockSelectedFilters = {
-            ...initialSelectedChoroplethFilters,
+            ...initialSelectedChoroplethFilters(),
             quarter: "1"
         };
 
@@ -140,7 +140,7 @@ describe("ChoroplethFilters component", () => {
                 ]
             }];
         const mockSelectedFilters = {
-            ...initialSelectedChoroplethFilters,
+            ...initialSelectedChoroplethFilters(),
             regions: ["a2"]
         };
         const mockGetters = {

--- a/src/app/static/src/tests/filteredData/getters.test.ts
+++ b/src/app/static/src/tests/filteredData/getters.test.ts
@@ -1,10 +1,11 @@
 import {flattenedSelectedRegionFilters, getters} from "../../app/store/filteredData/getters"
 import {Module} from "vuex";
-import {DataType, FilteredDataState, initialFilteredDataState} from "../../app/store/filteredData/filteredData";
+import {DataType, FilteredDataState} from "../../app/store/filteredData/filteredData";
 import {RootState} from "../../app/root";
 import {
     mockAncResponse,
     mockBaselineState,
+    mockFilteredDataState,
     mockModelResultResponse,
     mockModelRunState,
     mockProgramFilters,
@@ -46,7 +47,7 @@ describe("FilteredData getters", () => {
 
     it("gets correct selectedDataFilters when selectedDataType is Program", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Program},
+            state: mockFilteredDataState({selectedDataType: DataType.Program}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -73,7 +74,7 @@ describe("FilteredData getters", () => {
 
     it("gets correct selectedDataFilters when selectedDataType is Survey", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Survey},
+            state: mockFilteredDataState({selectedDataType: DataType.Survey}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -105,7 +106,7 @@ describe("FilteredData getters", () => {
 
     it("gets correct selectedDataFilters when selectedDataType is ANC", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.ANC},
+            state: mockFilteredDataState({selectedDataType: DataType.ANC}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -133,7 +134,7 @@ describe("FilteredData getters", () => {
 
     it("gets correct selectedDataFilters when selectedDataType is Output", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Output},
+            state: mockFilteredDataState({selectedDataType: DataType.Output}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -165,7 +166,7 @@ describe("FilteredData getters", () => {
 
     it("gets null selectedDataFilters when unknown data type", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: 99 as any},
+            state: mockFilteredDataState({selectedDataType: 99 as any}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -177,7 +178,7 @@ describe("FilteredData getters", () => {
 
     it("gets unfilteredData when selectedDataType is Survey", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Survey},
+            state: mockFilteredDataState({selectedDataType: DataType.Survey}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -198,7 +199,7 @@ describe("FilteredData getters", () => {
 
     it("gets unfilteredData when selectedDataType is Program", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Program},
+            state: mockFilteredDataState({selectedDataType: DataType.Program}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -219,7 +220,7 @@ describe("FilteredData getters", () => {
 
     it("gets unfilteredData when selectedDataType is ANC", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.ANC},
+            state: mockFilteredDataState({selectedDataType: DataType.ANC}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -240,7 +241,7 @@ describe("FilteredData getters", () => {
 
     it("gets unfilteredData when selectedDataType is Output", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: DataType.Output},
+            state: mockFilteredDataState({selectedDataType: DataType.Output}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -261,7 +262,7 @@ describe("FilteredData getters", () => {
 
     it("gets unfilteredData when selectedDataType is unknown", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {...initialFilteredDataState, selectedDataType: 99 as DataType.Output},
+            state: mockFilteredDataState({selectedDataType: 99 as DataType.Output}),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -304,8 +305,7 @@ describe("FilteredData getters", () => {
     it("gets flattened selected region filter", () => {
 
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -314,7 +314,7 @@ describe("FilteredData getters", () => {
                     quarter: "",
                     regions: ["R1", "R2", "R3"]
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -325,8 +325,7 @@ describe("FilteredData getters", () => {
 
     it("gets flattened selected region filter when region filter is empty", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -335,7 +334,7 @@ describe("FilteredData getters", () => {
                     quarter: "",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;

--- a/src/app/static/src/tests/filteredData/getters_regionIndicators.test.ts
+++ b/src/app/static/src/tests/filteredData/getters_regionIndicators.test.ts
@@ -4,7 +4,7 @@ import {DataType, FilteredDataState, initialFilteredDataState} from "../../app/s
 import {RootState} from "../../app/root";
 import {
     mockAncResponse,
-    mockBaselineState,
+    mockBaselineState, mockFilteredDataState,
     mockModelResultResponse,
     mockModelRunState,
     mockProgramResponse,
@@ -56,8 +56,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets regionIndicators for survey", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -66,7 +65,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -147,8 +146,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("filters regionIndicators for survey", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -157,7 +155,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1", //should be ignored
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -229,8 +227,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets regionIndicators for programme", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Program,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -239,7 +236,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -291,8 +288,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("filters regionIndicators for programme", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Program,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -301,7 +297,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -369,8 +365,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets regionIndicators for ANC", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -379,7 +374,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -435,8 +430,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("filter regionIndicators for ANC", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.ANC,
                 selectedChoroplethFilters: {
                     age: "1", //should be ignored
@@ -445,7 +439,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -516,7 +510,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets regionIndicators for Output", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
+            state: mockFilteredDataState({
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Output,
                 selectedChoroplethFilters: {
@@ -526,7 +520,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -578,7 +572,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("filters regionIndicators for Output", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
+            state: mockFilteredDataState({
                 ...initialFilteredDataState,
                 selectedDataType: DataType.Output,
                 selectedChoroplethFilters: {
@@ -588,7 +582,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -664,8 +658,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("filters regionIndicators by region", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -674,7 +667,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "1",
                     regions: ["area1"]
                 }
-            }
+            })
         };
         const testState = testStore.state as FilteredDataState;
         const testData = [
@@ -769,8 +762,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets empty regionIndicators if no data", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
-                ...initialFilteredDataState,
+            state: mockFilteredDataState({
                 selectedDataType: DataType.Survey,
                 selectedChoroplethFilters: {
                     age: "1",
@@ -779,7 +771,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;
@@ -800,7 +792,7 @@ describe("FilteredData regionIndicator getter", () => {
 
     it("gets empty regionIndicators if no selected daa type", () => {
         const testStore: Module<FilteredDataState, RootState> = {
-            state: {
+            state: mockFilteredDataState({
                 ...initialFilteredDataState,
                 selectedDataType: null,
                 selectedChoroplethFilters: {
@@ -810,7 +802,7 @@ describe("FilteredData regionIndicator getter", () => {
                     quarter: "",
                     regions: []
                 }
-            },
+            }),
             getters: getters
         };
         const testState = testStore.state as FilteredDataState;

--- a/src/app/static/src/tests/filteredData/mutations.test.ts
+++ b/src/app/static/src/tests/filteredData/mutations.test.ts
@@ -25,26 +25,26 @@ describe("FilteredData mutations", () => {
     };
 
     const testChoroplethFilterUpdated = (filterType: FilterType) => {
-        const testState = {...initialFilteredDataState};
+        const testState = {...initialFilteredDataState()};
 
         //initial sate
-        let expected = "" as any;
+        let expectedInitialState = "" as any;
         if (filterType == FilterType.Region){
-            expected = [];
+            expectedInitialState = [];
         }
         expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType))
-            .toStrictEqual(expected);
+            .toStrictEqual(expectedInitialState);
 
         mutations.ChoroplethFilterUpdated(testState, {
-            payload: [filterType, {id: "id", name: "name"}]
+            payload: [filterType, "test"]
         });
         expect(getSelectedChoroplethFilterByType(testState.selectedChoroplethFilters, filterType))
-            .toStrictEqual({id: "id", name: "name"});
+            .toStrictEqual("test");
     };
 
     it("sets selectedDataType on SelectedDataTypeUpdated", () => {
 
-        const testState = {...initialFilteredDataState};
+        const testState = mockFilteredDataState();
         mutations.SelectedDataTypeUpdated(testState, {
             payload: DataType.Program
         });

--- a/src/app/static/src/tests/load/mutations.test.ts
+++ b/src/app/static/src/tests/load/mutations.test.ts
@@ -1,15 +1,16 @@
 import {mutations} from "../../app/store/load/mutations";
-import {LoadingState, initialLoadState} from "../../app/store/load/load";
+import {initialLoadState, LoadingState} from "../../app/store/load/load";
+import {mockLoadState} from "../mocks";
 
 describe("Load mutations", () => {
     it("SettingFiles updates loading state correctly", () => {
-        const testState = {...initialLoadState};
+        const testState = mockLoadState();
         mutations.SettingFiles(testState, null);
         expect(testState.loadingState).toBe(LoadingState.SettingFiles);
     });
 
     it("UpdatingState updates loading state correctly", () => {
-        const testState = {...initialLoadState};
+        const testState = mockLoadState();
         mutations.UpdatingState(testState, null);
         expect(testState.loadingState).toBe(LoadingState.UpdatingState);
     });
@@ -26,7 +27,7 @@ describe("Load mutations", () => {
     });
 
     it("LoadFailed updates loading state correctly and sets error", () => {
-        const testState = {...initialLoadState};
+        const testState = mockLoadState();
         mutations.LoadFailed(testState, {type: "LoadFailed", payload: "TEST ERROR"});
         expect(testState.loadingState).toBe(LoadingState.LoadFailed);
         expect(testState.loadError).toBe("TEST ERROR");

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -82,14 +82,14 @@ export const mockFilteredDataState = (props?: Partial<FilteredDataState>) => {
 
 export const mockMetadataState = (props?: Partial<MetadataState>) => {
     return {
-        ...initialMetadataState,
+        ...initialMetadataState(),
         ...props
     }
 };
 
 export const mockLoadState = (props?: Partial<LoadState>) => {
     return {
-        ...initialLoadState,
+        ...initialLoadState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -39,7 +39,7 @@ export const mockPasswordState = (props?: Partial<PasswordState>) => {
 
 export const mockBaselineState = (props?: Partial<BaselineState>) => {
     return {
-        ...initialBaselineState,
+        ...initialBaselineState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -46,7 +46,7 @@ export const mockBaselineState = (props?: Partial<BaselineState>) => {
 
 export const mockSurveyAndProgramState = (props?: Partial<SurveyAndProgramDataState>) => {
     return {
-        ...initialSurveyAndProgramDataState,
+        ...initialSurveyAndProgramDataState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -13,16 +13,18 @@ import {
     ModelStatusResponse,
     PjnzResponse,
     PlottingMetadataResponse,
-    PopulationResponse, ProgrammeFilters,
+    PopulationResponse,
+    ProgrammeFilters,
     ProgrammeResponse,
     Response,
     ShapeResponse,
     SurveyFilters,
-    SurveyResponse, ValidateBaselineResponse
+    SurveyResponse,
+    ValidateBaselineResponse
 } from "../app/generated";
 import {FilteredDataState, initialFilteredDataState} from "../app/store/filteredData/filteredData";
 import {initialModelRunState, ModelRunState} from "../app/store/modelRun/modelRun";
-import {RootState} from "../app/root";
+import {emptyState, RootState} from "../app/root";
 import {initialStepperState, StepperState} from "../app/store/stepper/stepper";
 import {initialMetadataState, MetadataState} from "../app/store/metadata/metadata";
 import {initialLoadState, LoadState} from "../app/store/load/load";
@@ -96,21 +98,12 @@ export const mockLoadState = (props?: Partial<LoadState>) => {
 
 export const mockRootState = (props?: Partial<RootState>): RootState => {
     return {
-        version: "",
-        filteredData: mockFilteredDataState(),
-        baseline: mockBaselineState(),
-        surveyAndProgram: mockSurveyAndProgramState(),
-        modelRun: mockModelRunState(),
-        modelOptions: mockModelOptionsState(),
-        stepper: mockStepperState(),
-        metadata: mockMetadataState(),
-        load: mockLoadState(),
-        modelOutput: {},
+        ...emptyState(),
         ...props
     }
 };
 
-export const mockFile = (filename: string, fileContents: string,  type: string = "text/csv"): File => {
+export const mockFile = (filename: string, fileContents: string, type: string = "text/csv"): File => {
     return new File([fileContents], filename, {
         type: type,
         lastModified: 1
@@ -154,7 +147,7 @@ export const mockShapeResponse = (props: Partial<ShapeResponse> = {}): ShapeResp
         filename: "test.csv",
         filters: {
             level_labels: [{id: 1, area_level_label: "Country", display: true}],
-            regions: {label: "Malawi", id: "1", children : []}
+            regions: {label: "Malawi", id: "1", children: []}
         },
         ...props
     }

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -75,7 +75,7 @@ export const mockStepperState = (props?: Partial<StepperState>) => {
 
 export const mockFilteredDataState = (props?: Partial<FilteredDataState>) => {
     return {
-        ...initialFilteredDataState,
+        ...initialFilteredDataState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -68,7 +68,7 @@ export const mockModelOptionsState = (props?: Partial<ModelOptionsState>) => {
 
 export const mockStepperState = (props?: Partial<StepperState>) => {
     return {
-        ...initialStepperState,
+        ...initialStepperState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -53,7 +53,7 @@ export const mockSurveyAndProgramState = (props?: Partial<SurveyAndProgramDataSt
 
 export const mockModelRunState = (props?: Partial<ModelRunState>) => {
     return {
-        ...initialModelRunState,
+        ...initialModelRunState(),
         ...props
     }
 };
@@ -61,7 +61,7 @@ export const mockModelRunState = (props?: Partial<ModelRunState>) => {
 
 export const mockModelOptionsState = (props?: Partial<ModelOptionsState>) => {
     return {
-        ...initialModelOptionsState,
+        ...initialModelOptionsState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/modelRun/mutations.test.ts
+++ b/src/app/static/src/tests/modelRun/mutations.test.ts
@@ -1,6 +1,6 @@
 import {initialModelRunState} from "../../app/store/modelRun/modelRun";
 import {mutations} from "../../app/store/modelRun/mutations";
-import {mockModelResultResponse} from "../mocks";
+import {mockModelResultResponse, mockModelRunState} from "../mocks";
 
 describe("Model run mutations", () => {
 
@@ -9,7 +9,7 @@ describe("Model run mutations", () => {
     });
 
     it("sets status and clears errors when started", () => {
-        const testState = {...initialModelRunState, errors: [1, 2, 3]};
+        const testState = mockModelRunState({errors: [1, 2, 3]});
         mutations.ModelRunStarted(testState, {payload: {id: "1234"}});
         expect(testState.modelRunId).toBe("1234");
         expect(testState.status).toStrictEqual({id: "1234"});
@@ -17,7 +17,7 @@ describe("Model run mutations", () => {
     });
 
     it("sets run status, success and poll id when done", () => {
-        const testState = {...initialModelRunState};
+        const testState = mockModelRunState();
         mutations.RunStatusUpdated(testState, {payload: {id: "1234", done: true, success: true}});
         expect(testState.status.success).toBe(true);
         expect(testState.status).toStrictEqual({id: "1234", done: true, success: true});
@@ -25,26 +25,26 @@ describe("Model run mutations", () => {
     });
 
     it("does not update poll id if not done", () => {
-        const testState = {...initialModelRunState, statusPollId: 10};
+        const testState = mockModelRunState({statusPollId: 10});
         mutations.RunStatusUpdated(testState, {payload: {done: false}});
         expect(testState.statusPollId).toBe(10);
     });
 
     it("sets poll id", () => {
-        const testState = {...initialModelRunState};
+        const testState = mockModelRunState();
         mutations.PollingForStatusStarted(testState, {payload: 2});
         expect(testState.statusPollId).toBe(2);
     });
 
     it("sets result", () => {
-        const testState = {...initialModelRunState};
+        const testState = mockModelRunState();
         const testResponse = mockModelResultResponse();
         mutations.RunResultFetched(testState, {payload: testResponse});
         expect(testState.result).toBe(testResponse);
     });
 
     it("sets result error", () => {
-        const testState = {...initialModelRunState};
+        const testState = mockModelRunState();
         mutations.RunResultError(testState, {payload: "Test Error"});
         expect(testState.errors).toStrictEqual(["Test Error"]);
     });

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -6,15 +6,18 @@ describe("Root mutations", () => {
 
     it("can reset state", () => {
 
-        const state = mockRootState({
-            stepper: mockStepperState({activeStep: 2})
-        });
+        const state = mockRootState();
 
-        expect(state.stepper.activeStep).toBe(2);
+        // mutate simple prop
+        state.stepper.activeStep = 2;
+        // mutate nested prop
+        state.filteredData.selectedChoroplethFilters.quarter = "test";
 
         mutations.Reset(state);
 
         expect(state.stepper.activeStep).toBe(1);
+        expect(state.filteredData.selectedChoroplethFilters.quarter).toBe("");
+
     });
 
     it("can reset input state", () => {
@@ -24,15 +27,28 @@ describe("Root mutations", () => {
                 anc: "test" as any,
                 survey: "test" as any,
                 program: "test" as any
-            }),
-            filteredData: mockFilteredDataState({selectedDataType: DataType.ANC})
+            })
         });
+
+        // simulate mutations
+        state.filteredData.selectedChoroplethFilters.age = "1";
+        state.filteredData.selectedChoroplethFilters.quarter = "1";
+        state.filteredData.selectedChoroplethFilters.survey = "1";
+        state.filteredData.selectedChoroplethFilters.sex = "1";
+        state.filteredData.selectedChoroplethFilters.regions = ["1"];
 
         mutations.ResetInputs(state);
         expect(state.surveyAndProgram.anc).toBe(null);
         expect(state.surveyAndProgram.survey).toBe(null);
         expect(state.surveyAndProgram.program).toBe(null);
         expect(state.filteredData.selectedDataType).toBe(null);
+        
+        expect(state.filteredData.selectedChoroplethFilters.quarter).toBe("");
+        expect(state.filteredData.selectedChoroplethFilters.age).toBe("");
+        expect(state.filteredData.selectedChoroplethFilters.sex).toBe("");
+        expect(state.filteredData.selectedChoroplethFilters.survey).toBe("");
+        expect(state.filteredData.selectedChoroplethFilters.regions).toStrictEqual([]);
+
     });
 
 });

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -17,6 +17,14 @@ describe("Root mutations", () => {
         expect(state.stepper.activeStep).toBe(1);
         expect(state.filteredData.selectedChoroplethFilters.quarter).toBe("");
 
+        // do mutations again
+        state.stepper.activeStep = 2;
+        state.filteredData.selectedChoroplethFilters.quarter = "test";
+
+        mutations.Reset(state);
+
+        expect(state.stepper.activeStep).toBe(1);
+        expect(state.filteredData.selectedChoroplethFilters.quarter).toBe("");
     });
 
     it("can reset input state", () => {

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -1,6 +1,5 @@
 import {mutations} from "../../app/store/root/mutations";
-import {mockFilteredDataState, mockRootState, mockStepperState, mockSurveyAndProgramState} from "../mocks";
-import {DataType} from "../../app/store/filteredData/filteredData";
+import {mockRootState, mockSurveyAndProgramState} from "../mocks";
 
 describe("Root mutations", () => {
 
@@ -42,7 +41,7 @@ describe("Root mutations", () => {
         expect(state.surveyAndProgram.survey).toBe(null);
         expect(state.surveyAndProgram.program).toBe(null);
         expect(state.filteredData.selectedDataType).toBe(null);
-        
+
         expect(state.filteredData.selectedChoroplethFilters.quarter).toBe("");
         expect(state.filteredData.selectedChoroplethFilters.age).toBe("");
         expect(state.filteredData.selectedChoroplethFilters.sex).toBe("");

--- a/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
@@ -1,9 +1,6 @@
-import {
-    initialSurveyAndProgramDataState,
-    SurveyAndProgramDataState, surveyAndProgramGetters
-} from "../../app/store/surveyAndProgram/surveyAndProgram";
+import {SurveyAndProgramDataState, surveyAndProgramGetters} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {mutations} from "../../app/store/surveyAndProgram/mutations";
-import {mockRootState, mockSurveyResponse} from "../mocks";
+import {mockRootState, mockSurveyAndProgramState, mockSurveyResponse} from "../mocks";
 import {Module} from "vuex";
 import {RootState} from "../../app/root";
 
@@ -23,7 +20,7 @@ describe("Survey and programme mutations", () => {
     };
 
     it("sets surveys data and filename and clears error on SurveyUpdated", () => {
-        const testState = {...initialSurveyAndProgramDataState, surveyError: "test"};
+        const testState = mockSurveyAndProgramState({surveyError: "test"});
         mutations.SurveyUpdated(testState, testPayload);
         expect(testState.survey!!.data).toStrictEqual(testData);
         expect(testState.survey!!.filename).toBe("somefile.csv");
@@ -31,13 +28,13 @@ describe("Survey and programme mutations", () => {
     });
 
     it("sets error on SurveyError", () => {
-        const testState = {...initialSurveyAndProgramDataState};
+        const testState = mockSurveyAndProgramState();
         mutations.SurveyError(testState, {payload: "Some error"});
         expect(testState.surveyError).toBe("Some error");
     });
 
     it("sets programme data and filename and clears error on ProgramUpdated", () => {
-        const testState = {...initialSurveyAndProgramDataState, programError: "test"};
+        const testState = mockSurveyAndProgramState({programError: "test"});
         mutations.ProgramUpdated(testState, testPayload);
         expect(testState.program!!.data).toStrictEqual(testData);
         expect(testState.program!!.filename).toBe("somefile.csv");
@@ -45,13 +42,13 @@ describe("Survey and programme mutations", () => {
     });
 
     it("sets error on ProgramError", () => {
-        const testState = {...initialSurveyAndProgramDataState};
+        const testState = mockSurveyAndProgramState();
         mutations.ProgramError(testState, {payload: "Some error"});
         expect(testState.programError).toBe("Some error");
     });
 
     it("sets anc data and filename and clears error on ANCUpdated", () => {
-        const testState = {...initialSurveyAndProgramDataState, ancError: "test"};
+        const testState = mockSurveyAndProgramState({ancError: "test"});
         mutations.ANCUpdated(testState, testPayload);
         expect(testState.anc!!.data).toStrictEqual(testData);
         expect(testState.anc!!.filename).toBe("somefile.csv");
@@ -59,14 +56,14 @@ describe("Survey and programme mutations", () => {
     });
 
     it("sets error on ANCError", () => {
-        const testState = {...initialSurveyAndProgramDataState};
+        const testState = mockSurveyAndProgramState();
         mutations.ANCError(testState, {payload: "Some error"});
         expect(testState.ancError).toBe("Some error");
     });
 
     it("is complete once survey file is present", () => {
-        const testStore:  Module<SurveyAndProgramDataState, RootState> = {
-            state: {...initialSurveyAndProgramDataState},
+        const testStore: Module<SurveyAndProgramDataState, RootState> = {
+            state: mockSurveyAndProgramState(),
             getters: surveyAndProgramGetters
         };
         const testState = testStore.state as SurveyAndProgramDataState;
@@ -81,7 +78,7 @@ describe("Survey and programme mutations", () => {
     });
 
     it("sets ready state", () => {
-        const testState = {...initialSurveyAndProgramDataState};
+        const testState = mockSurveyAndProgramState();
         mutations.Ready(testState);
         expect(testState.ready).toBe(true);
     });


### PR DESCRIPTION
This moves over all intial data states to be functions rather than objects, so that we always get a fresh copy rather than shallow cloning.

Also adds some logic to the root mutations tests to make them a bit more robust, as that's where I first discovered this bug.

Many of the modules aren't currently vulnerable to this bug because their states are shallow objects, but I've moved over everything to this new pattern for consistency.
