### PR TITLE
mrc-1186 Do not load modelRun.ready from file, always reset to false

### DIFF
--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -42,7 +42,7 @@ const existingState = localStorageManager.getState();
 
 export const modelRun: Module<ModelRunState, RootState> = {
     namespaced,
-    state: {...initialModelRunState(), ...existingState && existingState.modelRun},
+    state: {...initialModelRunState(), ...existingState && existingState.modelRun, ready: false},
     actions,
     getters: modelRunGetters,
     mutations

--- a/src/app/static/src/tests/modelRun/modelRunState.test.ts
+++ b/src/app/static/src/tests/modelRun/modelRunState.test.ts
@@ -5,14 +5,16 @@ localStorageManager.saveState({
         modelRunId: "1234",
         status: {success: true},
         errors: [],
-        statusPollId: -1
+        statusPollId: -1,
+        ready: true
     }
 } as any);
 
 import {modelRun, ModelRunState} from "../../app/store/modelRun/modelRun";
 
-it("loads initial state from local storage", () => {
+it("loads initial state from local storage, but resets ready to false", () => {
     const state = modelRun.state as ModelRunState;
     expect(state.modelRunId).toBe("1234");
     expect(state.status).toStrictEqual({success: true});
+    expect(state.ready).toBe(false);
 });


### PR DESCRIPTION
The related bug (loading a saved file with completed modelRun reverted all state) was caused because modelRun was being initialised wrongly to true, so store seemed to be in an invalid state, becaues the modelRun step appeared to be ready+complete, despite having no data yet. This change delays marking modelRun as ready until data is fetched). 

Could have done this by not saving the ready state to file, rather than always overwriting in the read state, but this way older saved files can be reloaded too. 