### PR TITLE
mrc-721 confirm editing files

### DIFF
--- a/src/app/static/src/app/components/ResetConfirmation.vue
+++ b/src/app/static/src/app/components/ResetConfirmation.vue
@@ -1,0 +1,53 @@
+<template>
+    <modal :open="open">
+        <h4>Have you saved your work?</h4>
+        <p>Changing this will result in {{formattedSteps}} being reset.
+            You may want to save your work before continuing.</p>
+        <template v-slot:footer>
+            <button type="button"
+                    class="btn btn-white"
+                    @click="continueEditing">
+                I understand and I want to keep editing
+            </button>
+            <button type="button"
+                    class="btn btn-red"
+                    @click="cancelEditing">
+                Cancel editing so I can save my work
+            </button>
+        </template>
+    </modal>
+</template>
+
+<script lang="ts">
+    import Vue from "vue";
+    import Modal from "./Modal.vue";
+    import {mapGetterByName} from "../utils";
+    import {StepDescription} from "../store/stepper/stepper";
+
+    export default Vue.extend<{}, {}, any, any>({
+        props: ["open", "continueEditing", "cancelEditing"],
+        computed: {
+            laterCompleteSteps: mapGetterByName("stepper", "laterCompleteSteps"),
+            formattedSteps() {
+                const steps = this.laterCompleteSteps;
+                if (steps.length == 0) {
+                    // in practice this will never happen
+                    return "no steps"
+                }
+                if (steps.length == 1) {
+                    return "step " + formatStep(steps[0])
+                } else {
+                    return "steps " + steps.slice(0, steps.length - 1)
+                        .map(formatStep)
+                        .join(", ") + ", and " + formatStep(steps[steps.length - 1])
+                }
+            }
+        },
+        components: {Modal}
+    });
+
+    const formatStep = (step: StepDescription) => {
+        return `${step.number} (${step.text})`
+    };
+
+</script>

--- a/src/app/static/src/app/components/ResetConfirmation.vue
+++ b/src/app/static/src/app/components/ResetConfirmation.vue
@@ -1,8 +1,11 @@
 <template>
     <modal :open="open">
         <h4>Have you saved your work?</h4>
-        <p>Changing this will result in {{formattedSteps}} being reset.
-            You may want to save your work before continuing.</p>
+        <p>Changing this will result in the following steps being discarded:</p>
+        <ul>
+            <li v-for="step in formattedSteps">{{step}}</li>
+        </ul>
+        <p>You may want to save your work before continuing.</p>
         <template v-slot:footer>
             <button type="button"
                     class="btn btn-white"
@@ -24,30 +27,30 @@
     import {mapGetterByName} from "../utils";
     import {StepDescription} from "../store/stepper/stepper";
 
-    export default Vue.extend<{}, {}, any, any>({
+    interface Computed {
+        laterCompleteSteps: StepDescription[]
+        formattedSteps: string[]
+    }
+
+    interface Props {
+        open: boolean
+        continueEditing: boolean
+        cancelEditing: boolean
+    }
+
+    export default Vue.extend<{}, {}, Computed, any>({
         props: ["open", "continueEditing", "cancelEditing"],
         computed: {
             laterCompleteSteps: mapGetterByName("stepper", "laterCompleteSteps"),
             formattedSteps() {
-                const steps = this.laterCompleteSteps;
-                if (steps.length == 0) {
-                    // in practice this will never happen
-                    return "no steps"
-                }
-                if (steps.length == 1) {
-                    return "step " + formatStep(steps[0])
-                } else {
-                    return "steps " + steps.slice(0, steps.length - 1)
-                        .map(formatStep)
-                        .join(", ") + ", and " + formatStep(steps[steps.length - 1])
-                }
+                return this.laterCompleteSteps.map(formatStep)
             }
         },
         components: {Modal}
     });
 
     const formatStep = (step: StepDescription) => {
-        return `${step.number} (${step.text})`
+        return `Step ${step.number}: ${step.text}`
     };
 
 </script>

--- a/src/app/static/src/app/components/ResetConfirmation.vue
+++ b/src/app/static/src/app/components/ResetConfirmation.vue
@@ -7,7 +7,7 @@
             <button type="button"
                     class="btn btn-white"
                     @click="continueEditing">
-                I understand and I want to keep editing
+                Discard these steps and keep editing
             </button>
             <button type="button"
                     class="btn btn-red"

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -1,10 +1,12 @@
 import {RootState} from "../../root";
 import {Getter, GetterTree} from "vuex";
-import {StepperState} from "./stepper";
+import {StepDescription, StepperState} from "./stepper";
 
 interface StepperGetters {
     ready: Getter<StepperState, RootState>,
     complete: Getter<StepperState, RootState>
+    laterCompleteSteps: Getter<StepperState, RootState>
+    editsRequireConfirmation: Getter<StepperState, RootState>
 }
 
 export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
@@ -20,5 +22,12 @@ export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
             5: rootGetters['modelRun/complete'],
             6: false
         }
+    },
+    laterCompleteSteps: (state: StepperState, getters: any) => {
+        const activeStep = state.activeStep;
+        return state.steps.filter((s: StepDescription) => s.number > activeStep && getters.complete[s.number]);
+    },
+    editsRequireConfirmation: (state: StepperState, getters: any) => {
+        return getters.laterCompleteSteps.length > 0;
     }
 };

--- a/src/app/static/src/tests/components/fileUploadWithEditConfirmation.test.ts
+++ b/src/app/static/src/tests/components/fileUploadWithEditConfirmation.test.ts
@@ -1,0 +1,142 @@
+import Vuex from "vuex";
+import Vue from "vue";
+import {mount, Slots, Wrapper} from '@vue/test-utils';
+import FileUpload from "../../app/components/FileUpload.vue";
+import ResetConfirmation from "../../app/components/ResetConfirmation.vue";
+import {mockFile} from "../mocks";
+
+Vue.use(Vuex);
+
+describe("File upload component", () => {
+
+    const mockGetters = {
+        editsRequireConfirmation: () => true,
+        laterCompleteSteps: () => [{number: 4, text: "Run model"}]
+    };
+
+    const createStore = () => new Vuex.Store({
+        modules: {
+            stepper: {
+                namespaced: true,
+                getters: mockGetters
+            }
+        }
+    });
+
+    const createSut = (props?: any, slots?: Slots) => {
+        return mount(FileUpload, {
+            store: createStore(),
+            propsData: {
+                error: "",
+                label: "",
+                valid: true,
+                upload: jest.fn(),
+                deleteFile: jest.fn(),
+                name: "pjnz",
+                accept: "csv",
+                ...props
+            },
+            slots: slots
+        });
+    };
+
+    const testFile = mockFile("TEST FILE NAME", "TEST CONTENTS");
+
+    function uploadConfirmationModal(wrapper: Wrapper<FileUpload>) {
+        return wrapper.findAll(ResetConfirmation).at(0)
+    }
+
+    function deleteConfirmationModal(wrapper: Wrapper<FileUpload>) {
+        return wrapper.findAll(ResetConfirmation).at(1)
+    }
+
+    it("opens confirmation modal when remove is clicked", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            valid: true,
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(true);
+    });
+
+    it("deletes file if user confirms edit", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            valid: true,
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-white").trigger("click");
+        expect(removeHandler.mock.calls.length).toBe(1);
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
+    });
+
+    it("does not delete file if user cancels edit", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            valid: true,
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-red").trigger("click");
+        expect(removeHandler.mock.calls.length).toBe(0);
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
+    });
+
+    it("opens confirmation modal when new file is selected", () => {
+        const wrapper = createSut();
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+        (wrapper.vm as any).handleFileSelect();
+        expect(uploadConfirmationModal(wrapper).props("open")).toBe(true);
+    });
+
+    it("uploads file if user confirms edit", (done) => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        (wrapper.vm as any).handleFileSelect();
+        uploadConfirmationModal(wrapper).find(".btn-white").trigger("click");
+
+        setTimeout(() => {
+            expect(uploader.mock.calls.length).toBe(1);
+            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
+            done();
+        });
+    });
+
+    it("does not upload file if user cancels edit", (done) => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        (wrapper.vm as any).handleFileSelect();
+        uploadConfirmationModal(wrapper).find(".btn-red").trigger("click");
+
+        setTimeout(() => {
+            expect(uploader.mock.calls.length).toBe(0);
+            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
+            done();
+        });
+    });
+
+});

--- a/src/app/static/src/tests/components/resetConfirmation.test.ts
+++ b/src/app/static/src/tests/components/resetConfirmation.test.ts
@@ -1,0 +1,50 @@
+import {shallowMount} from "@vue/test-utils";
+import ResetConfirmation from "../../app/components/ResetConfirmation.vue";
+import Vuex from "vuex";
+import Vue from "vue";
+
+Vue.use(Vuex);
+
+const createStore = (mockGetters: any) => new Vuex.Store({
+    modules: {
+        stepper: {
+            namespaced: true,
+            getters: mockGetters
+        }
+    }
+});
+
+describe("Reset confirmation modal", () => {
+
+
+    it("can deal with no later complete steps", () => {
+        // even though in practice it should never be opened with no steps to be reset
+        const mockGetters = {
+            laterCompleteSteps: () => []
+        };
+        const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
+        expect(rendered.find("p").text())
+            .toContain("Changing this will result in no steps being reset.");
+    });
+
+    it("returns single later complete step", () => {
+        const mockGetters = {
+            laterCompleteSteps: () => [{number: 2, text: "Upload survey and programme data"}]
+        };
+        const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
+        expect(rendered.find("p").text())
+            .toContain("Changing this will result in step 2 (Upload survey and programme data) being reset.");
+    });
+
+    it("returns multiple later complete steps", () => {
+        const mockGetters = {
+            laterCompleteSteps: () => [{number: 2, text: "Upload survey and programme data"},
+                {number: 3, text: "Model options"},
+                {number: 4, text: "Run model"}]
+        };
+        const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
+        expect(rendered.find("p").text())
+            .toContain("Changing this will result in steps 2 (Upload survey and programme data), 3 (Model options), and 4 (Run model)");
+    });
+
+});

--- a/src/app/static/src/tests/components/resetConfirmation.test.ts
+++ b/src/app/static/src/tests/components/resetConfirmation.test.ts
@@ -16,27 +16,7 @@ const createStore = (mockGetters: any) => new Vuex.Store({
 
 describe("Reset confirmation modal", () => {
 
-
-    it("can deal with no later complete steps", () => {
-        // even though in practice it should never be opened with no steps to be reset
-        const mockGetters = {
-            laterCompleteSteps: () => []
-        };
-        const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
-        expect(rendered.find("p").text())
-            .toContain("Changing this will result in no steps being reset.");
-    });
-
-    it("returns single later complete step", () => {
-        const mockGetters = {
-            laterCompleteSteps: () => [{number: 2, text: "Upload survey and programme data"}]
-        };
-        const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
-        expect(rendered.find("p").text())
-            .toContain("Changing this will result in step 2 (Upload survey and programme data) being reset.");
-    });
-
-    it("returns multiple later complete steps", () => {
+    it("returns later complete steps", () => {
         const mockGetters = {
             laterCompleteSteps: () => [{number: 2, text: "Upload survey and programme data"},
                 {number: 3, text: "Model options"},
@@ -44,7 +24,13 @@ describe("Reset confirmation modal", () => {
         };
         const rendered = shallowMount(ResetConfirmation, {store: createStore(mockGetters)});
         expect(rendered.find("p").text())
-            .toContain("Changing this will result in steps 2 (Upload survey and programme data), 3 (Model options), and 4 (Run model)");
+            .toContain("Changing this will result in the following steps being discarded:");
+        const steps = rendered.findAll("li");
+        expect(steps.length).toBe(3);
+        expect(steps.at(0).text()).toBe("Step 2: Upload survey and programme data");
+        expect(steps.at(1).text()).toBe("Step 3: Model options");
+        expect(steps.at(2).text()).toBe("Step 4: Run model");
+
     });
 
 });

--- a/src/app/static/src/tests/stepper/getters.test.ts
+++ b/src/app/static/src/tests/stepper/getters.test.ts
@@ -1,0 +1,38 @@
+import {mockStepperState} from "../mocks";
+import {getters} from "../../app/store/stepper/getters";
+
+describe("stepper getters", () => {
+
+    const state = mockStepperState({
+        activeStep: 1
+    });
+
+    const testGetters = {
+        complete: {
+            1: true,
+            2: true,
+            3: false,
+            4: false,
+            5: false,
+            6: false
+        }
+    };
+
+    it("returns later complete steps", () => {
+        const steps = getters.laterCompleteSteps(state, testGetters, null as any, null as any);
+        expect(steps.length).toBe(1);
+        expect(steps[0].number).toBe(2);
+    });
+
+    it("edits require confirmation if there are later complete steps", () => {
+        const localTestGetters = {...testGetters, laterCompleteSteps: [{}]};
+        const result = getters.editsRequireConfirmation(state, localTestGetters, null as any, null as any);
+        expect(result).toBe(true);
+    });
+
+    it("edits do not require confirmation if there are no later complete steps", () => {
+        const localTestGetters = {...testGetters, laterCompleteSteps: []};
+        const result = getters.editsRequireConfirmation(state, localTestGetters, null as any, null as any);
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR adds the confirmation modal for the file uploads. See what you think of the modal content itself, as well as the code. Could format the steps being reset as a bullet pointed list perhaps.

 I've just got 2 call to actions - cancel or continue, rather than adding any save or download buttons into the modal. My thinking was that:
a) would be too many calls to action
b) context is important for meaning and it might be confusing/ambiguous what the various save/download buttons mean if they appear outside of their normal context

Contains commits from https://github.com/mrc-ide/hint/pull/185 so please merge that one first.