### PR TITLE
mrc-1412 send full file object to hintr

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/APIClient.kt
@@ -18,7 +18,7 @@ interface APIClient {
     fun validateBaselineIndividual(file: SessionFileWithPath, type: FileType): ResponseEntity<String>
     fun validateBaselineCombined(files: Map<String, SessionFileWithPath?>): ResponseEntity<String>
     fun validateSurveyAndProgramme(file: SessionFileWithPath, shapePath: String, type: FileType): ResponseEntity<String>
-    fun submit(data: Map<String, String>, modelRunOptions: ModelRunOptions): ResponseEntity<String>
+    fun submit(data: Map<String, SessionFileWithPath>, modelRunOptions: ModelRunOptions): ResponseEntity<String>
     fun getStatus(id: String): ResponseEntity<String>
     fun getResult(id: String): ResponseEntity<String>
     fun getPlottingMetadata(iso3: String): ResponseEntity<String>
@@ -65,7 +65,7 @@ class HintrAPIClient(
         return postJson("validate/survey-and-programme", json)
     }
 
-    override fun submit(data: Map<String, String>, modelRunOptions: ModelRunOptions): ResponseEntity<String> {
+    override fun submit(data: Map<String, SessionFileWithPath>, modelRunOptions: ModelRunOptions): ResponseEntity<String> {
 
         val json = objectMapper.writeValueAsString(
                 mapOf("options" to modelRunOptions.options,

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
@@ -14,7 +14,7 @@ class ModelRunController(val fileManager: FileManager, val apiClient: APIClient)
     @PostMapping("/run/")
     @ResponseBody
     fun run(@RequestBody modelRunOptions: ModelRunOptions): ResponseEntity<String> {
-        val allFiles = fileManager.getAllHashes()
+        val allFiles = fileManager.getFiles()
         return apiClient.submit(allFiles, modelRunOptions)
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
@@ -19,13 +19,13 @@ class ModelRunControllerTests {
 
     @Test
     fun `can run`() {
-        val mockHashes = mapOf<String, String>()
-        val mockFileManager = mock<FileManager>{
-            on {getAllHashes()} doReturn mockHashes
+        val mockFiles = mapOf<String, SessionFileWithPath>()
+        val mockFileManager = mock<FileManager> {
+            on { getFiles() } doReturn mockFiles
         }
 
         val mockAPIClient = mock<APIClient> {
-            on {submit(mockHashes, modelRunOptions)} doReturn mockResponse
+            on { submit(mockFiles, modelRunOptions) } doReturn mockResponse
         }
 
         val sut = ModelRunController(mockFileManager, mockAPIClient)
@@ -37,8 +37,8 @@ class ModelRunControllerTests {
     @Test
     fun `can get status`() {
         val mockFileManager = mock<FileManager>()
-        val mockAPIClient = mock<APIClient>{
-            on {getStatus("testId")} doReturn mockResponse
+        val mockAPIClient = mock<APIClient> {
+            on { getStatus("testId") } doReturn mockResponse
         }
 
         val sut = ModelRunController(mockFileManager, mockAPIClient)
@@ -51,7 +51,7 @@ class ModelRunControllerTests {
     fun `can get result`() {
         val mockFileManager = mock<FileManager>()
         val mockAPIClient = mock<APIClient> {
-            on {getResult("testId")} doReturn mockResponse
+            on { getResult("testId") } doReturn mockResponse
         }
         val sut = ModelRunController(mockFileManager, mockAPIClient)
 
@@ -66,8 +66,8 @@ class ModelRunControllerTests {
             on { getFiles(FileType.Shape, FileType.Survey, FileType.Programme, FileType.ANC) } doReturn mockFiles
         }
 
-        val mockAPIClient = mock<APIClient>{
-            on {getModelRunOptions(mockFiles)} doReturn mockResponse
+        val mockAPIClient = mock<APIClient> {
+            on { getModelRunOptions(mockFiles) } doReturn mockResponse
         }
         val sut = ModelRunController(mockFileManager, mockAPIClient)
 
@@ -78,8 +78,8 @@ class ModelRunControllerTests {
     @Test
     fun `can cancel`() {
         val mockFileManager = mock<FileManager>()
-        val mockAPIClient = mock<APIClient>{
-            on {cancelModelRun("testId")} doReturn mockResponse
+        val mockAPIClient = mock<APIClient> {
+            on { cancelModelRun("testId") } doReturn mockResponse
         }
         val sut = ModelRunController(mockFileManager, mockAPIClient)
 


### PR DESCRIPTION
hintr doesn't check the schema being passed so this works with the mock model setup, but should not be merged until Naomi is updated to support this schema.