### PR TITLE
mrc-785 Show session expired message in front end

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -33,7 +33,7 @@ class MvcConfig(val config: Config) : WebMvcConfigurer {
         registry.addInterceptor(SecurityInterceptor(config, "FormClient"))
                 .addPathPatterns("/")
 
-        //Ajax endpoints - secure, but do not redirect with login form client
+        //Ajax endpoints - secure, but do not redirect with login form client - return a 401
         registry.addInterceptor(SecurityInterceptor(config, ""))
                 .addPathPatterns("/**")
                 .excludePathPatterns("/", "/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -29,9 +29,14 @@ class MvcConfig(val config: Config) : WebMvcConfigurer {
     }
 
     override fun addInterceptors(registry: InterceptorRegistry) {
+        //Root url - redirect to login if required
         registry.addInterceptor(SecurityInterceptor(config, "FormClient"))
+                .addPathPatterns("/")
+
+        //'API' endpoints - secure, but do not redirect with login form client
+        registry.addInterceptor(SecurityInterceptor(config, ""))
                 .addPathPatterns("/**")
-                .excludePathPatterns("/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")
+                .excludePathPatterns("/", "/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")
     }
 
     override fun configureAsyncSupport(configurer: AsyncSupportConfigurer) {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -33,7 +33,7 @@ class MvcConfig(val config: Config) : WebMvcConfigurer {
         registry.addInterceptor(SecurityInterceptor(config, "FormClient"))
                 .addPathPatterns("/")
 
-        //'API' endpoints - secure, but do not redirect with login form client
+        //Ajax endpoints - secure, but do not redirect with login form client
         registry.addInterceptor(SecurityInterceptor(config, ""))
                 .addPathPatterns("/**")
                 .excludePathPatterns("/", "/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -36,7 +36,8 @@ class MvcConfig(val config: Config) : WebMvcConfigurer {
         //Ajax endpoints - secure, but do not redirect with login form client - return a 401
         registry.addInterceptor(SecurityInterceptor(config, ""))
                 .addPathPatterns("/**")
-                .excludePathPatterns("/", "/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**")
+                .excludePathPatterns("/", "/login", "/login/", "/password/**", "/callback", "/callback/", "/public/**",
+                        "/logout", "/logout/")
     }
 
     override fun configureAsyncSupport(configurer: AsyncSupportConfigurer) {

--- a/src/app/src/main/resources/application.properties
+++ b/src/app/src/main/resources/application.properties
@@ -14,5 +14,3 @@ server.compression.enabled=true
 server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
 # Compress the response only if the response size is at least 1KB
 server.compression.min-response-size=1024
-
-server.servlet.session.timeout=60s

--- a/src/app/src/main/resources/application.properties
+++ b/src/app/src/main/resources/application.properties
@@ -14,3 +14,5 @@ server.compression.enabled=true
 server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
 # Compress the response only if the response size is at least 1KB
 server.compression.min-response-size=1024
+
+server.servlet.session.timeout=60s

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
@@ -25,8 +25,7 @@ class DownloadTests : SecureIntegrationTests() {
         do {
             Thread.sleep(500)
             val statusResponse = testRestTemplate.getForEntity<String>("/model/status/$id")
-            print(statusResponse.body)
-        } while (statusResponse.body!!.contains("\"status\":\"RUNNING\""))
+        } while (statusResponse.body != null && statusResponse.body!!.contains("\"status\":\"RUNNING\""))
 
         return id
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
@@ -48,11 +48,11 @@ class HintApplicationTests : SecureIntegrationTests() {
     @EnumSource(IsAuthorized::class)
     fun `only authorized users can access REST endpoints`(isAuthorized: IsAuthorized) {
         val entity = testRestTemplate.getForEntity<String>("/baseline/pjnz/")
-        assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
         if (isAuthorized == IsAuthorized.TRUE) {
+            assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(entity.body!!).isEqualTo("{\"errors\":[],\"status\":\"success\",\"data\":null}")
         } else {
-            assertThat(entity.body!!).contains("<title>Login</title>")
+            assertThat(entity.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
         }
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/IntegrationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/IntegrationTests.kt
@@ -76,14 +76,7 @@ abstract class SecureIntegrationTests : CleanDatabaseTests() {
 
             }
             IsAuthorized.FALSE -> {
-                if (responseEntity.statusCode == HttpStatus.FOUND) {
-                    // obtains when request is a POST
-                    assertLoginLocation(responseEntity)
-                } else {
-                    // obtains when request is a GET
-                    assertSuccess(responseEntity)
-                    Assertions.assertThat(responseEntity.body!!).contains("<title>Login</title>")
-                }
+                assertUnauthorized(responseEntity)
             }
         }
     }
@@ -96,15 +89,13 @@ abstract class SecureIntegrationTests : CleanDatabaseTests() {
                 assertSuccess(responseEntity)
             }
             IsAuthorized.FALSE -> {
-                if (responseEntity.statusCode == HttpStatus.FOUND) {
-                    // obtains when request is a POST
-                    assertLoginLocation(responseEntity)
-                } else {
-                    // obtains when request is a GET
-                    assertSuccess(responseEntity)
-                }
+               assertUnauthorized(responseEntity)
             }
         }
+    }
+
+    fun <T> assertUnauthorized(responseEntity: ResponseEntity<T>) {
+        Assertions.assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
     }
 
     fun <T> assertSuccess(responseEntity: ResponseEntity<T>) {
@@ -129,14 +120,7 @@ abstract class SecureIntegrationTests : CleanDatabaseTests() {
                 JSONValidator().validateError(responseEntity.body!!, errorCode, errorDetail, errorStartsWith)
             }
             IsAuthorized.FALSE -> {
-                if (responseEntity.statusCode == HttpStatus.FOUND) {
-                    // it's a POST
-                    Assertions.assertThat(responseEntity.headers.location!!.toString()).isEqualTo("/login")
-                }
-                else {
-                    // it's a GET
-                    Assertions.assertThat(responseEntity.body!!).contains("<title>Login</title>")
-                }
+                assertUnauthorized(responseEntity)
             }
         }
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SecurityConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SecurityConfigTests.kt
@@ -1,9 +1,6 @@
 package org.imperial.mrc.hint.unit.security
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.*
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.MvcConfig
 import org.junit.jupiter.api.Test
@@ -27,7 +24,7 @@ class SecurityConfigTests {
             on { addInterceptor(any()) } doReturn mockInterceptor
         }
         sut.addInterceptors(interceptors)
-        verify(interceptors).addInterceptor(any())
+        verify(interceptors, times(2)).addInterceptor(any())
     }
 
 }

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -94,7 +94,18 @@ export class APIService<S extends string, E extends string> implements API<S, E>
         if (this._ignoreErrors) {
             return
         }
-        const failure = e.response && e.response.data;
+
+        let failure = e.response && e.response.data;
+        if (!failure && e.response && e.response.status == 401) {
+            failure = {
+                status: "failure",
+                errors: [{
+                    error: "Your session has expired. Please refresh the page and log in again. You can save your work before refreshing."}
+                ],
+                data: {}
+            }
+        }
+
         if (!isHINTResponse(failure)) {
             this._commitError("Could not parse API response. Please contact support.");
         } else if (this._onError) {

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -116,6 +116,28 @@ describe("ApiService", () => {
         expect(committedPayload).toBe("OTHER_ERROR");
     });
 
+    it ("commits a default error message if an empty 401 response is received", async () => {
+
+        mockAxios.onGet("/baseline/")
+            .reply(401, null)
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+
+        const commit = ({type, payload}: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+
+        await api(commit as any)
+            .withError("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(committedPayload).toBe(
+            "Your session has expired. Please refresh the page and log in again. You can save your work before refreshing.");
+    });
+
     it("commits the success response with the specified type", async () => {
 
         mockAxios.onGet(`/baseline/`)


### PR DESCRIPTION
This is a bit of a hack as I've put the actual error message into the front end rather than json response from the backend, where it was relatively simple to return an empty 401 response rather than redirecting, but unless I'm missing something really obvious, tricky to put in a JSON response entity. Theoretically could override SecurityInterceptor and hook into the HttpServletResponse object (same one the Filter uses), but I was struggling to get that to honour the new content in the response emitted through the response wrapper (although it would get logged). The message is kind of specific to the front end anyway... 

You can test this manually without having to hang around for an hour by adding "server.servlet.session.timeout=60s" to application.properties. 