### PR TITLE
mrc-1179 make error message more manageable

### DIFF
--- a/src/app/static/src/app/components/Errors.vue
+++ b/src/app/static/src/app/components/Errors.vue
@@ -45,7 +45,7 @@
         },
         computed: {
             ...mapStateProps<ErrorsState, keyof ComputedState>(namespace, {
-                errors: state => state.errors
+                errors: state => Array.from(new Set(state.errors))
             }),
             hasErrors: function() { return this.errors.length > 0}
         },

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -26,11 +26,11 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             .withError(BaselineMutation.PJNZUploadError)
             .freezeResponse()
             .postAndReturn<PjnzResponse>("/baseline/pjnz/", formData)
-            .then(() => {
-                if (!state.baselineError && state.iso3) {
+            .then((response) => {
+                if (response) {
                     dispatch('metadata/getPlottingMetadata', state.iso3, {root: true});
+                    dispatch('validate');
                 }
-                dispatch('validate');
                 dispatch("surveyAndProgram/deleteAll", {}, {root: true});
             });
     },
@@ -42,8 +42,10 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             .withError(BaselineMutation.ShapeUploadError)
             .freezeResponse()
             .postAndReturn<ShapeResponse>("/baseline/shape/", formData)
-            .then(() => {
-                dispatch('validate');
+            .then((response) => {
+                if (response) {
+                    dispatch('validate');
+                }
                 dispatch("surveyAndProgram/deleteAll", {}, {root: true});
             });
     },
@@ -55,14 +57,17 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             .withError(BaselineMutation.PopulationUploadError)
             .freezeResponse()
             .postAndReturn<PopulationResponse>("/baseline/population/", formData)
-            .then(() => {
-                dispatch('validate');
+            .then((response) => {
+                if (response) {
+                    dispatch('validate');
+                }
                 dispatch("surveyAndProgram/deleteAll", {}, {root: true});
             });
     },
 
     async deletePJNZ({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
+            .ignoreErrors()
             .delete("/baseline/pjnz/")
             .then(() => {
                 commit({type: BaselineMutation.PJNZUpdated, payload: null});
@@ -72,6 +77,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
     async deleteShape({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
+            .ignoreErrors()
             .delete("/baseline/shape/")
             .then(() => {
                 commit({type: BaselineMutation.ShapeUpdated, payload: null});
@@ -81,6 +87,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
     async deletePopulation({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
+            .ignoreErrors()
             .delete("/baseline/population/")
             .then(() => {
                 commit({type: BaselineMutation.PopulationUpdated, payload: null});

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -67,31 +67,34 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
     async deletePJNZ({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
-            .ignoreErrors()
             .delete("/baseline/pjnz/")
-            .then(() => {
-                commit({type: BaselineMutation.PJNZUpdated, payload: null});
-                dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+            .then((response) => {
+                if (response) {
+                    commit({type: BaselineMutation.PJNZUpdated, payload: null});
+                    dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+                }
             });
     },
 
     async deleteShape({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
-            .ignoreErrors()
             .delete("/baseline/shape/")
-            .then(() => {
-                commit({type: BaselineMutation.ShapeUpdated, payload: null});
-                dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+            .then((response) => {
+                if (response) {
+                    commit({type: BaselineMutation.ShapeUpdated, payload: null});
+                    dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+                }
             });
     },
 
     async deletePopulation({commit, dispatch}) {
         await api<BaselineMutation, BaselineMutation>(commit)
-            .ignoreErrors()
             .delete("/baseline/population/")
-            .then(() => {
-                commit({type: BaselineMutation.PopulationUpdated, payload: null});
-                dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+            .then((response) => {
+                if (response) {
+                    commit({type: BaselineMutation.PopulationUpdated, payload: null});
+                    dispatch("surveyAndProgram/deleteAll", {}, {root: true});
+                }
             });
     },
 

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -71,7 +71,6 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteSurvey({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
-            .ignoreErrors()
             .delete("/disease/survey/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
@@ -80,7 +79,6 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteProgram({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
-            .ignoreErrors()
             .delete("/disease/programme/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
@@ -89,7 +87,6 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteANC({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
-            .ignoreErrors()
             .delete("/disease/anc/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -71,6 +71,7 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteSurvey({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+            .ignoreErrors()
             .delete("/disease/survey/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
@@ -79,6 +80,7 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteProgram({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+            .ignoreErrors()
             .delete("/disease/programme/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
@@ -87,6 +89,7 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
 
     async deleteANC({commit}) {
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+            .ignoreErrors()
             .delete("/disease/anc/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -55,7 +55,7 @@ describe("Baseline actions", () => {
         expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
     });
 
-    it("upload PJNZ does not fetch plotting metadata if error occurs", async () => {
+    it("upload PJNZ does not fetch plotting metadata or validate if error occurs", async () => {
         mockAxios.onPost(`/baseline/pjnz/`)
             .reply(400, mockFailure("test error"));
 
@@ -64,25 +64,8 @@ describe("Baseline actions", () => {
         const dispatch = jest.fn();
         await actions.uploadPJNZ({commit, state, dispatch} as any, new FormData());
 
-        expect(dispatch.mock.calls.length).toBe(2);
-
-        expect(dispatch.mock.calls[0][0]).toBe("validate");
-        expect(dispatch.mock.calls[1][0]).toBe("surveyAndProgram/deleteAll");
-    });
-
-    it("upload PJNZ does not fetch plotting metadata if iso3 not set", async () => {
-        mockAxios.onPost(`/baseline/pjnz/`)
-            .reply(400, mockFailure("test error"));
-
-        const commit = jest.fn();
-        const state = mockBaselineState({iso3: ""});
-        const dispatch = jest.fn();
-        await actions.uploadPJNZ({commit, state, dispatch} as any, new FormData());
-
-        expect(dispatch.mock.calls.length).toBe(2);
-
-        expect(dispatch.mock.calls[0][0]).toBe("validate");
-        expect(dispatch.mock.calls[1][0]).toBe("surveyAndProgram/deleteAll");
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
     });
 
     testUploadErrorCommitted("/baseline/pjnz/",

--- a/src/app/static/src/tests/components/errors.test.ts
+++ b/src/app/static/src/tests/components/errors.test.ts
@@ -39,6 +39,15 @@ describe("Errors component", () => {
         expect(wrapper.html()).toBeFalsy();
     });
 
+    it ("only renders duplicate errors once", () => {
+        const store = createStore(["Error 1", "Error 1", "New Error"]);
+        const wrapper = shallowMount(Errors, {propsData, store, localVue});
+        const paras = wrapper.findAll("p");
+        expect(paras.length).toBe(2);
+        expect(paras.at(0).text()).toBe("Error 1");
+        expect(paras.at(1).text()).toBe("New Error");
+    });
+
     it ("commits dismissAll mutation when close button pressed", () => {
         const store = createStore(["First error"]);
         const wrapper = shallowMount(Errors, {propsData, store, localVue});


### PR DESCRIPTION
* don't validate baseline files on a failed upload
* only show duplicate errors once - this avoids multiple "session has expired" messages