### PR TITLE
mrc-794  bug fix - email domains should be case insensitive

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/PasswordController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/PasswordController.kt
@@ -1,6 +1,6 @@
 package org.imperial.mrc.hint.controllers
 
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.emails.EmailManager
 import org.imperial.mrc.hint.emails.PasswordEmailTemplate
 import org.imperial.mrc.hint.exceptions.HintException
@@ -20,7 +20,7 @@ class TokenException(message: String) : HintException(message, HttpStatus.BAD_RE
 @Controller
 @Validated
 @RequestMapping("/password")
-class PasswordController(private val userRepository: UserRepository,
+class PasswordController(private val userLogic: UserLogic,
                          private val oneTimeTokenManager: OneTimeTokenManager,
                          private val emailManager: EmailManager) {
 
@@ -32,7 +32,7 @@ class PasswordController(private val userRepository: UserRepository,
     @PostMapping("/request-reset-link")
     @ResponseBody
     fun requestResetLink(@RequestParam("email") email: String): String {
-        val user = userRepository.getUser(email)
+        val user = userLogic.getUser(email)
 
         if (user != null) {
             emailManager.sendPasswordEmail(email, user.username, PasswordEmailTemplate.ResetPassword())
@@ -54,7 +54,7 @@ class PasswordController(private val userRepository: UserRepository,
                           @RequestParam("password") @Size(min = 6, message = "Password must be at least 6 characters long")
                           password: String): String {
         val user = oneTimeTokenManager.validateToken(token) ?: throw TokenException("Token is not valid")
-        userRepository.updateUserPassword(user, password)
+        userLogic.updateUserPassword(user, password)
         return EmptySuccessResponse.toJsonString()
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
@@ -1,81 +1,18 @@
 package org.imperial.mrc.hint.db
 
-import org.imperial.mrc.hint.emails.EmailManager
-import org.imperial.mrc.hint.emails.PasswordEmailTemplate
-import org.imperial.mrc.hint.exceptions.UserException
 import org.jooq.DSLContext
-import org.pac4j.core.profile.CommonProfile
-import org.pac4j.sql.profile.DbProfile
-import org.pac4j.sql.profile.service.DbProfileService
 import org.springframework.stereotype.Component
-import java.security.SecureRandom
-import java.util.*
 
 interface UserRepository {
-    fun addUser(email: String, password: String?)
-    fun removeUser(email: String)
-    fun getUser(email: String): CommonProfile?
-    fun updateUserPassword(user: CommonProfile, password: String)
+    fun getAllUserNames(): List<String>
 }
 
 @Component
-class DbProfileServiceUserRepository(private val dsl: DSLContext,
-                                     private val profileService: DbProfileService,
-                                     private val emailManager: EmailManager) : UserRepository {
+class JooqUserRepository(private val dsl: DSLContext) : UserRepository {
 
-    override fun addUser(email: String, password: String?) {
-
-        if (getUser(email) != null) {
-            throw UserException("User already exists")
-        }
-
-        val profile = DbProfile()
-        profile.build(email, mapOf("username" to email))
-
-        val pw = if (password.isNullOrEmpty()) {
-            val pw = generateRandomPassword()
-            emailManager.sendPasswordEmail(email, email, PasswordEmailTemplate.CreateAccount())
-            pw
-        } else {
-            password
-        }
-        profileService.create(profile, pw)
-    }
-
-    override fun removeUser(email: String) {
-        val user = getUser(email) ?: throw UserException("User does not exist")
-        profileService.removeById(user.id)
-    }
-
-    override fun getUser(email: String): CommonProfile? {
-
-        val emailArray = email.split("@")
-        val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")
-
-        val existingEmail = dsl.select(Tables.USERS.USERNAME)
+    override fun getAllUserNames(): List<String> {
+        return dsl.select(Tables.USERS.USERNAME)
                 .from(Tables.USERS)
                 .fetchInto(String::class.java)
-                .find { caseInsensitiveDomainRegex.matches(it) }
-                ?: return null
-
-        return profileService.findById(existingEmail)
-    }
-
-    override fun updateUserPassword(user: CommonProfile, password: String) {
-        val dbUser: DbProfile = getUser(user.id) as DbProfile
-        profileService.update(dbUser, password)
-    }
-
-    companion object {
-
-        const val PASSWORD_LENGTH = 10
-
-        private fun generateRandomPassword(): String {
-            val random = SecureRandom()
-            val rnd = ByteArray(PASSWORD_LENGTH)
-            random.nextBytes(rnd)
-            return Base64.getEncoder().encodeToString(rnd)
-        }
-
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.db
 import org.imperial.mrc.hint.emails.EmailManager
 import org.imperial.mrc.hint.emails.PasswordEmailTemplate
 import org.imperial.mrc.hint.exceptions.UserException
+import org.jooq.DSLContext
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.sql.profile.DbProfile
 import org.pac4j.sql.profile.service.DbProfileService
@@ -18,10 +19,12 @@ interface UserRepository {
 }
 
 @Component
-class DbProfileServiceUserRepository(private val profileService: DbProfileService,
+class DbProfileServiceUserRepository(private val dsl: DSLContext,
+                                     private val profileService: DbProfileService,
                                      private val emailManager: EmailManager) : UserRepository {
 
     override fun addUser(email: String, password: String?) {
+
         if (getUser(email) != null) {
             throw UserException("User already exists")
         }
@@ -45,7 +48,20 @@ class DbProfileServiceUserRepository(private val profileService: DbProfileServic
     }
 
     override fun getUser(email: String): CommonProfile? {
-        return profileService.findById(email)
+
+        val emailArray = email.split("@")
+        val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")
+
+        val emails = dsl.select(Tables.USERS.USERNAME)
+                .from(Tables.USERS)
+                .fetchInto(String::class.java)
+                .filter { caseInsensitiveDomainRegex.matches(it) }
+
+        return if (emails.count() == 1) {
+            profileService.findById(emails[0])
+        } else {
+            profileService.findById(email)
+        }
     }
 
     override fun updateUserPassword(user: CommonProfile, password: String) {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
@@ -52,16 +52,13 @@ class DbProfileServiceUserRepository(private val dsl: DSLContext,
         val emailArray = email.split("@")
         val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")
 
-        val emails = dsl.select(Tables.USERS.USERNAME)
+        val existingEmail = dsl.select(Tables.USERS.USERNAME)
                 .from(Tables.USERS)
                 .fetchInto(String::class.java)
-                .filter { caseInsensitiveDomainRegex.matches(it) }
+                .find { caseInsensitiveDomainRegex.matches(it) }
+                ?: return null
 
-        return if (emails.count() == 1) {
-            profileService.findById(emails[0])
-        } else {
-            profileService.findById(email)
-        }
+        return profileService.findById(existingEmail)
     }
 
     override fun updateUserPassword(user: CommonProfile, password: String) {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
@@ -43,8 +43,8 @@ class DbProfileServiceUserRepository(private val dsl: DSLContext,
     }
 
     override fun removeUser(email: String) {
-        getUser(email) ?: throw UserException("User does not exist")
-        profileService.removeById(email)
+        val user = getUser(email) ?: throw UserException("User does not exist")
+        profileService.removeById(user.id)
     }
 
     override fun getUser(email: String): CommonProfile? {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
@@ -55,7 +55,7 @@ class DbProfileServiceUserLogic(private val userRepository: UserRepository,
 
         val emailArray = email.split("@")
         if (emailArray.count() == 1) {
-            return profileService.findById(email)
+            throw UserException("Please provide a valid email address")
         }
 
         val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
@@ -59,6 +59,7 @@ class DbProfileServiceUserLogic(private val userRepository: UserRepository,
         }
 
         val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")
+
         val username = userRepository.getAllUserNames()
                 .find { caseInsensitiveDomainRegex.matches(it) }
                 ?: return null

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logic/UserLogic.kt
@@ -1,0 +1,86 @@
+package org.imperial.mrc.hint.logic
+
+import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.emails.EmailManager
+import org.imperial.mrc.hint.emails.PasswordEmailTemplate
+import org.imperial.mrc.hint.exceptions.UserException
+import org.pac4j.core.profile.CommonProfile
+import org.pac4j.sql.profile.DbProfile
+import org.pac4j.sql.profile.service.DbProfileService
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.util.*
+
+interface UserLogic {
+    fun addUser(email: String, password: String?)
+    fun removeUser(email: String)
+    fun getUser(email: String): CommonProfile?
+    fun updateUserPassword(user: CommonProfile, password: String)
+}
+
+@Component
+class DbProfileServiceUserLogic(private val userRepository: UserRepository,
+                                private val profileService: DbProfileService,
+                                private val emailManager: EmailManager) : UserLogic {
+
+    override fun addUser(email: String, password: String?) {
+
+        if (!email.contains("@")) {
+            throw UserException("Please provide a valid email address")
+        }
+
+        if (getUser(email) != null) {
+            throw UserException("User already exists")
+        }
+
+        val profile = DbProfile()
+        profile.build(email, mapOf("username" to email))
+
+        val pw = if (password.isNullOrEmpty()) {
+            val pw = generateRandomPassword()
+            emailManager.sendPasswordEmail(email, email, PasswordEmailTemplate.CreateAccount())
+            pw
+        } else {
+            password
+        }
+        profileService.create(profile, pw)
+    }
+
+    override fun removeUser(email: String) {
+        val user = getUser(email) ?: throw UserException("User does not exist")
+        profileService.removeById(user.id)
+    }
+
+    override fun getUser(email: String): CommonProfile? {
+
+        val emailArray = email.split("@")
+        if (emailArray.count() == 1) {
+            return profileService.findById(email)
+        }
+
+        val caseInsensitiveDomainRegex = Regex("(?-i)${emailArray[0]}@(?i)${emailArray[1]}")
+        val username = userRepository.getAllUserNames()
+                .find { caseInsensitiveDomainRegex.matches(it) }
+                ?: return null
+
+        return profileService.findById(username)
+    }
+
+    override fun updateUserPassword(user: CommonProfile, password: String) {
+        val dbUser: DbProfile = getUser(user.id) as DbProfile
+        profileService.update(dbUser, password)
+    }
+
+    companion object {
+
+        const val PASSWORD_LENGTH = 10
+
+        private fun generateRandomPassword(): String {
+            val random = SecureRandom()
+            val rnd = ByteArray(PASSWORD_LENGTH)
+            random.nextBytes(rnd)
+            return Base64.getEncoder().encodeToString(rnd)
+        }
+
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/SessionRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/SessionRepositoryTests.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.imperial.mrc.hint.FileType
 import org.imperial.mrc.hint.db.SessionRepository
 import org.imperial.mrc.hint.db.Tables.SESSION_FILE
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.db.tables.UserSession.USER_SESSION
 import org.imperial.mrc.hint.exceptions.SessionException
 import org.imperial.mrc.hint.models.SessionFile
@@ -25,17 +25,18 @@ class SessionRepositoryTests {
     private lateinit var sut: SessionRepository
 
     @Autowired
-    private lateinit var userRepo: UserRepository
+    private lateinit var userRepo: UserLogic
 
     @Autowired
     private lateinit var dsl: DSLContext
 
     private val sessionId = "sid"
+    private val testEmail = "test@test.com"
 
     @Test
     fun `can save session`() {
-        userRepo.addUser("email", "pw")
-        val uid = userRepo.getUser("email")!!.id
+        userRepo.addUser(testEmail, "pw")
+        val uid = userRepo.getUser(testEmail)!!.id
         sut.saveSession(sessionId, uid)
 
         val session = dsl.selectFrom(USER_SESSION)
@@ -47,8 +48,8 @@ class SessionRepositoryTests {
 
     @Test
     fun `saveSession is idempotent`() {
-        userRepo.addUser("email", "pw")
-        val uid = userRepo.getUser("email")!!.id
+        userRepo.addUser(testEmail, "pw")
+        val uid = userRepo.getUser(testEmail)!!.id
         sut.saveSession(sessionId, uid)
         sut.saveSession(sessionId, uid)
 
@@ -258,8 +259,8 @@ class SessionRepositoryTests {
     }
 
     private fun setUpSession(): String {
-        userRepo.addUser("email", "pw")
-        val uid = userRepo.getUser("email")!!.id
+        userRepo.addUser(testEmail, "pw")
+        val uid = userRepo.getUser(testEmail)!!.id
         sut.saveSession(sessionId, uid)
 
         return uid

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserLogicTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserLogicTests.kt
@@ -105,7 +105,7 @@ class UserLogicTests {
     
     @Test
     fun `throws error if trying to get user with invalid email`() {
-        Assertions.assertThatThrownBy { sut.getUser("email", "testpassword") }
+        Assertions.assertThatThrownBy { sut.getUser("email") }
                 .isInstanceOf(UserException::class.java)
                 .hasMessageContaining("Please provide a valid email address")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserLogicTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserLogicTests.kt
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
 @Transactional
-class UserRepositoryTests {
+class UserLogicTests {
     @Autowired
     private lateinit var sut: UserLogic
 
@@ -101,7 +101,13 @@ class UserRepositoryTests {
     fun `can get user with differently cased domain`() {
         sut.addUser("test@test.com", "testpassword")
         assertThat(sut.getUser("test@TEST.com")!!.username).isEqualTo(TEST_EMAIL)
-
+    }
+    
+    @Test
+    fun `throws error if trying to get user with invalid email`() {
+        Assertions.assertThatThrownBy { sut.getUser("email", "testpassword") }
+                .isInstanceOf(UserException::class.java)
+                .hasMessageContaining("Please provide a valid email address")
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -29,14 +29,14 @@ class UserRepositoryTests {
     fun `can add user`() {
         sut.addUser(TEST_EMAIL, "testpassword")
 
-        Assertions.assertThat(sut.getUser(TEST_EMAIL)).isNotNull
+        assertThat(sut.getUser(TEST_EMAIL)).isNotNull
     }
 
     @Test
     fun `can add user without password`() {
         sut.addUser(TEST_EMAIL, null)
 
-        Assertions.assertThat(sut.getUser(TEST_EMAIL)).isNotNull
+        assertThat(sut.getUser(TEST_EMAIL)).isNotNull
     }
 
     @Test
@@ -44,7 +44,15 @@ class UserRepositoryTests {
         sut.addUser(TEST_EMAIL, "testpassword")
 
         sut.removeUser(TEST_EMAIL)
-        Assertions.assertThat(sut.getUser(TEST_EMAIL)).isNull()
+        assertThat(sut.getUser(TEST_EMAIL)).isNull()
+    }
+
+    @Test
+    fun `can remove user with differently cased domain`() {
+        sut.addUser("test@test.com", "testpassword")
+
+        sut.removeUser("test@TEST.com")
+        assertThat(sut.getUser("test@test.com")).isNull()
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -1,6 +1,7 @@
 package org.imperial.mrc.hint.database
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.exceptions.UserException
 import org.junit.jupiter.api.Test
@@ -12,7 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.Transactional
 
 //Database should be running (via ./scripts/run-dependencies.sh)
-@ActiveProfiles(profiles=["test"])
+@ActiveProfiles(profiles = ["test"])
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
 @Transactional
@@ -25,24 +26,21 @@ class UserRepositoryTests {
     }
 
     @Test
-    fun `can add user`()
-    {
+    fun `can add user`() {
         sut.addUser(TEST_EMAIL, "testpassword")
 
         Assertions.assertThat(sut.getUser(TEST_EMAIL)).isNotNull
     }
 
     @Test
-    fun `can add user without password`()
-    {
+    fun `can add user without password`() {
         sut.addUser(TEST_EMAIL, null)
 
         Assertions.assertThat(sut.getUser(TEST_EMAIL)).isNotNull
     }
 
     @Test
-    fun `can remove user`()
-    {
+    fun `can remove user`() {
         sut.addUser(TEST_EMAIL, "testpassword")
 
         sut.removeUser(TEST_EMAIL)
@@ -50,8 +48,7 @@ class UserRepositoryTests {
     }
 
     @Test
-    fun `cannot add same user twice`()
-    {
+    fun `cannot add same user twice`() {
         sut.addUser(TEST_EMAIL, "testpassword")
 
         Assertions.assertThatThrownBy { sut.addUser(TEST_EMAIL, "testpassword") }
@@ -61,11 +58,33 @@ class UserRepositoryTests {
     }
 
     @Test
-    fun `cannot remove nonexistent user`()
-    {
-        Assertions.assertThatThrownBy{ sut.removeUser("notaperson.@email.com") }
+    fun `cannot add same user twice with differently cased domain`() {
+        sut.addUser("test@test.com", "testpassword")
+
+        Assertions.assertThatThrownBy { sut.addUser("test@TEST.com", "testpassword") }
+                .isInstanceOf(UserException::class.java)
+                .hasMessageContaining("User already exists")
+
+    }
+
+    @Test
+    fun `cannot remove nonexistent user`() {
+        Assertions.assertThatThrownBy { sut.removeUser("notaperson.@email.com") }
                 .isInstanceOf(UserException::class.java)
                 .hasMessageContaining("User does not exist")
+
+    }
+
+    @Test
+    fun `can get user`() {
+        sut.addUser(TEST_EMAIL, "testpassword")
+        assertThat(sut.getUser(TEST_EMAIL)!!.username).isEqualTo(TEST_EMAIL)
+    }
+
+    @Test
+    fun `can get user with differently cased domain`() {
+        sut.addUser("test@test.com", "testpassword")
+        assertThat(sut.getUser("test@TEST.com")!!.username).isEqualTo(TEST_EMAIL)
 
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -2,7 +2,7 @@ package org.imperial.mrc.hint.database
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.exceptions.UserException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class UserRepositoryTests {
     @Autowired
-    private lateinit var sut: UserRepository
+    private lateinit var sut: UserLogic
 
     companion object {
         const val TEST_EMAIL = "test@test.com"
@@ -37,6 +37,14 @@ class UserRepositoryTests {
         sut.addUser(TEST_EMAIL, null)
 
         assertThat(sut.getUser(TEST_EMAIL)).isNotNull
+    }
+
+    @Test
+    fun `emails without @ signs are invalid`() {
+
+        Assertions.assertThatThrownBy { sut.addUser("email", "testpassword") }
+                .isInstanceOf(UserException::class.java)
+                .hasMessageContaining("Please provide a valid email address")
     }
 
     @Test
@@ -95,4 +103,5 @@ class UserRepositoryTests {
         assertThat(sut.getUser("test@TEST.com")!!.username).isEqualTo(TEST_EMAIL)
 
     }
+
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
@@ -1,9 +1,8 @@
 package org.imperial.mrc.hint.integration
 
 import org.jooq.Table
-import org.imperial.mrc.hint.db.DbProfileServiceUserRepository
+import org.imperial.mrc.hint.logic.DbProfileServiceUserLogic
 import org.imperial.mrc.hint.db.Tables
-import org.imperial.mrc.hint.db.Tables.SESSION_FILE
 import org.imperial.mrc.hint.helpers.tmpUploadDirectory
 import org.jooq.DSLContext
 import org.junit.jupiter.api.AfterEach
@@ -20,7 +19,7 @@ abstract class CleanDatabaseTests
     protected lateinit var dsl: DSLContext
 
     @Autowired
-    private lateinit var userRepo: DbProfileServiceUserRepository
+    private lateinit var userRepo: DbProfileServiceUserLogic
 
     @AfterEach
     fun tearDown() {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/PasswordControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/PasswordControllerTests.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.imperial.mrc.hint.controllers.PasswordController
 import org.imperial.mrc.hint.controllers.TokenException
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.emails.EmailManager
 import org.imperial.mrc.hint.emails.PasswordEmailTemplate
 import org.imperial.mrc.hint.security.tokens.OneTimeTokenManager
@@ -19,7 +19,7 @@ class PasswordControllerTests {
         on { username } doReturn "test.user"
     }
 
-    val mockUserRepo = mock<UserRepository> {
+    val mockUserRepo = mock<UserLogic> {
         on { getUser("test.user@test.com") } doReturn mockUser
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserLogicTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserLogicTests.kt
@@ -15,7 +15,7 @@ import org.pac4j.sql.profile.DbProfile
 import org.pac4j.sql.profile.service.DbProfileService
 import java.util.*
 
-class UserRepositoryTests {
+class UserLogicTests {
 
     companion object {
         const val TEST_EMAIL = "test@test.com"

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserRepositoryTests.kt
@@ -24,7 +24,7 @@ class UserRepositoryTests {
     fun `add user calls create on profile service`() {
 
         val mockProfileService = mock<DbProfileService>()
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
 
         sut.addUser(TEST_EMAIL, "testpassword")
 
@@ -39,7 +39,7 @@ class UserRepositoryTests {
     fun `adding user without password creates random pw and sends account creation email`() {
         val mockEmailManager = mock<EmailManager>()
         val mockProfileService = mock<DbProfileService>()
-        val sut = DbProfileServiceUserRepository(mockProfileService, mockEmailManager)
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mockEmailManager)
 
         sut.addUser(TEST_EMAIL, null)
         verify(mockEmailManager).sendPasswordEmail(eq(TEST_EMAIL),
@@ -55,7 +55,7 @@ class UserRepositoryTests {
     @Test
     fun `adding user with password does not send email`() {
         val mockEmailManager = mock<EmailManager>()
-        val sut = DbProfileServiceUserRepository(mock(), mockEmailManager)
+        val sut = DbProfileServiceUserRepository(mock(), mock(), mockEmailManager)
 
         sut.addUser(TEST_EMAIL, "test_pw")
         verifyZeroInteractions(mockEmailManager)
@@ -68,7 +68,7 @@ class UserRepositoryTests {
             on { findById(TEST_EMAIL) } doReturn mock<DbProfile>()
         }
 
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
 
         assertThatThrownBy { sut.addUser(TEST_EMAIL, "testpassword") }
                 .isInstanceOf(UserException::class.java)
@@ -82,7 +82,7 @@ class UserRepositoryTests {
             on { findById(TEST_EMAIL) } doReturn mock<DbProfile>()
         }
 
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
         sut.removeUser(TEST_EMAIL)
 
         verify(mockProfileService).removeById(TEST_EMAIL)
@@ -93,7 +93,7 @@ class UserRepositoryTests {
 
         val mockProfileService = mock<DbProfileService>()
 
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
 
         assertThatThrownBy { sut.removeUser(TEST_EMAIL) }
                 .isInstanceOf(UserException::class.java)
@@ -107,7 +107,7 @@ class UserRepositoryTests {
             on { findById(TEST_EMAIL) } doReturn mockProfile
         }
 
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
         val result = sut.getUser(TEST_EMAIL)
         assertThat(result).isSameAs(mockProfile)
     }
@@ -124,7 +124,7 @@ class UserRepositoryTests {
             on { findById(TEST_EMAIL) } doReturn mockDbProfile
         }
 
-        val sut = DbProfileServiceUserRepository(mockProfileService, mock())
+        val sut = DbProfileServiceUserRepository(mock(), mockProfileService, mock())
         sut.updateUserPassword(mockCommonProfile, "testPassword")
 
         verify(mockProfileService).update(mockDbProfile, "testPassword")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/db/UserRepositoryTests.kt
@@ -84,7 +84,7 @@ class UserRepositoryTests {
     fun `remove user calls removeById on profile service`() {
 
         val mockProfileService = mock<DbProfileService> {
-            on { findById(TEST_EMAIL) } doReturn mock<DbProfile>()
+            on { findById(TEST_EMAIL) } doReturn DbProfile().apply { id = TEST_EMAIL }
         }
 
         val sut = DbProfileServiceUserLogic(mockUserRepo, mockProfileService, mock())
@@ -123,13 +123,12 @@ class UserRepositoryTests {
             on { id } doReturn TEST_EMAIL
         }
 
-        val mockDbProfile = mock<DbProfile>()
-
+        val mockDbProfile = DbProfile().apply { id = TEST_EMAIL }
         val mockProfileService = mock<DbProfileService> {
             on { findById(TEST_EMAIL) } doReturn mockDbProfile
         }
 
-        val sut = DbProfileServiceUserLogic(mock(), mockProfileService, mock())
+        val sut = DbProfileServiceUserLogic(mockUserRepo, mockProfileService, mock())
         sut.updateUserPassword(mockCommonProfile, "testPassword")
 
         verify(mockProfileService).update(mockDbProfile, "testPassword")

--- a/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
+++ b/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
@@ -3,9 +3,9 @@ package org.imperial.mrc.hint.userCLI
 import org.docopt.Docopt
 import org.imperial.mrc.hint.ConfiguredAppProperties
 import org.imperial.mrc.hint.db.DbConfig
-import org.imperial.mrc.hint.db.DbProfileServiceUserRepository
+import org.imperial.mrc.hint.logic.DbProfileServiceUserLogic
 import org.imperial.mrc.hint.db.JooqTokenRepository
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.emails.EmailConfig
 import org.imperial.mrc.hint.security.HintDbProfileService
 import org.imperial.mrc.hint.security.SecurePasswordEncoder
@@ -55,7 +55,7 @@ fun main(args: Array<String>) {
     }
 }
 
-class UserCLI(private val userRepository: UserRepository)
+class UserCLI(private val userLogic: UserLogic)
 {
     fun addUser(options: Map<String, Any>): String
     {
@@ -64,7 +64,7 @@ class UserCLI(private val userRepository: UserRepository)
         println("Adding user $email")
 //        println(password)
 
-        userRepository.addUser(email, password)
+        userLogic.addUser(email, password)
         return "OK"
     }
 
@@ -74,7 +74,7 @@ class UserCLI(private val userRepository: UserRepository)
         println("Removing user $email")
 
 
-        userRepository.removeUser(email)
+        userLogic.removeUser(email)
         return "OK"
     }
 
@@ -84,7 +84,7 @@ class UserCLI(private val userRepository: UserRepository)
         val email = options["<email>"].getStringValue()
         println("Checking if user exists: $email")
 
-        val exists = userRepository.getUser(email) != null
+        val exists = userLogic.getUser(email) != null
         return exists.toString()
     }
 
@@ -94,7 +94,7 @@ class UserCLI(private val userRepository: UserRepository)
     }
 }
 
-fun getUserRepository(dataSource: DataSource): UserRepository {
+fun getUserRepository(dataSource: DataSource): UserLogic {
 
     val profileService = HintDbProfileService(dataSource, SecurePasswordEncoder())
 
@@ -109,6 +109,6 @@ fun getUserRepository(dataSource: DataSource): UserRepository {
             signatureConfig,
             JwtAuthenticator(signatureConfig))
 
-    return DbProfileServiceUserRepository(profileService,
+    return DbProfileServiceUserLogic(profileService,
             EmailConfig().getEmailManager(appProperties, oneTimeTokenManager))
 }

--- a/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
+++ b/src/userCLI/src/main/kotlin/org/imperial/mrc/hint/userCLI/App.kt
@@ -36,7 +36,7 @@ fun main(args: Array<String>) {
     val dataSource = DbConfig().dataSource(ConfiguredAppProperties())
 
     try {
-        val userCLI = UserCLI(getUserRepository(dataSource))
+        val userCLI = UserCLI(getUserLogic(dataSource))
         val result = when {
             addUser -> userCLI.addUser(options)
             removeUser -> userCLI.removeUser(options)
@@ -86,7 +86,7 @@ class UserCLI(private val userLogic: UserLogic) {
     }
 }
 
-fun getUserRepository(dataSource: DataSource): UserLogic {
+fun getUserLogic(dataSource: DataSource): UserLogic {
 
     val profileService = HintDbProfileService(dataSource, SecurePasswordEncoder())
 

--- a/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
+++ b/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
@@ -20,8 +20,8 @@ class AppTests {
         const val TEST_EMAIL = "test@test.com"
 
         val dataSource = DbConfig().dataSource(ConfiguredAppProperties())
-        val userRepository = getUserRepository(dataSource)
-        val sut = UserCLI(userRepository)
+        val userLogic = getUserLogic(dataSource)
+        val sut = UserCLI(userLogic)
 
         @AfterAll
         @JvmStatic

--- a/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
+++ b/src/userCLI/src/test/kotlin/org/imperial/mrc/hint/userCLI/AppTests.kt
@@ -7,7 +7,7 @@ import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.ConfiguredAppProperties
 import org.imperial.mrc.hint.db.DbConfig
-import org.imperial.mrc.hint.db.UserRepository
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.exceptions.UserException
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
@@ -57,7 +57,7 @@ class AppTests {
 
     @Test
     fun `null password gets passed to user repo`() {
-        val mockUserRepo = mock<UserRepository>()
+        val mockUserRepo = mock<UserLogic>()
         UserCLI(mockUserRepo).addUser(mapOf("<email>" to TEST_EMAIL))
         verify(mockUserRepo).addUser(eq(TEST_EMAIL), isNull())
     }


### PR DESCRIPTION
"To reproduce:
1. Ask for password reset email to <user>@IMPERIAL.ac.uk
2. No password reset email is received

I would expect us to convert IMPERIAL.ac.uk to lowercase and use that. This has bitten us with avenir health accounts which have been created as AvenirHealth but requesting pw reset as avenirhealth."

Have turned the `UserRepository` into `UserLogic` (which is a more apt name, as previously noted, as performs lots of logic e.g. sending emails.) Created a new `UserRepository` which just looks up usernames from the db, allowing `UserLogic` to do the case insensitive matching against stored usernames.