### PR TITLE
mrc-750 Do not clear local storage until submit login form

### DIFF
--- a/src/app/templates/login.ftl
+++ b/src/app/templates/login.ftl
@@ -8,12 +8,13 @@
     <script>
         function validate(event) {
             const form = document.getElementById("login-form");
-            if (!form.checkValidity()) {
+            if (form.checkValidity()) {
+                localStorage.clear();
+            } else {
                 event.preventDefault();
                 form.classList.add('was-validated');
             }
         }
-        localStorage.clear();
     </script>
 </head>
 <body>


### PR DESCRIPTION
Fixes bug where hitting back (to login page) then forward after uploading PJNZ appears to save baseline state, but then Continue link is not enabled when remaining baseline files are uploaded. 

This was because the login page was clearing local storage on page load. This meant that state saved to local storage, including the plotting metadata was now null. However the baseline files were being fetched and displayed when the page was reloaded, because the session was still valid. Both baseline and metadata modules need to be complete before the stepper would continue. Baseline was, metadata wasn't. 

Fixed by waiting until form is submitted before clearing local storage. This is also when the session is cleared and replaced with a new one. 

Took a while to figure this one out!!