### PR TITLE
Add report bug link to header

### DIFF
--- a/src/app/static/src/app/components/UserHeader.vue
+++ b/src/app/static/src/app/components/UserHeader.vue
@@ -23,7 +23,7 @@
                         <input type="file" style="display: none;" ref="loadFile" v-on:change="load" accept=".json">
                     </div>
                 </div>
-                <a href="https://forms.gle/QxCT1b4ScLqKPg6a7" target="_blank" style="margin-right: 10px">Report a bug</a>
+                <a href="https://forms.gle/QxCT1b4ScLqKPg6a7" target="_blank" class="pr-2 mr-2 border-right">Report a bug</a>
                 <a href="/logout">Logout</a>
             </div>
         </nav>

--- a/src/app/static/src/app/components/UserHeader.vue
+++ b/src/app/static/src/app/components/UserHeader.vue
@@ -23,6 +23,7 @@
                         <input type="file" style="display: none;" ref="loadFile" v-on:change="load" accept=".json">
                     </div>
                 </div>
+                <a href="https://forms.gle/QxCT1b4ScLqKPg6a7" target="_blank" style="margin-right: 10px">Report a bug</a>
                 <a href="/logout">Logout</a>
             </div>
         </nav>

--- a/src/app/static/src/tests/components/userHeader.test.ts
+++ b/src/app/static/src/tests/components/userHeader.test.ts
@@ -234,4 +234,11 @@ describe("user header", () => {
         expect(clearErrorMock.mock.calls.length).toBe(1);
     });
 
+    it("contains bug report link", () => {
+        const wrapper = shallowMount(UserHeader,
+            {
+                store: createStore()
+            });
+        expect(wrapper.find("a[href='https://forms.gle/QxCT1b4ScLqKPg6a7']")).toBeDefined();
+    });
 });


### PR DESCRIPTION
This adds a link which opens in another tab

I put some margin in the vue file on the a tag - I can move that to a css class if that is better practice? Not sure what should be done here.

One question - I am seeing some styling issues on the stepper see
![image](https://user-images.githubusercontent.com/39248272/70129688-240d6b80-1677-11ea-97a4-44332374360f.png)

Not sure whether that is related to my change or it is some local development environment issue.