### PR TITLE
mrc-1289: More explicit username label

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
@@ -22,7 +22,7 @@ class LoginTests
 
         assertThat(doc.select("form").attr("onsubmit")).isEqualTo("validate(event);")
 
-        assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username")
+        assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username (email address)")
         assertThat(doc.select("form #user-id").attr("value")).isEqualTo("test user")
         assertThat(doc.select("form #user-id").attr("type")).isEqualTo("text")
         assertThat(doc.select("form #userid-feedback").hasClass("invalid-feedback")).isTrue()
@@ -50,7 +50,7 @@ class LoginTests
         model["title"] = "test title"
         val doc = template.jsoupDocFor(model)
 
-        assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username")
+        assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username (email address)")
         assertThat(doc.select("form #user-id").attr("value")).isEqualTo("")
 
         assertThat(doc.select("form label[for='pw-id']").text()).isEqualTo("Password")

--- a/src/app/static/templates/login.ftl
+++ b/src/app/static/templates/login.ftl
@@ -27,7 +27,7 @@
         <div class="card-body">
             <form id="login-form" method="post" action="/callback" class="needs-validation" novalidate onsubmit="validate(event);">
                 <div class="form-group">
-                    <label for="user-id">Username</label>
+                    <label for="user-id">Username (email address)</label>
                     <input type="text" size="20" class="form-control" name="username" id="user-id" value="${username}" required>
                     <div id="userid-feedback" class="invalid-feedback">Please enter your username.</div>
                 </div>


### PR DESCRIPTION
This PR expands the text from "Username" to "Username (email address)" in the login screen, based on feedback from @r-ash in previous workshops