### PR TITLE
mrc-1432 BUG - error when loading state for Nigeria

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
@@ -118,6 +118,7 @@ class HintrAPIClient(
 
     private fun postJson(url: String, json: String): ResponseEntity<String> {
         return "$baseUrl/$url".httpPost()
+                .addTimeouts()
                 .header("Accept-Language" to getAcceptLanguage())
                 .header("Content-Type" to "application/json")
                 .body(json)


### PR DESCRIPTION
The error coming back is a timeout for the validate/baseline-combined endpoint - I was baffled for a while as this is a quick endpoint (and is returned fine from hintr, checked the logs).

Finally I noticed that the `postJson` method is missing the timeout extensions all the other methods have. Haven't tested that this fixes things but I'm pretty confident. Fuel's default timeouts are ridiculously low, like 15 seconds.