### PR TITLE
mrc-721 preliminary PR - make modal more flexible

### DIFF
--- a/src/app/static/src/app/components/Modal.vue
+++ b/src/app/static/src/app/components/Modal.vue
@@ -7,10 +7,8 @@
                     <div class="modal-body">
                         <slot></slot>
                     </div>
-                    <div v-if="okButton" class="modal-footer">
-                        <button type="button" class="btn btn-red" data-dismiss="modal" aria-label="Close" @click="$emit('ok')">
-                            OK
-                        </button>
+                    <div class="modal-footer" v-if="$slots['footer']">
+                        <slot name="footer"></slot>
                     </div>
                 </div>
             </div>
@@ -22,7 +20,7 @@
 
     export default Vue.extend({
         name: "Modal",
-        props: ["open", "okButton"],
+        props: ["open"],
         computed: {
             style: function () {
                 return {display: this.open ? "block" : "none"}

--- a/src/app/static/src/app/components/UserHeader.vue
+++ b/src/app/static/src/app/components/UserHeader.vue
@@ -26,10 +26,19 @@
                 <a href="/logout">Logout</a>
             </div>
         </nav>
-        <modal :open="hasError" :okButton="true" @ok="clearLoadError">
+        <modal :open="hasError">
             <h4>Load Error</h4>
             <p>Failed to load state.</p>
             <p>{{loadError}}</p>
+            <template v-slot:footer>
+                <button type="button"
+                        class="btn btn-red"
+                        data-dismiss="modal"
+                        aria-label="Close"
+                        @click="clearLoadError">
+                    OK
+                </button>
+            </template>
         </modal>
     </header>
 </template>

--- a/src/app/static/src/app/components/modelRun/ModelRun.vue
+++ b/src/app/static/src/app/components/modelRun/ModelRun.vue
@@ -7,7 +7,7 @@
         <h4 v-if="success" class="mt-3" id="model-run-complete">Model run complete
             <tick color="#e31837" width="20px"></tick>
         </h4>
-        <modal :open="running" :okButton="false">
+        <modal :open="running">
             <h4>Running model</h4>
         </modal>
     </div>

--- a/src/app/static/src/tests/components/modal.test.ts
+++ b/src/app/static/src/tests/components/modal.test.ts
@@ -40,34 +40,32 @@ describe("modal", () => {
         expect(wrapper.find(".modal-body").text()).toBe("TEST");
     });
 
-    it ("does not include button if okButton is false", () => {
+    it ("does not include footer if footer slot is missing", () => {
         const wrapper = shallowMount(Modal, {
             propsData: {
-                open: true,
-                okButton: false
+                open: true
             },
             slots: {
                 default: "TEST"
             }
         });
 
-        expect(wrapper.findAll("button").length).toBe(0);
+        expect(wrapper.findAll(".modal-footer").length).toBe(0);
     });
 
-    it ("okButton emits event when clicked", () => {
+    it ("includes footer slot if provided", () => {
         const wrapper = shallowMount(Modal, {
             propsData: {
-                open: true,
-                okButton: true
+                open: true
             },
             slots: {
-                default: "TEST"
+                default: "TEST",
+                footer: "test-footer"
             }
         });
 
-        const okButton = wrapper.find("button");
-        okButton.trigger("click");
-        expect(wrapper.emitted("ok").length).toEqual(1);
+        expect(wrapper.findAll(".modal-footer").length).toBe(1);
+        expect(wrapper.find(".modal-footer").text()).toBe("test-footer");
     });
 
 });

--- a/src/app/static/src/tests/components/userHeader.test.ts
+++ b/src/app/static/src/tests/components/userHeader.test.ts
@@ -1,4 +1,4 @@
-import {shallowMount} from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import UserHeader from "../../app/components/UserHeader.vue";
 import Vuex from "vuex";
 import {
@@ -208,6 +208,30 @@ describe("user header", () => {
         const modal = wrapper.find(Modal);
         expect(modal.attributes("open")).toEqual("true");
         expect(modal.text()).toContain("test error");
-    })
+    });
+
+
+    it("modal can be dismissed", () => {
+        const clearErrorMock = jest.fn();
+        const wrapper = mount(UserHeader,
+            {
+                store: createStore({
+                    load: {
+                        namespaced: true,
+                        state: mockLoadState({
+                            loadingState: LoadingState.LoadFailed,
+                            loadError: "test error"
+                        }),
+                        actions: {
+                            clearLoadState: clearErrorMock
+                        }
+                    }
+                })
+            });
+
+        const modal = wrapper.find(Modal);
+        modal.find(".btn").trigger("click");
+        expect(clearErrorMock.mock.calls.length).toBe(1);
+    });
 
 });


### PR DESCRIPTION
This just makes the existing modal component a bit more flexible, by changing the "ok button" to a footer slot. This is so we can re-use it in the confirmation of resetting data modal which will have a different footer with 2 buttons, one to continue and one to cancel.