### PR TITLE
mrc-1190 pass language accept header to API

### DIFF
--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -3,7 +3,7 @@ import {ErrorsMutation} from "./store/errors/mutations";
 import {ActionContext, Commit} from "vuex";
 import {freezer, isHINTResponse} from "./utils";
 import {Error, Response} from "./generated";
-import {RootState} from "./root";
+import {RootState, TranslatableState} from "./root";
 
 declare var appUrl: string;
 
@@ -29,7 +29,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private readonly _commit: Commit;
     private readonly _headers: any;
 
-    constructor(context: ActionContext<any, RootState>) {
+    constructor(context: ActionContext<any, TranslatableState>) {
         this._commit = context.commit;
         this._headers = {"Accept-Language": context.rootState.language};
     }
@@ -168,4 +168,4 @@ export class APIService<S extends string, E extends string> implements API<S, E>
 }
 
 export const api =
-    <S extends string, E extends string>(context: ActionContext<any, RootState>) => new APIService<S, E>(context);
+    <S extends string, E extends string>(context: ActionContext<any, TranslatableState>) => new APIService<S, E>(context);

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -147,13 +147,13 @@ export class APIService<S extends string, E extends string> implements API<S, E>
         return this._handleAxiosResponse(axios.get(fullUrl, {headers: this._headers}));
     }
 
-    async postAndReturn<T>(url: string, data: any): Promise<void | ResponseWithType<T>> {
+    async postAndReturn<T>(url: string, data?: any): Promise<void | ResponseWithType<T>> {
         this._verifyHandlers(url);
         const fullUrl = this._buildFullUrl(url);
 
         // this allows us to pass data of type FormData in both the browser and
         // in node for testing, using the "form-data" package in the latter case
-        const headers = typeof data.getHeaders == "function" ?
+        const headers = data && typeof data.getHeaders == "function" ?
             {...this._headers, ...data.getHeaders()}
             : this._headers;
 

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -27,9 +27,11 @@ import {
 import {errors, ErrorsState, initialErrorsState} from "./store/errors/errors";
 import {Language} from "./store/translations/locales";
 
+export interface TranslatableState {
+    language: Language
+}
 
-export interface RootState {
-    language: Language,
+export interface RootState extends TranslatableState {
     version: string;
     baseline: BaselineState,
     metadata: MetadataState,

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -19,9 +19,10 @@ export interface BaselineActions {
 
 export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
-    async uploadPJNZ({commit, dispatch, state}, formData) {
+    async uploadPJNZ(context, formData) {
+        const {commit, dispatch, state} = context;
         commit({type: BaselineMutation.PJNZUpdated, payload: null});
-        await api<BaselineMutation, BaselineMutation>(commit)
+        await api<BaselineMutation, BaselineMutation>(context)
             .withSuccess(BaselineMutation.PJNZUpdated)
             .withError(BaselineMutation.PJNZUploadError)
             .freezeResponse()
@@ -35,9 +36,10 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             });
     },
 
-    async uploadShape({commit, dispatch}, formData) {
+    async uploadShape(context, formData) {
+        const {commit, dispatch} = context;
         commit({type: BaselineMutation.ShapeUpdated, payload: null});
-        await api<BaselineMutation, BaselineMutation>(commit)
+        await api<BaselineMutation, BaselineMutation>(context)
             .withSuccess(BaselineMutation.ShapeUpdated)
             .withError(BaselineMutation.ShapeUploadError)
             .freezeResponse()
@@ -50,9 +52,10 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             });
     },
 
-    async uploadPopulation({commit, dispatch}, formData) {
+    async uploadPopulation(context, formData) {
+        const {commit, dispatch} = context;
         commit({type: BaselineMutation.PopulationUpdated, payload: null});
-        await api<BaselineMutation, BaselineMutation>(commit)
+        await api<BaselineMutation, BaselineMutation>(context)
             .withSuccess(BaselineMutation.PopulationUpdated)
             .withError(BaselineMutation.PopulationUploadError)
             .freezeResponse()
@@ -65,8 +68,9 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             });
     },
 
-    async deletePJNZ({commit, dispatch}) {
-        await api<BaselineMutation, BaselineMutation>(commit)
+    async deletePJNZ(context) {
+        const {commit, dispatch} = context;
+        await api<BaselineMutation, BaselineMutation>(context)
             .delete("/baseline/pjnz/")
             .then((response) => {
                 if (response) {
@@ -76,8 +80,9 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             });
     },
 
-    async deleteShape({commit, dispatch}) {
-        await api<BaselineMutation, BaselineMutation>(commit)
+    async deleteShape(context) {
+        const {commit, dispatch} = context;
+        await api<BaselineMutation, BaselineMutation>(context)
             .delete("/baseline/shape/")
             .then((response) => {
                 if (response) {
@@ -87,8 +92,9 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
             });
     },
 
-    async deletePopulation({commit, dispatch}) {
-        await api<BaselineMutation, BaselineMutation>(commit)
+    async deletePopulation(context) {
+        const {commit, dispatch} = context;
+        await api<BaselineMutation, BaselineMutation>(context)
             .delete("/baseline/population/")
             .then((response) => {
                 if (response) {
@@ -106,19 +112,20 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
         ]);
     },
 
-    async getBaselineData({commit, dispatch}) {
+    async getBaselineData(context) {
+        const {commit, dispatch} = context;
         await Promise.all([
-            api<BaselineMutation, BaselineMutation>(commit)
+            api<BaselineMutation, BaselineMutation>(context)
                 .ignoreErrors()
                 .withSuccess(BaselineMutation.PJNZUpdated)
                 .freezeResponse()
                 .get<PjnzResponse>("/baseline/pjnz/"),
-            api<BaselineMutation, BaselineMutation>(commit)
+            api<BaselineMutation, BaselineMutation>(context)
                 .ignoreErrors()
                 .withSuccess(BaselineMutation.PopulationUpdated)
                 .freezeResponse()
                 .get<PjnzResponse>("/baseline/population/"),
-            api<BaselineMutation, BaselineMutation>(commit)
+            api<BaselineMutation, BaselineMutation>(context)
                 .ignoreErrors()
                 .withSuccess(BaselineMutation.ShapeUpdated)
                 .freezeResponse()
@@ -130,9 +137,10 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
         commit({type: "Ready", payload: true});
     },
 
-    async validate({commit}) {
+    async validate(context) {
+        const {commit} = context;
         commit({type: "Validating", payload: null});
-        await api<BaselineMutation, BaselineMutation>(commit)
+        await api<BaselineMutation, BaselineMutation>(context)
             .withSuccess(BaselineMutation.Validated)
             .withError(BaselineMutation.BaselineError)
             .freezeResponse()

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -25,7 +25,8 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
         reader.readAsText(file);
     },
 
-    async setFiles({commit, dispatch, state}, savedFileContents) {
+    async setFiles(context, savedFileContents) {
+        const {commit, dispatch, state} = context;
         commit({type: "SettingFiles", payload: null});
 
         const objectContents = verifyCheckSum(savedFileContents);
@@ -38,7 +39,7 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
         const files = objectContents.files;
         const savedState = objectContents.state;
 
-        await api<LoadActionTypes, LoadErrorActionTypes>(commit)
+        await api<LoadActionTypes, LoadErrorActionTypes>(context)
             .withSuccess("UpdatingState")
             .withError("LoadFailed")
             .postAndReturn<Dict<LocalSessionFile>>("/session/files/", files)

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -12,8 +12,8 @@ export interface MetadataActions {
 
 export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
 
-    async getPlottingMetadata({commit}, iso3) {
-        await api<MetadataActionTypes, MetadataErrorActionTypes>(commit)
+    async getPlottingMetadata(context, iso3) {
+        await api<MetadataActionTypes, MetadataErrorActionTypes>(context)
             .withSuccess("PlottingMetadataFetched")
             .withError("PlottingMetadataError")
             .get(`/meta/plotting/${iso3}`);

--- a/src/app/static/src/app/store/modelOptions/actions.ts
+++ b/src/app/static/src/app/store/modelOptions/actions.ts
@@ -11,9 +11,10 @@ export interface ModelOptionsActions {
 
 export const actions: ActionTree<ModelOptionsState, RootState> & ModelOptionsActions = {
 
-    async fetchModelRunOptions({commit}) {
+    async fetchModelRunOptions(context) {
+        const {commit} = context;
         commit(ModelOptionsMutation.FetchingModelOptions);
-        const response = await api<ModelOptionsMutation, ModelOptionsMutation>(commit)
+        const response = await api<ModelOptionsMutation, ModelOptionsMutation>(context)
             .withSuccess(ModelOptionsMutation.ModelOptionsFetched)
             .get<DynamicFormMeta>("/model/options/");
 

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -14,18 +14,20 @@ export interface ModelRunActions {
 
 export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
 
-    async run({commit, rootState}) {
+    async run(context) {
+        const {commit, rootState} = context;
         const options = rootState.modelOptions.options;
         const version = rootState.modelOptions.version;
-        await api<ModelRunMutation, ModelRunMutation>(commit)
+        await api<ModelRunMutation, ModelRunMutation>(context)
             .withSuccess(ModelRunMutation.ModelRunStarted)
             .withError(ModelRunMutation.ModelRunError)
             .postAndReturn<ModelSubmitResponse>("/model/run/", {options, version})
     },
 
-    poll({commit, state, dispatch}, runId) {
+    poll(context, runId) {
+        const {commit, dispatch, state} = context;
         const id = setInterval(() => {
-            api<ModelRunMutation, ModelRunMutation>(commit)
+            api<ModelRunMutation, ModelRunMutation>(context)
                 .withSuccess(ModelRunMutation.RunStatusUpdated)
                 .withError(ModelRunMutation.RunStatusError)
                 .get<ModelStatusResponse>(`/model/status/${runId}`)
@@ -39,9 +41,10 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
         commit({type: "PollingForStatusStarted", payload: id})
     },
 
-    async getResult({commit, state}) {
+    async getResult(context) {
+        const {commit, state} = context;
         if (state.status.done) {
-            await api<ModelRunMutation, ModelRunMutation>(commit)
+            await api<ModelRunMutation, ModelRunMutation>(context)
                 .withSuccess(ModelRunMutation.RunResultFetched)
                 .withError(ModelRunMutation.RunResultError)
                 .freezeResponse()

--- a/src/app/static/src/app/store/password/actions.ts
+++ b/src/app/static/src/app/store/password/actions.ts
@@ -2,6 +2,7 @@ import {ActionContext, ActionTree} from "vuex";
 import {PasswordState} from "./password";
 import {api} from "../../apiService";
 import qs from "qs";
+import {RootState} from "../../root";
 
 export type PasswordActionTypes = "ResetLinkRequested" | "ResetPassword"
 export type PasswordActionErrorTypes = "RequestResetLinkError" | "ResetPasswordError"
@@ -12,21 +13,21 @@ export interface ResetPasswordActionParams {
 }
 
 export interface PasswordActions {
-    requestResetLink: (store: ActionContext<PasswordState, PasswordState>, email: string) => void
-    resetPassword: (store: ActionContext<PasswordState, PasswordState>, payload: ResetPasswordActionParams) => void
+    requestResetLink: (store: ActionContext<PasswordState, RootState>, email: string) => void
+    resetPassword: (store: ActionContext<PasswordState, RootState>, payload: ResetPasswordActionParams) => void
 }
 
-export const actions: ActionTree<PasswordState, PasswordState> & PasswordActions = {
+export const actions: ActionTree<PasswordState, RootState> & PasswordActions = {
 
-    async requestResetLink({commit}, email) {
-        await api<PasswordActionTypes, PasswordActionErrorTypes>(commit)
+    async requestResetLink(context, email) {
+        await api<PasswordActionTypes, PasswordActionErrorTypes>(context)
             .withError("RequestResetLinkError")
             .withSuccess("ResetLinkRequested")
             .postAndReturn<Boolean>("/password/request-reset-link/", qs.stringify({email: email}));
     },
 
-    async resetPassword({commit}, payload) {
-        await api<PasswordActionTypes, PasswordActionErrorTypes>(commit)
+    async resetPassword(context, payload) {
+        await api<PasswordActionTypes, PasswordActionErrorTypes>(context)
             .withError("ResetPasswordError")
             .withSuccess("ResetPassword")
             .postAndReturn<Boolean>("/password/reset-password/", qs.stringify({

--- a/src/app/static/src/app/store/password/actions.ts
+++ b/src/app/static/src/app/store/password/actions.ts
@@ -13,11 +13,11 @@ export interface ResetPasswordActionParams {
 }
 
 export interface PasswordActions {
-    requestResetLink: (store: ActionContext<PasswordState, RootState>, email: string) => void
-    resetPassword: (store: ActionContext<PasswordState, RootState>, payload: ResetPasswordActionParams) => void
+    requestResetLink: (store: ActionContext<PasswordState, PasswordState>, email: string) => void
+    resetPassword: (store: ActionContext<PasswordState, PasswordState>, payload: ResetPasswordActionParams) => void
 }
 
-export const actions: ActionTree<PasswordState, RootState> & PasswordActions = {
+export const actions: ActionTree<PasswordState, PasswordState> & PasswordActions = {
 
     async requestResetLink(context, email) {
         await api<PasswordActionTypes, PasswordActionErrorTypes>(context)

--- a/src/app/static/src/app/store/password/password.ts
+++ b/src/app/static/src/app/store/password/password.ts
@@ -1,6 +1,8 @@
 import {Error} from "../../generated";
+import {TranslatableState} from "../../root";
+import {Language} from "../translations/locales";
 
-export interface PasswordState {
+export interface PasswordState extends TranslatableState {
     resetLinkRequested: boolean
     requestResetLinkError: Error | null
     passwordWasReset: boolean
@@ -8,6 +10,7 @@ export interface PasswordState {
 }
 
 export const initialPasswordState: PasswordState = {
+    language: Language.en,
     resetLinkRequested: false,
     requestResetLinkError: null,
     passwordWasReset: false,

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -24,10 +24,11 @@ function commitSelectedDataTypeUpdated(commit: Commit, dataType: DataType) {
 
 export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyAndProgramActions = {
 
-    async uploadSurvey({commit}, formData) {
+    async uploadSurvey(context, formData) {
+        const {commit} = context;
         commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
 
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .withError(SurveyAndProgramMutation.SurveyError)
             .withSuccess(SurveyAndProgramMutation.SurveyUpdated)
             .freezeResponse()
@@ -39,10 +40,11 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
             });
     },
 
-    async uploadProgram({commit}, formData) {
+    async uploadProgram(context, formData) {
+        const {commit} = context;
         commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
 
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .withError(SurveyAndProgramMutation.ProgramError)
             .withSuccess(SurveyAndProgramMutation.ProgramUpdated)
             .freezeResponse()
@@ -54,10 +56,11 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
             });
     },
 
-    async uploadANC({commit}, formData) {
+    async uploadANC(context, formData) {
+        const {commit} = context;
         commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
 
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .withError(SurveyAndProgramMutation.ANCError)
             .withSuccess(SurveyAndProgramMutation.ANCUpdated)
             .freezeResponse()
@@ -69,24 +72,27 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
             });
     },
 
-    async deleteSurvey({commit}) {
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+    async deleteSurvey(context) {
+        const {commit} = context;
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/survey/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
             });
     },
 
-    async deleteProgram({commit}) {
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+    async deleteProgram(context) {
+        const {commit} = context;
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/programme/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
             });
     },
 
-    async deleteANC({commit}) {
-        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+    async deleteANC(context) {
+        const {commit} = context;
+        await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/anc/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
@@ -101,21 +107,21 @@ export const actions: ActionTree<SurveyAndProgramDataState, RootState> & SurveyA
         ]);
     },
 
-    async getSurveyAndProgramData({commit}) {
-
+    async getSurveyAndProgramData(context) {
+        const {commit} = context;
         await Promise.all(
             [
-                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
                     .ignoreErrors()
                     .withSuccess(SurveyAndProgramMutation.SurveyUpdated)
                     .freezeResponse()
                     .get<SurveyResponse>("/disease/survey/"),
-                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
                     .ignoreErrors()
                     .withSuccess(SurveyAndProgramMutation.ProgramUpdated)
                     .freezeResponse()
                     .get<ProgrammeResponse>("/disease/programme/"),
-                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(commit)
+                api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
                     .ignoreErrors()
                     .withSuccess(SurveyAndProgramMutation.ANCUpdated)
                     .freezeResponse()

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -9,6 +9,7 @@ describe("ApiService", () => {
     beforeEach(() => {
         console.log = jest.fn();
         console.warn = jest.fn();
+        mockAxios.reset();
     });
 
     afterEach(() => {
@@ -279,6 +280,39 @@ describe("ApiService", () => {
 
         expect(warnings[0][0]).toBe("No error handler registered for request /baseline/.");
         expect(warnings[1][0]).toBe("No success handler registered for request /baseline/.");
+    });
+
+    it("passes language header on get", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess(true));
+
+        await api({commit: jest.fn(), rootState} as any)
+            .withSuccess("whatever")
+            .ignoreErrors()
+            .get("/baseline/");
+
+        expect(mockAxios.history.get[0].headers).toStrictEqual({
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en"
+        })
+    });
+
+    it("passes language header on post", async () => {
+
+        mockAxios.onPost(`/baseline/`)
+            .reply(200, mockSuccess(true));
+
+        await api({commit: jest.fn(), rootState} as any)
+            .withSuccess("whatever")
+            .ignoreErrors()
+            .postAndReturn("/baseline/");
+
+        expect(mockAxios.history.post[0].headers).toStrictEqual({
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en",
+            "Content-Type": "application/x-www-form-urlencoded"
+        })
     });
 
     async function expectCouldNotParseAPIResponseError() {

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -1,6 +1,8 @@
 import {api} from "../app/apiService";
-import {mockAxios, mockError, mockFailure, mockSuccess} from "./mocks";
+import {mockAxios, mockError, mockFailure, mockRootState, mockSuccess} from "./mocks";
 import {freezer} from '../app/utils';
+
+const rootState = mockRootState();
 
 describe("ApiService", () => {
 
@@ -19,7 +21,7 @@ describe("ApiService", () => {
             .reply(500, mockFailure("some error message"));
 
         try {
-            await api(jest.fn())
+            await api({commit: jest.fn(), rootState} as any)
                 .get("/baseline/")
         } catch (e) {
 
@@ -37,7 +39,7 @@ describe("ApiService", () => {
 
         const commit = jest.fn();
 
-        await api(commit)
+        await api({commit, rootState} as any)
             .get("/unusual/");
 
         expect((console.warn as jest.Mock).mock.calls[0][0])
@@ -63,7 +65,7 @@ describe("ApiService", () => {
 
         const commit = jest.fn();
 
-        await api(commit)
+        await api({commit, rootState} as any)
             .get("/unusual/");
 
         expect((console.warn as jest.Mock).mock.calls[0][0])
@@ -93,7 +95,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .withError("TEST_TYPE")
             .get("/baseline/");
 
@@ -114,7 +116,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .withError("TEST_TYPE")
             .get("/baseline/");
 
@@ -135,7 +137,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .withError("TEST_TYPE")
             .get("/baseline/");
 
@@ -158,7 +160,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .withSuccess("TEST_TYPE")
             .get("/baseline/");
 
@@ -172,7 +174,7 @@ describe("ApiService", () => {
             .reply(200, mockSuccess("TEST"));
 
         const commit = jest.fn();
-        const response = await api(commit as any)
+        const response = await api({commit, rootState} as any)
             .withSuccess("TEST_TYPE")
             .get("/baseline/");
 
@@ -194,7 +196,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .freezeResponse()
             .withSuccess("TEST_TYPE")
             .get("/baseline/");
@@ -219,7 +221,7 @@ describe("ApiService", () => {
             committedPayload = payload;
         };
 
-        await api(commit as any)
+        await api({commit, rootState} as any)
             .withSuccess("TEST_TYPE")
             .get("/baseline/");
 
@@ -257,7 +259,7 @@ describe("ApiService", () => {
         mockAxios.onGet(`/baseline/`)
             .reply(500, mockFailure("some error message"));
 
-        await api(jest.fn())
+        await api({commit: jest.fn(), rootState} as any)
             .withSuccess("whatever")
             .ignoreErrors()
             .get("/baseline/");
@@ -270,7 +272,7 @@ describe("ApiService", () => {
         mockAxios.onGet(`/baseline/`)
             .reply(200, mockSuccess(true));
 
-        await api(jest.fn())
+        await api({commit: jest.fn(), rootState} as any)
             .get("/baseline/");
 
         const warnings = (console.warn as jest.Mock).mock.calls;
@@ -281,7 +283,7 @@ describe("ApiService", () => {
 
     async function expectCouldNotParseAPIResponseError() {
         const commit = jest.fn();
-        await api(commit)
+        await api({commit, rootState} as any)
             .get("/baseline/");
 
         expect(commit.mock.calls.length).toBe(1);

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -2,7 +2,7 @@ import {
     mockAxios,
     mockBaselineState, mockError,
     mockFailure,
-    mockPopulationResponse,
+    mockPopulationResponse, mockRootState,
     mockShapeResponse,
     mockSuccess,
     mockValidateBaselineResponse
@@ -12,6 +12,7 @@ import {BaselineMutation} from "../../app/store/baseline/mutations";
 import {expectEqualsFrozen, testUploadErrorCommitted} from "../testHelpers";
 
 const FormData = require("form-data");
+const rootState = mockRootState();
 
 describe("Baseline actions", () => {
 
@@ -33,7 +34,8 @@ describe("Baseline actions", () => {
         const commit = jest.fn();
         const state = mockBaselineState({iso3: "MWI"});
         const dispatch = jest.fn();
-        await actions.uploadPJNZ({commit, state, dispatch} as any, new FormData());
+
+        await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: BaselineMutation.PJNZUpdated, payload: null});
 
@@ -62,7 +64,7 @@ describe("Baseline actions", () => {
         const commit = jest.fn();
         const state = mockBaselineState({pjnzError: mockError("test error")});
         const dispatch = jest.fn();
-        await actions.uploadPJNZ({commit, state, dispatch} as any, new FormData());
+        await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, new FormData());
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
@@ -81,7 +83,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.uploadShape({commit, dispatch} as any, new FormData());
+        await actions.uploadShape({commit, dispatch, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: BaselineMutation.ShapeUpdated,
@@ -108,7 +110,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.uploadPopulation({commit, dispatch} as any, new FormData());
+        await actions.uploadPopulation({commit, dispatch, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: BaselineMutation.PopulationUpdated,
@@ -144,7 +146,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
 
         const calls = commit.mock.calls.map((callArgs) => callArgs[0]["type"]);
         expect(calls).toContain(BaselineMutation.PJNZUpdated);
@@ -163,7 +165,7 @@ describe("Baseline actions", () => {
             .reply(200, mockSuccess(mockValidateResponse));
 
         const commit = jest.fn();
-        await actions.validate({commit} as any);
+        await actions.validate({commit, rootState} as any);
 
         //commits to Validating first
         expect(commit.mock.calls[0][0]).toStrictEqual({
@@ -183,7 +185,7 @@ describe("Baseline actions", () => {
             .reply(400, mockFailure("Baseline is inconsistent"));
 
         const commit = jest.fn();
-        await actions.validate({commit} as any);
+        await actions.validate({commit, rootState} as any);
 
         //commits to Validating first
         expect(commit.mock.calls[0][0]).toStrictEqual({
@@ -211,7 +213,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
 
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.Ready);
@@ -224,7 +226,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.deletePJNZ({commit, dispatch} as any);
+        await actions.deletePJNZ({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
         expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
@@ -237,7 +239,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.deleteShape({commit, dispatch} as any);
+        await actions.deleteShape({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
         expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
@@ -250,7 +252,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.deletePopulation({commit, dispatch} as any);
+        await actions.deletePopulation({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PopulationUpdated);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
         expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
@@ -266,7 +268,7 @@ describe("Baseline actions", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.deleteAll({commit, dispatch} as any);
+        await actions.deleteAll({commit, dispatch, rootState} as any);
         expect(mockAxios.history["delete"].length).toBe(3)
     });
 

--- a/src/app/static/src/tests/integration/baseline.itest.ts
+++ b/src/app/static/src/tests/integration/baseline.itest.ts
@@ -1,5 +1,5 @@
 import {actions} from "../../app/store/baseline/actions";
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {getFormData} from "./helpers";
 import {BaselineMutation} from "../../app/store/baseline/mutations";
 
@@ -15,7 +15,7 @@ describe("Baseline actions", () => {
         const state = {country: "Malawi"} as any;
         const formData = getFormData("Botswana2018.PJNZ");
 
-        await actions.uploadPJNZ({commit, state, dispatch} as any, formData);
+        await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
@@ -26,7 +26,7 @@ describe("Baseline actions", () => {
     it("can get baseline data", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
 
         const calls = commit.mock.calls.map((callArgs) => callArgs[0]["type"]);
         expect(calls).toContain(BaselineMutation.PJNZUpdated);
@@ -38,7 +38,7 @@ describe("Baseline actions", () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const formData = getFormData("malawi.geojson");
-        await actions.uploadShape({commit, dispatch} as any, formData);
+        await actions.uploadShape({commit, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
@@ -50,18 +50,18 @@ describe("Baseline actions", () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const formData = getFormData("population.csv");
-        await actions.uploadPopulation({commit, dispatch} as any, formData);
+        await actions.uploadPopulation({commit, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PopulationUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
             .toBe("population.csv");
     });
 
-    it ("can validate baseline data", async () => {
+    it("can validate baseline data", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
 
-        await actions.validate({commit, dispatch} as any);
+        await actions.validate({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.BaselineError);
         expect(commit.mock.calls[1][0]["payload"].detail).toContain("Countries aren't consistent");
     });
@@ -72,18 +72,18 @@ describe("Baseline actions", () => {
         const formData = getFormData("Botswana2018.PJNZ");
 
         // upload
-        await actions.uploadPJNZ({commit, dispatch, state: {}} as any, formData);
+        await actions.uploadPJNZ({commit, dispatch, rootState, state: {}} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deletePJNZ({commit, dispatch} as any);
+        await actions.deletePJNZ({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == BaselineMutation.PJNZUpdated)[0]["payload"]).toBe(null);
     });
 
@@ -93,18 +93,18 @@ describe("Baseline actions", () => {
         const formData = getFormData("malawi.geojson");
 
         // upload
-        await actions.uploadShape({commit, dispatch} as any, formData);
+        await actions.uploadShape({commit, dispatch, rootState} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deleteShape({commit, dispatch} as any);
+        await actions.deleteShape({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == BaselineMutation.ShapeUpdated)[0]["payload"]).toBe(null);
     });
 
@@ -114,18 +114,18 @@ describe("Baseline actions", () => {
         const formData = getFormData("population.csv");
 
         // upload
-        await actions.uploadPopulation({commit, dispatch} as any, formData);
+        await actions.uploadPopulation({commit, dispatch, rootState} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deletePopulation({commit, dispatch} as any);
+        await actions.deletePopulation({commit, dispatch, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PopulationUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getBaselineData({commit, dispatch} as any);
+        await actions.getBaselineData({commit, dispatch, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == BaselineMutation.PopulationUpdated)[0]["payload"]).toBe(null);
     });
 

--- a/src/app/static/src/tests/integration/integrationTest.ts
+++ b/src/app/static/src/tests/integration/integrationTest.ts
@@ -1,9 +1,11 @@
 import axios, {AxiosRequestConfig} from 'axios';
 import {Service} from 'axios-middleware';
+import {Language} from "../../app/store/translations/locales";
 
 const FormData = require("form-data");
-
 const service = new Service(axios);
+
+export const rootState = {language: Language.en};
 
 export const login = async () => {
     const formData = new FormData();

--- a/src/app/static/src/tests/integration/load.itest.ts
+++ b/src/app/static/src/tests/integration/load.itest.ts
@@ -1,6 +1,6 @@
 import {actions} from "../../app/store/load/actions";
 import {addCheckSum} from "../../app/utils";
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {actions as baselineActions} from "../../app/store/baseline/actions";
 import {ShapeResponse} from "../../app/generated";
 
@@ -16,7 +16,7 @@ describe("load actions", () => {
         const file = fs.createReadStream("../testdata/malawi.geojson");
         const formData = new FormData();
         formData.append('file', file);
-        await baselineActions.uploadShape({commit, dispatch: jest.fn()} as any, formData);
+        await baselineActions.uploadShape({commit, dispatch: jest.fn(), rootState} as any, formData);
         shape = (commit.mock.calls[1][0]["payload"] as ShapeResponse);
     });
 
@@ -27,7 +27,7 @@ describe("load actions", () => {
             state: {}
         });
         const fakeFileContents = addCheckSum(fakeState);
-        await actions.setFiles({commit, dispatch: jest.fn(), state: {}} as any, fakeFileContents);
+        await actions.setFiles({commit, dispatch: jest.fn(), state: {}, rootState} as any, fakeFileContents);
 
         expect(commit.mock.calls[0][0].type).toBe("SettingFiles");
         expect(commit.mock.calls[1][0].type).toBe("UpdatingState");

--- a/src/app/static/src/tests/integration/metadata.itest.ts
+++ b/src/app/static/src/tests/integration/metadata.itest.ts
@@ -11,7 +11,7 @@ describe("Metadata actions", () => {
     it("can get plotting metadata", async () => {
         const commit = jest.fn();
 
-        await actions.getPlottingMetadata({commit} as any, "MWI");
+        await actions.getPlottingMetadata({commit, rootState} as any, "MWI");
         expect(commit.mock.calls[0][0]["type"]).toBe("PlottingMetadataFetched");
 
         const payload = commit.mock.calls[0][0]["payload"] as PlottingMetadataResponse;

--- a/src/app/static/src/tests/integration/metadata.itest.ts
+++ b/src/app/static/src/tests/integration/metadata.itest.ts
@@ -1,5 +1,5 @@
 import {actions} from "../../app/store/metadata/actions";
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {PlottingMetadataResponse} from "../../app/generated";
 
 describe("Metadata actions", () => {

--- a/src/app/static/src/tests/integration/modelOptions.itest.ts
+++ b/src/app/static/src/tests/integration/modelOptions.itest.ts
@@ -1,5 +1,5 @@
 import {actions} from "../../app/store/modelOptions/actions";
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {isDynamicFormMeta} from "../../app/components/forms/dynamicFormChecker";
 import {actions as baselineActions} from "../../app/store/baseline/actions";
 import {actions as surveyActions} from "../../app/store/surveyAndProgram/actions";
@@ -18,13 +18,13 @@ describe("model options actions integration", () => {
         let formData = new FormData();
         formData.append('file', file);
 
-        await baselineActions.uploadShape({commit, dispatch} as any, formData);
+        await baselineActions.uploadShape({commit, dispatch, rootState} as any, formData);
 
         file = fs.createReadStream("../testdata/survey.csv");
         formData = new FormData();
         formData.append('file', file);
 
-        await surveyActions.uploadSurvey({commit, dispatch} as any, formData);
+        await surveyActions.uploadSurvey({commit, dispatch, rootState} as any, formData);
     });
 
     it("can get valid model options", async () => {

--- a/src/app/static/src/tests/integration/modelOptions.itest.ts
+++ b/src/app/static/src/tests/integration/modelOptions.itest.ts
@@ -29,7 +29,7 @@ describe("model options actions integration", () => {
 
     it("can get valid model options", async () => {
         const commit = jest.fn();
-        await actions.fetchModelRunOptions({commit} as any);
+        await actions.fetchModelRunOptions({commit, rootState} as any);
         expect(commit.mock.calls[1][0]["type"]).toBe("ModelOptionsFetched");
         const payload = commit.mock.calls[1][0]["payload"];
         expect(isDynamicFormMeta(payload)).toBe(true);

--- a/src/app/static/src/tests/integration/modelRun.itest.ts
+++ b/src/app/static/src/tests/integration/modelRun.itest.ts
@@ -1,8 +1,9 @@
 import {actions} from "../../app/store/modelRun/actions";
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {ModelSubmitResponse} from "../../app/generated";
 import {RootState} from "../../app/root";
 import {ModelRunState} from "../../app/store/modelRun/modelRun";
+import {Language} from "../../app/store/translations/locales";
 
 describe("Model run actions", () => {
 
@@ -11,6 +12,7 @@ describe("Model run actions", () => {
         await login();
         const commit = jest.fn();
         const mockState = {
+            language: Language.en,
             modelOptions: {
                 options: {},
                 version: {hintr: "unknown", naomi: "unknown", rrq: "unknown"}
@@ -23,6 +25,7 @@ describe("Model run actions", () => {
     it("can trigger model run", async () => {
         const commit = jest.fn();
         const mockState = {
+            language: Language.en,
             modelOptions: {
                 options: {},
                 version: {hintr: "unknown", naomi: "unknown", rrq: "unknown"}
@@ -37,7 +40,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const mockState = {status: {done: true}} as ModelRunState;
 
-        actions.poll({commit, state: mockState, dispatch: jest.fn()} as any, runId);
+        actions.poll({commit, state: mockState, dispatch: jest.fn(), rootState} as any, runId);
         expect(commit.mock.calls[0][0]["type"]).toBe("PollingForStatusStarted");
         const pollingInterval = (commit.mock.calls[0][0]["payload"]);
 
@@ -61,7 +64,7 @@ describe("Model run actions", () => {
                 id: "1234"
             }
         } as ModelRunState;
-        await actions.getResult({commit, state: mockState} as any);
+        await actions.getResult({commit, state: mockState, rootState} as any);
 
         // passing an invalid run id so this will return an error
         // but the expected error message confirms

--- a/src/app/static/src/tests/integration/password.itest.ts
+++ b/src/app/static/src/tests/integration/password.itest.ts
@@ -1,12 +1,13 @@
 import {actions} from "../../app/store/password/actions";
 import {mockError} from "../mocks";
+import {rootState} from "./integrationTest";
 
 describe("Password actions", () => {
 
     it("can request password reset link", async () => {
 
         const commit = jest.fn();
-        await actions.requestResetLink({commit} as any, "test.user@example.com");
+        await actions.requestResetLink({commit, rootState} as any, "test.user@example.com");
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ResetLinkRequested",
@@ -17,7 +18,7 @@ describe("Password actions", () => {
     it("can reset password", async () => {
 
         const commit = jest.fn();
-        await actions.resetPassword({commit} as any, {token: "FAKETOKEN", password: "pw"});
+        await actions.resetPassword({commit, rootState} as any, {token: "FAKETOKEN", password: "pw"});
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ResetPasswordError",

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -1,6 +1,6 @@
 import {actions} from "../../app/store/surveyAndProgram/actions";
 import {actions as baselineActions} from "../../app/store/baseline/actions"
-import {login} from "./integrationTest";
+import {login, rootState} from "./integrationTest";
 import {getFormData} from "./helpers";
 import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
 
@@ -13,7 +13,7 @@ describe("Survey and programme actions", () => {
         const dispatch = jest.fn();
         const formData = getFormData("malawi.geojson");
 
-        await baselineActions.uploadShape({commit, dispatch} as any, formData);
+        await baselineActions.uploadShape({commit, dispatch, rootState} as any, formData);
     });
 
     it("can upload survey", async () => {
@@ -23,7 +23,7 @@ describe("Survey and programme actions", () => {
 
         const formData = getFormData("survey.csv");
 
-        await actions.uploadSurvey({commit, dispatch} as any, formData);
+        await actions.uploadSurvey({commit, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(SurveyAndProgramMutation.SurveyUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
@@ -37,7 +37,7 @@ describe("Survey and programme actions", () => {
 
         const formData = getFormData("programme.csv");
 
-        await actions.uploadProgram({commit, dispatch} as any, formData);
+        await actions.uploadProgram({commit, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
@@ -49,7 +49,7 @@ describe("Survey and programme actions", () => {
         const commit = jest.fn();
         const formData = getFormData("anc.csv");
 
-        await actions.uploadANC({commit} as any, formData);
+        await actions.uploadANC({commit, rootState} as any, formData);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
@@ -63,18 +63,18 @@ describe("Survey and programme actions", () => {
         const formData = getFormData("survey.csv");
 
         // upload
-        await actions.uploadSurvey({commit} as any, formData);
+        await actions.uploadSurvey({commit, rootState} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deleteSurvey({commit} as any);
+        await actions.deleteSurvey({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.SurveyUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getSurveyAndProgramData({commit} as any);
+        await actions.getSurveyAndProgramData({commit, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == SurveyAndProgramMutation.SurveyUpdated)[0]["payload"]).toBe(null);
     });
 
@@ -84,18 +84,18 @@ describe("Survey and programme actions", () => {
         const formData = getFormData("programme.csv");
 
         // upload
-        await actions.uploadProgram({commit} as any, formData);
+        await actions.uploadProgram({commit, rootState} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deleteProgram({commit} as any);
+        await actions.deleteProgram({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getSurveyAndProgramData({commit} as any);
+        await actions.getSurveyAndProgramData({commit, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == SurveyAndProgramMutation.ProgramUpdated)[0]["payload"]).toBe(null);
     });
 
@@ -105,18 +105,18 @@ describe("Survey and programme actions", () => {
         const formData = getFormData("anc.csv");
 
         // upload
-        await actions.uploadANC({commit} as any, formData);
+        await actions.uploadANC({commit, rootState} as any, formData);
 
         commit.mockReset();
 
         // delete
-        await actions.deleteANC({commit} as any);
+        await actions.deleteANC({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
 
         commit.mockReset();
 
         // if the file has been deleted, data should come back null
-        await actions.getSurveyAndProgramData({commit} as any);
+        await actions.getSurveyAndProgramData({commit, rootState} as any);
         expect(commit.mock.calls.find(c => c[0]["type"] == SurveyAndProgramMutation.ANCUpdated)[0]["payload"]).toBe(null);
     });
 

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -4,7 +4,7 @@ import {LoadingState} from "../../app/store/load/load";
 import {addCheckSum} from "../../app/utils";
 import {localStorageManager} from "../../app/localStorageManager";
 
-const FormData = require("form-data");
+const rootState = mockRootState();
 
 describe("Load actions", () => {
 
@@ -20,7 +20,7 @@ describe("Load actions", () => {
 
     it("load reads blob and dispatches setFiles action", (done) => {
         const dispatch = jest.fn();
-        actions.load({dispatch} as any, new File(["Test File Contents"], "testFile"));
+        actions.load({dispatch, rootState} as any, new File(["Test File Contents"], "testFile"));
 
         const interval = setInterval(()=> {
             if (dispatch.mock.calls.length > 0) {
@@ -34,7 +34,7 @@ describe("Load actions", () => {
 
     it("clears loading state", async () => {
         const commit = jest.fn();
-        await actions.clearLoadState({commit} as any);
+        await actions.clearLoadState({commit, rootState} as any);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "LoadStateCleared", payload: null});
     });
 
@@ -47,7 +47,7 @@ describe("Load actions", () => {
         const state = mockLoadState({loadingState: LoadingState.UpdatingState});
         const dispatch = jest.fn();
         const fileContents = addCheckSum('{"files": "TEST FILES", "state": "TEST STATE"}');
-        await actions.setFiles({commit, state, dispatch} as any, fileContents);
+        await actions.setFiles({commit, state, dispatch, rootState} as any, fileContents);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "SettingFiles", payload: null});
         expect(commit.mock.calls[1][0]).toStrictEqual({type: "UpdatingState", payload: {}});
@@ -66,7 +66,7 @@ describe("Load actions", () => {
         const state = mockLoadState({loadingState: LoadingState.NotLoading});
         const dispatch = jest.fn();
         const fileContents = '["badchecksum", {"files": "TEST FILES", "state": "TEST STATE"}]';
-        await actions.setFiles({commit, state, dispatch} as any, fileContents);
+        await actions.setFiles({commit, state, dispatch, rootState} as any, fileContents);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "SettingFiles", payload: null});
         expect(commit.mock.calls[1][0]).toStrictEqual({
@@ -87,7 +87,7 @@ describe("Load actions", () => {
         const state = mockLoadState({loadingState: LoadingState.NotLoading});
         const dispatch = jest.fn();
         const fileContents = addCheckSum('{"files": "TEST FILES", "state": "TEST STATE"}');
-        await actions.setFiles({commit, state, dispatch} as any, fileContents);
+        await actions.setFiles({commit, state, dispatch, rootState} as any, fileContents);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "SettingFiles", payload: null});
         expect(commit.mock.calls[1][0]).toStrictEqual({type: "LoadFailed", payload: mockError("Test error")});
@@ -105,7 +105,7 @@ describe("Load actions", () => {
         window.location = {reload: mockLocationReload} as any;
 
         const testState = mockRootState();
-        await actions.updateStoreState({} as any, testState);
+        await actions.updateStoreState({rootState} as any, testState);
 
         expect(mockSaveToLocalStorage.mock.calls[0][0]).toBe(testState);
         expect(mockLocationReload.mock.calls.length).toBe(1);

--- a/src/app/static/src/tests/metadata/actions.test.ts
+++ b/src/app/static/src/tests/metadata/actions.test.ts
@@ -1,10 +1,11 @@
 import {
     mockAxios, mockError,
-    mockFailure,
+    mockFailure, mockRootState,
     mockSuccess
 } from "../mocks";
 import {actions} from "../../app/store/metadata/actions";
 
+const rootState = mockRootState();
 describe("Metadata actions", () => {
 
     beforeEach(() => {
@@ -23,7 +24,7 @@ describe("Metadata actions", () => {
             .reply(200, mockSuccess("TEST DATA"));
 
         const commit = jest.fn();
-        await actions.getPlottingMetadata({commit} as any, "Malawi");
+        await actions.getPlottingMetadata({commit, rootState} as any, "Malawi");
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "PlottingMetadataFetched", payload: "TEST DATA"});
     });
@@ -41,7 +42,7 @@ describe("Metadata actions", () => {
             .reply(statusCode, mockFailure("Test Error"));
 
         const commit = jest.fn();
-        await actions.getPlottingMetadata({commit} as any, "Malawi");
+        await actions.getPlottingMetadata({commit, rootState} as any, "Malawi");
 
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "PlottingMetadataError", payload: mockError("Test Error")});
     }

--- a/src/app/static/src/tests/modelOptions/actions.test.ts
+++ b/src/app/static/src/tests/modelOptions/actions.test.ts
@@ -1,6 +1,7 @@
 import {actions} from "../../app/store/modelOptions/actions";
-import {mockAxios, mockSuccess} from "../mocks";
+import {mockAxios, mockRootState, mockSuccess} from "../mocks";
 
+const rootState = mockRootState();
 describe("model run options actions", () => {
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("model run options actions", () => {
     it("fetches and commits model run options and version", async () => {
         mockAxios.onGet("/model/options/").reply(200, mockSuccess("TEST", "v1"));
         const commit = jest.fn();
-        await actions.fetchModelRunOptions({commit} as any);
+        await actions.fetchModelRunOptions({commit, rootState} as any);
 
         expect(commit.mock.calls[0][0]).toStrictEqual("FetchingModelOptions");
         expect(commit.mock.calls[1][0]).toStrictEqual({

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -8,8 +8,10 @@ import {
     mockSuccess
 } from "../mocks";
 import {actions} from "../../app/store/modelRun/actions";
-import {ModelResultResponse, ModelStatusResponse} from "../../app/generated";
+import {ModelStatusResponse} from "../../app/generated";
 import {expectEqualsFrozen} from "../testHelpers";
+
+const rootState = mockRootState();
 
 describe("Model run actions", () => {
 
@@ -46,7 +48,7 @@ describe("Model run actions", () => {
             .reply(200, mockSuccess({id: "12345"}));
 
         const commit = jest.fn();
-        await actions.run({commit, rootState: mockRootState()} as any);
+        await actions.run({commit, rootState} as any);
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ModelRunStarted",
             payload: {id: "12345"}
@@ -65,7 +67,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
 
-        actions.poll({commit, state, dispatch} as any, "1234");
+        actions.poll({commit, state, dispatch, rootState} as any, "1234");
 
         setInterval(() => {
             expect(dispatch.mock.calls[0][0]).toStrictEqual("getResult");
@@ -85,7 +87,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
 
-        actions.poll({commit, state, dispatch} as any, "1234");
+        actions.poll({commit, state, dispatch, rootState} as any, "1234");
 
         setInterval(() => {
             expect(dispatch.mock.calls.length).toEqual(0);
@@ -103,7 +105,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const state = mockModelRunState();
 
-        actions.poll({commit, state} as any, "1234");
+        actions.poll({commit, state, rootState} as any, "1234");
 
         setTimeout(() => {
             expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
@@ -124,7 +126,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const state = mockModelRunState();
 
-        actions.poll({commit, state} as any, "1234");
+        actions.poll({commit, state, rootState} as any, "1234");
 
         setTimeout(() => {
             expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
@@ -145,7 +147,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const state = mockModelRunState({modelRunId: "1234", status: {done: true} as ModelStatusResponse});
 
-        await actions.getResult({commit, state} as any);
+        await actions.getResult({commit, state, rootState} as any);
 
         expectEqualsFrozen(commit.mock.calls[0][0], {
             type: "RunResultFetched",
@@ -181,7 +183,7 @@ describe("Model run actions", () => {
             result: testResult as any
         });
 
-        await actions.getResult({commit, state} as any);
+        await actions.getResult({commit, state, rootState} as any);
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: "plottingSelections/updateBarchartSelections",
@@ -201,7 +203,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const state = mockModelRunState({modelRunId: "1234", status: {done: true, id: "1234"} as ModelStatusResponse});
 
-        await actions.getResult({commit, state} as any);
+        await actions.getResult({commit, state, rootState} as any);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "RunResultError",
@@ -220,7 +222,7 @@ describe("Model run actions", () => {
         const commit = jest.fn();
         const state = mockModelRunState({modelRunId: "1234", status: {done: false, id: "1234"} as ModelStatusResponse});
 
-        await actions.getResult({commit, state} as any);
+        await actions.getResult({commit, state, rootState} as any);
 
         expect(mockAxios.history.get.length).toBe(0);
         expect(commit.mock.calls[0][0]).toStrictEqual({

--- a/src/app/static/src/tests/password/actions.test.ts
+++ b/src/app/static/src/tests/password/actions.test.ts
@@ -1,6 +1,7 @@
-import {mockAxios, mockError, mockFailure, mockSuccess} from "../mocks";
+import {mockAxios, mockError, mockFailure, mockRootState, mockSuccess} from "../mocks";
 import {actions} from "../../app/store/password/actions";
 
+const rootState = mockRootState();
 describe("Password actions", () => {
 
     beforeEach(() => {
@@ -20,7 +21,7 @@ describe("Password actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.requestResetLink({commit} as any, "test@email.com");
+        await actions.requestResetLink({commit, rootState} as any, "test@email.com");
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ResetLinkRequested",
@@ -34,7 +35,7 @@ describe("Password actions", () => {
             .reply(500, mockFailure("test error"));
 
         const commit = jest.fn();
-        await actions.requestResetLink({commit} as any, "test@email.com");
+        await actions.requestResetLink({commit, rootState} as any, "test@email.com");
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "RequestResetLinkError",
@@ -48,7 +49,7 @@ describe("Password actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.resetPassword({commit} as any, {"token": "testToken", "password": "new_password"});
+        await actions.resetPassword({commit, rootState} as any, {"token": "testToken", "password": "new_password"});
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ResetPassword",
@@ -62,7 +63,7 @@ describe("Password actions", () => {
             .reply(500, mockFailure("test error"));
 
         const commit = jest.fn();
-        await actions.resetPassword({commit} as any, {"token": "testToken", "password": "new_password"});
+        await actions.resetPassword({commit, rootState} as any, {"token": "testToken", "password": "new_password"});
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "ResetPasswordError",

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -4,7 +4,7 @@ import {
     mockAxios,
     mockError,
     mockFailure,
-    mockProgramResponse,
+    mockProgramResponse, mockRootState,
     mockSuccess,
     mockSurveyResponse
 } from "../mocks";
@@ -14,6 +14,7 @@ import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutatio
 import {expectEqualsFrozen} from "../testHelpers";
 
 const FormData = require("form-data");
+const rootState = mockRootState();
 
 describe("Survey and programme actions", () => {
 
@@ -33,7 +34,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess({data: "SOME DATA"}));
 
         const commit = jest.fn();
-        await actions.uploadSurvey({commit} as any, new FormData());
+        await actions.uploadSurvey({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.SurveyUpdated,
@@ -56,7 +57,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadSurvey({commit} as any, new FormData());
+        await actions.uploadSurvey({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.SurveyUpdated,
@@ -77,7 +78,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess("TEST"));
 
         const commit = jest.fn();
-        await actions.uploadProgram({commit} as any, new FormData());
+        await actions.uploadProgram({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramUpdated,
@@ -100,7 +101,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadProgram({commit} as any, new FormData());
+        await actions.uploadProgram({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramUpdated,
@@ -122,7 +123,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess("TEST"));
 
         const commit = jest.fn();
-        await actions.uploadANC({commit} as any, new FormData());
+        await actions.uploadANC({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCUpdated,
@@ -145,7 +146,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadANC({commit} as any, new FormData());
+        await actions.uploadANC({commit, rootState} as any, new FormData());
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCUpdated,
@@ -173,7 +174,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess(mockAncResponse()));
 
         const commit = jest.fn();
-        await actions.getSurveyAndProgramData({commit} as any);
+        await actions.getSurveyAndProgramData({commit, rootState} as any);
 
         const calls = commit.mock.calls.map((callArgs) => callArgs[0]["type"]);
         expect(calls).toContain(SurveyAndProgramMutation.SurveyUpdated);
@@ -199,7 +200,7 @@ describe("Survey and programme actions", () => {
             .reply(500);
 
         const commit = jest.fn();
-        await actions.getSurveyAndProgramData({commit} as any);
+        await actions.getSurveyAndProgramData({commit, rootState} as any);
 
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.Ready);
@@ -210,7 +211,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.deleteSurvey({commit} as any);
+        await actions.deleteSurvey({commit, rootState} as any);
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.SurveyUpdated);
     });
@@ -220,7 +221,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.deleteProgram({commit} as any);
+        await actions.deleteProgram({commit, rootState} as any);
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
     });
@@ -230,7 +231,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.deleteANC({commit} as any);
+        await actions.deleteANC({commit, rootState} as any);
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
     });
@@ -246,7 +247,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess(true));
 
         const commit = jest.fn();
-        await actions.deleteAll({commit} as any);
+        await actions.deleteAll({commit, rootState} as any);
         expect(mockAxios.history["delete"].length).toBe(3);
         expect(commit).toBeCalledTimes(3);
         expect(commit.mock.calls.map(c => c[0]["type"])).toEqual([

--- a/src/app/static/src/tests/testHelpers.ts
+++ b/src/app/static/src/tests/testHelpers.ts
@@ -1,4 +1,4 @@
-import {mockAxios, mockBaselineState, mockError, mockFailure} from "./mocks";
+import {mockAxios, mockBaselineState, mockError, mockFailure, mockRootState} from "./mocks";
 import {ActionContext, MutationTree} from "vuex";
 import {PayloadWithType} from "../app/types";
 import i18next from "i18next";
@@ -23,7 +23,8 @@ export function testUploadErrorCommitted(url: string,
         const commit = jest.fn();
         const state = mockBaselineState();
         const dispatch = jest.fn();
-        await action({commit, state, dispatch} as any, new FormData());
+        const rootState = mockRootState();
+        await action({commit, state, dispatch, rootState} as any, new FormData());
 
         // first call to clear the data
         expect(commit.mock.calls[0][0]).toStrictEqual({


### PR DESCRIPTION
This won't do anything yet because the back-end isn't there, but pass the `Accept-Language` header on every POST and GET request.