### PR TITLE
mrc-1235 translate css content

### DIFF
--- a/src/app/static/src/app/index.ts
+++ b/src/app/static/src/app/index.ts
@@ -3,7 +3,8 @@ import {store} from "./main"
 import Stepper from "./components/Stepper.vue";
 import UserHeader from "./components/header/UserHeader.vue";
 import Errors from "./components/Errors.vue";
-import {mapActions} from "vuex";
+import {mapActions, mapState} from "vuex";
+import {RootState} from "./root";
 
 export const app = new Vue({
     el: "#app",
@@ -13,6 +14,9 @@ export const app = new Vue({
         UserHeader,
         Errors
     },
+    computed: mapState<RootState>({
+        language: state => state.language
+    }),
     methods: {
         ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
         ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'}),

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -70,6 +70,12 @@ a {
   text-align: center;
 }
 
+.fr {
+  .custom-file-label::after {
+    content: "Parcourir" !important;
+  }
+}
+
 .lds-spin.xs {
   margin-top: -15px;
 }

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -1,4 +1,4 @@
-import {mount} from '@vue/test-utils';
+import {mount, shallowMount} from '@vue/test-utils';
 import Vuex, {Store} from 'vuex';
 import {ReadyState, RootState, storeOptions} from "../../app/root";
 import {localStorageManager} from "../../app/localStorageManager";
@@ -57,6 +57,17 @@ describe("App", () => {
             expect(modelRunActions.getResult).toHaveBeenCalled();
             done();
         });
+    });
+
+    it("gets language from state", () => {
+        const store = getStore();
+        let c = app.$options;
+        const rendered = shallowMount({
+            computed: c.computed,
+            template: "<div :class='language'></div>"
+        }, {store});
+
+        expect(rendered.classes()).toContain("en");
     });
 
     it("updates local storage on every mutation", () => {

--- a/src/app/static/templates/index.ftl
+++ b/src/app/static/templates/index.ftl
@@ -8,7 +8,7 @@
     <!-- endinject -->
 </head>
 <body>
-<div id="app">
+<div id="app" :class="language">
     <user-header title="${title}"></user-header>
     <stepper></stepper>
     <errors title="${title}"></errors>


### PR DESCRIPTION
The custom file input button's text is determined by css. This PR adds a css class to the app element based on the language and changes the text accordingly. Testing options are a bit limited here, it'd be nice to work out a better pattern for testing the app given the reliance on `index.ftl` but not super important right now.