### PR TITLE
mrc-1444 performance improvement

### DIFF
--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -214,6 +214,9 @@
                 return this.currentFeatures.map(f => f.properties!!["area_id"]);
             },
             colourRanges() {
+                if (!this.initialised){
+                    return {}
+                }
                 let selectedCurrentLevelAreaIds = this.selectedAreaIds.filter(a => this.currentLevelFeatureIds.indexOf(a) > -1);
 
                 return getColourRanges(
@@ -230,6 +233,9 @@
                 return Array.from(selectedAreaIdSet)
             },
             featureIndicators() {
+                if (!this.initialised){
+                    return {}
+                }
                 return getFeatureIndicators(
                     this.chartdata,
                     this.selectedAreaIds,

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -136,12 +136,13 @@ export const iterateDataValues = function(
            indicatorMeta: ChoroplethIndicatorMetadata, value: number) => void) {
 
     const selectedFilterValueIds: Dict<string[]> = {};
-    if (filters && selectedFilterValues) {
-        for (const f of filters) {
+    const validFilters = filters && filters.filter(f => f.options && f.options.length > 0);
+
+    if (validFilters && selectedFilterValues) {
+        for (const f of validFilters) {
             selectedFilterValueIds[f.id] = selectedFilterValues[f.id].map(n => n.id)
         }
     }
-    const validFilters = filters && filters.filter(f => f.options && f.options.length > 0);
 
     for (const row of data) {
         if (validFilters && selectedFilterValues && excludeRow(row, validFilters, selectedFilterValueIds)) {

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -2,7 +2,6 @@ import * as d3ScaleChromatic from "d3-scale-chromatic";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
 import {Dict, Filter, NumericRange} from "../../types";
 import {ColourScaleSelections, ColourScaleType} from "../../store/plottingSelections/plottingSelections";
-import {jsJsx} from "ts-loader/dist/constants";
 
 export const getColor = (value: number, metadata: ChoroplethIndicatorMetadata,
                          colourRange: NumericRange) => {
@@ -138,12 +137,11 @@ export const iterateDataValues = function (
 
     const selectedFilterValueIds: Dict<string[]> = {};
     const validFilters = filters && selectedFilterValues
-        && filters.filter(f => f.options && f.options.length > 0);
+        && filters.filter(f => f.options && f.options.length > 0 && selectedFilterValues!!.hasOwnProperty(f.id));
 
     if (validFilters) {
         for (const f of validFilters) {
-                selectedFilterValueIds[f.id] = selectedFilterValues!!.hasOwnProperty(f.id) ?
-                    selectedFilterValues!![f.id].map(n => n.id) : []
+            selectedFilterValueIds[f.id] = selectedFilterValues!![f.id].map(n => n.id)
         }
     }
     for (const row of data) {

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -2,6 +2,7 @@ import * as d3ScaleChromatic from "d3-scale-chromatic";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
 import {Dict, Filter, NumericRange} from "../../types";
 import {ColourScaleSelections, ColourScaleType} from "../../store/plottingSelections/plottingSelections";
+import {jsJsx} from "ts-loader/dist/constants";
 
 export const getColor = (value: number, metadata: ChoroplethIndicatorMetadata,
                          colourRange: NumericRange) => {
@@ -30,8 +31,8 @@ export const getColor = (value: number, metadata: ChoroplethIndicatorMetadata,
     return colorFunction(colorValue);
 };
 
-export const colourScaleStepFromMetadata = function(meta: ChoroplethIndicatorMetadata) {
-  return (meta.max - meta.min) / 10;
+export const colourScaleStepFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
+    return (meta.max - meta.min) / 10;
 };
 
 export const colorFunctionFromName = function (name: string) {
@@ -44,11 +45,11 @@ export const colorFunctionFromName = function (name: string) {
     return result;
 };
 
-export const getIndicatorRanges = function(data: any,
-                                           indicatorsMeta: ChoroplethIndicatorMetadata[],
-                                           filters: Filter[] | null = null,
-                                           selectedFilterValues: Dict<FilterOption[]> | null = null,
-                                           selectedAreaIds: string[] | null = null): Dict<NumericRange>{
+export const getIndicatorRanges = function (data: any,
+                                            indicatorsMeta: ChoroplethIndicatorMetadata[],
+                                            filters: Filter[] | null = null,
+                                            selectedFilterValues: Dict<FilterOption[]> | null = null,
+                                            selectedAreaIds: string[] | null = null): Dict<NumericRange> {
     const result = {} as Dict<NumericRange>;
     iterateDataValues(data, indicatorsMeta, selectedAreaIds, filters, selectedFilterValues,
         (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number) => {
@@ -65,21 +66,21 @@ export const getIndicatorRanges = function(data: any,
     return result;
 };
 
-export const getColourRanges = function(data: any,
-                                        indicatorsMeta: ChoroplethIndicatorMetadata[],
-                                        colourScales: ColourScaleSelections,
-                                        filters: Filter[],
-                                        selectedFilterValues: Dict<FilterOption[]>,
-                                        selectedAreaIds: string[]) {
-  const result = {} as Dict<NumericRange>;
-  let fullIndicatorRanges = null;
-  let filteredIndicatorRanges = null;
+export const getColourRanges = function (data: any,
+                                         indicatorsMeta: ChoroplethIndicatorMetadata[],
+                                         colourScales: ColourScaleSelections,
+                                         filters: Filter[],
+                                         selectedFilterValues: Dict<FilterOption[]>,
+                                         selectedAreaIds: string[]) {
+    const result = {} as Dict<NumericRange>;
+    let fullIndicatorRanges = null;
+    let filteredIndicatorRanges = null;
 
-  for(const meta of indicatorsMeta) {
+    for (const meta of indicatorsMeta) {
         const indicatorId = meta.indicator;
         const colourScale = colourScales[indicatorId];
         const colourScaleType = colourScale ? colourScale.type : ColourScaleType.Default;
-        switch(colourScaleType) {
+        switch (colourScaleType) {
             case(ColourScaleType.Default):
                 result[indicatorId] = {min: meta.min, max: meta.max};
                 break;
@@ -103,17 +104,17 @@ export const getColourRanges = function(data: any,
 
                 result[indicatorId] = roundRange({
                     min: filteredIndicatorRanges[indicatorId] ? filteredIndicatorRanges[indicatorId].min : 0,
-                    max:  filteredIndicatorRanges[indicatorId] ? filteredIndicatorRanges[indicatorId].max : 0
+                    max: filteredIndicatorRanges[indicatorId] ? filteredIndicatorRanges[indicatorId].max : 0
                 });
                 break;
             default:
                 break;
         }
-  }
-  return result;
+    }
+    return result;
 };
 
-export const roundRange = function(unrounded: NumericRange) {
+export const roundRange = function (unrounded: NumericRange) {
     //round appropriate to the range magnitude
     let decPl = 0;
     let magnitude = unrounded.max == unrounded.min ? unrounded.min : (unrounded.max - unrounded.min);
@@ -126,7 +127,7 @@ export const roundRange = function(unrounded: NumericRange) {
     return {min: roundToPlaces(unrounded.min, decPl), max: roundToPlaces(unrounded.max, decPl)};
 };
 
-export const iterateDataValues = function(
+export const iterateDataValues = function (
     data: any,
     indicatorsMeta: ChoroplethIndicatorMetadata[],
     selectedAreaIds: string[] | null,
@@ -136,16 +137,17 @@ export const iterateDataValues = function(
            indicatorMeta: ChoroplethIndicatorMetadata, value: number) => void) {
 
     const selectedFilterValueIds: Dict<string[]> = {};
-    const validFilters = filters && filters.filter(f => f.options && f.options.length > 0);
+    const validFilters = filters && selectedFilterValues
+        && filters.filter(f => f.options && f.options.length > 0);
 
-    if (validFilters && selectedFilterValues) {
+    if (validFilters) {
         for (const f of validFilters) {
-            selectedFilterValueIds[f.id] = selectedFilterValues[f.id].map(n => n.id)
+                selectedFilterValueIds[f.id] = selectedFilterValues!!.hasOwnProperty(f.id) ?
+                    selectedFilterValues!![f.id].map(n => n.id) : []
         }
     }
-
     for (const row of data) {
-        if (validFilters && selectedFilterValues && excludeRow(row, validFilters, selectedFilterValueIds)) {
+        if (validFilters && excludeRow(row, validFilters, selectedFilterValueIds)) {
             continue;
         }
 
@@ -174,7 +176,7 @@ export const iterateDataValues = function(
     }
 };
 
-const excludeRow = function(row: any, filters: Filter[], selectedFilterValues: Dict<string[]>){
+const excludeRow = function (row: any, filters: Filter[], selectedFilterValues: Dict<string[]>) {
     let excludeRow = false;
     for (const filter of filters) {
         if (selectedFilterValues[filter.id].indexOf(row[filter.column_id].toString()) < 0) {
@@ -194,7 +196,7 @@ export const toIndicatorNameLookup = (array: ChoroplethIndicatorMetadata[]) =>
 export const roundToContext = function (value: number, context: number[]) {
     //Rounds the value to one more decimal place than is present in the 'context'
     let maxDecPl = 0;
-    for(const contextValue of context) {
+    for (const contextValue of context) {
         const maxFraction = contextValue.toString().split(".");
         const decPl = maxFraction.length > 1 ? maxFraction[1].length : 0;
         maxDecPl = Math.max(maxDecPl, decPl + 1);
@@ -203,7 +205,7 @@ export const roundToContext = function (value: number, context: number[]) {
     return roundToPlaces(value, maxDecPl);
 };
 
-const roundToPlaces = function(value: number, decPl: number){
+const roundToPlaces = function (value: number, decPl: number) {
     const roundingNum = Math.pow(10, decPl);
     return Math.round(value * roundingNum) / roundingNum;
 };

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -1,20 +1,37 @@
 import {
     colorFunctionFromName,
+    colourScaleStepFromMetadata,
     getColor,
+    getColourRanges,
     getIndicatorRanges,
-    toIndicatorNameLookup,
-    roundToContext, colourScaleStepFromMetadata, getColourRanges, roundRange
+    iterateDataValues,
+    roundRange,
+    roundToContext,
+    toIndicatorNameLookup
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
-import {ChoroplethIndicatorMetadata, FilterOption} from "../../../app/generated";
-import {ColourScaleSelections, ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {Filter} from "../../../app/generated";
+import {ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {Dict, NumericRange} from "../../../app/types";
 
 const indicators = [
     {
-        indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
+        indicator: "plhiv",
+        value_column: "plhiv",
+        name: "PLHIV",
+        min: 0,
+        max: 0,
+        colour: "interpolateGreys",
+        invert_scale: false
     },
     {
-        indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        indicator: "prevalence",
+        value_column: "prevalence",
+        name: "Prevalence",
+        min: 0,
+        max: 0,
+        colour: "interpolateGreys",
+        invert_scale: false
     }
 ];
 
@@ -40,7 +57,7 @@ it("getColor calculates colour string", () => {
         },
         {
             min: 0,
-            max:1
+            max: 1
         });
 
     expect(result).toEqual("rgb(151, 151, 151)");
@@ -91,22 +108,58 @@ it("can get colour ranges", () => {
 
     const indicatorsMeta = [
         {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
+            indicator: "prevalence",
+            value_column: "prevalence",
+            name: "Prevalence",
+            min: 0,
+            max: 1,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:20, colour: "interpolateGreys", invert_scale: false
+            indicator: "plhiv",
+            value_column: "plhiv",
+            name: "PLHIV",
+            min: 0,
+            max: 20,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "art_cov", value_column: "art_cov", name: "ART coverage", min: 0, max:20, colour: "interpolateGreys", invert_scale: false
+            indicator: "art_cov",
+            value_column: "art_cov",
+            name: "ART coverage",
+            min: 0,
+            max: 20,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "vls", value_column: "vls", name: "Viral Load Suppression", min: 0, max:21, colour: "interpolateGreys", invert_scale: false
+            indicator: "vls",
+            value_column: "vls",
+            name: "Viral Load Suppression",
+            min: 0,
+            max: 21,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "nonexistent_full", value_column: "ne_full", name: "Not In Data", min: 0, max:1, colour: "interpolateGreys", invert_scale: false
+            indicator: "nonexistent_full",
+            value_column: "ne_full",
+            name: "Not In Data",
+            min: 0,
+            max: 1,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "nonexistent_filtered", value_column: "ne_filtered", name: "Not In Data", min: 0, max:1, colour: "interpolateGreys", invert_scale: false
+            indicator: "nonexistent_filtered",
+            value_column: "ne_filtered",
+            name: "Not In Data",
+            min: 0,
+            max: 1,
+            colour: "interpolateGreys",
+            invert_scale: false
         }
     ];
 
@@ -119,7 +172,12 @@ it("can get colour ranges", () => {
         nonexistent_filtered: {type: ColourScaleType.DynamicFiltered, customMin: 0, customMax: 1}
     };
 
-    const filters = [{id: "year", column_id: "year", label: "Year", options: [{id: "2018", label: ""}, {id: "2019", label: ""}]}];
+    const filters = [{
+        id: "year",
+        column_id: "year",
+        label: "Year",
+        options: [{id: "2018", label: ""}, {id: "2019", label: ""}]
+    }];
     const selectedFilterValues = {year: [{id: "2019", label: "2019"}]};
 
     const areaIds = ["MWI_1_1", "MWI_1_2"];
@@ -138,10 +196,16 @@ it("can get colour ranges", () => {
 
 it("getColouRanges for unknown scale type returns nothing", () => {
     const indicatorsMeta = [{
-            indicator: "fakeIndicator", value_column: "fake", name: "fake", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
+        indicator: "fakeIndicator",
+        value_column: "fake",
+        name: "fake",
+        min: 0,
+        max: 1,
+        colour: "interpolateGreys",
+        invert_scale: false
     }];
     const colourScales = {
-      fakeIndicator: {type: 99 as ColourScaleType, customMin: 0, customMax: 0}
+        fakeIndicator: {type: 99 as ColourScaleType, customMin: 0, customMax: 0}
     };
     const result = getColourRanges([], indicatorsMeta, colourScales, [], {}, []);
     expect(result).toStrictEqual({});
@@ -162,14 +226,14 @@ it("getColor can invert color function", () => {
     expect(result).toEqual("rgb(255, 255, 255)"); //0 = white in interpolateGreys
 
     const invertedResult = getColor(0, {
-            min: 0,
-            max: 1,
-            colour: "interpolateGreys",
-            invert_scale: true,
-            indicator: "test",
-            value_column: "",
-            name: ""
-        }, {min: 0, max: 1});
+        min: 0,
+        max: 1,
+        colour: "interpolateGreys",
+        invert_scale: true,
+        indicator: "test",
+        value_column: "",
+        name: ""
+    }, {min: 0, max: 1});
     expect(invertedResult).toEqual("rgb(0, 0, 0)");
 });
 
@@ -291,10 +355,22 @@ it("getColor can use negative min and negative max", () => {
 it("can get indicator name lookup", () => {
     const indicators = [
         {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
+            indicator: "plhiv",
+            value_column: "plhiv",
+            name: "PLHIV",
+            min: 0,
+            max: 0,
+            colour: "interpolateGreys",
+            invert_scale: false
         },
         {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+            indicator: "prevalence",
+            value_column: "prevalence",
+            name: "Prevalence",
+            min: 0,
+            max: 0,
+            colour: "interpolateGreys",
+            invert_scale: false
         }
     ];
     expect(toIndicatorNameLookup(indicators)).toStrictEqual({
@@ -303,23 +379,23 @@ it("can get indicator name lookup", () => {
     });
 });
 
-it ("round to context rounds values to 1 more decimal place than the context where context is integer", () => {
+it("round to context rounds values to 1 more decimal place than the context where context is integer", () => {
     expect(roundToContext(0.1234, [0, 1])).toBe(0.1);
 });
 
-it ("round to context rounds values to 1 more decimal place than the context where context has fewer decimal places than value", () => {
+it("round to context rounds values to 1 more decimal place than the context where context has fewer decimal places than value", () => {
     expect(roundToContext(0.1234, [0, 0.1])).toBe(0.12);
 });
 
-it ("round to context does not round value if it already has fewer decimal places than context", () => {
+it("round to context does not round value if it already has fewer decimal places than context", () => {
     expect(roundToContext(0.1, [0, 0.12])).toBe(0.1);
 });
 
-it ("round to context does not round value if both values and context are integers", () => {
+it("round to context does not round value if both values and context are integers", () => {
     expect(roundToContext(5, [0, 10])).toBe(5);
 });
 
-it ("round to context can round when context includes negative", () => {
+it("round to context can round when context includes negative", () => {
     expect(roundToContext(-0.3614, [-0.45, 0])).toBe(-0.361);
 });
 
@@ -347,4 +423,64 @@ it("roundRange rounds as expected", () => {
 it("roundRange can round where max equals min", () => {
     expect(roundRange({min: 0.314, max: 0.314})).toStrictEqual({min: 0.31, max: 0.31});
     expect(roundRange({min: 10, max: 10})).toStrictEqual({min: 10, max: 10});
+});
+
+it("can iterate data values and filter rows", () => {
+
+    const indicators = [
+        {
+            indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
+            name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        },
+        {
+            indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
+            name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        }
+    ];
+
+    const data = [
+        {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
+        {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
+        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2010},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010}
+    ];
+
+    const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
+
+    const result: number[] = [];
+    iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {"year": [{id: "2010", label: "2010"}]},
+        (areaId, meta, value) => result.push(value));
+
+    expect(result).toStrictEqual([12, 0.5, 14, 0.6, 14]);
+});
+
+it("handles iterating data values where there are no selected filter options", () => {
+
+    const indicators = [
+        {
+            indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
+            name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        },
+        {
+            indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
+            name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        }
+    ];
+
+    const data = [
+        {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
+        {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
+        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2010},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010}
+    ];
+
+    const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
+
+    const result: number[] = [];
+    iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {},
+        (areaId, meta, value) => result.push(value));
+
+    expect(result).toStrictEqual([]);
 });

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -442,8 +442,8 @@ it("can iterate data values and filter rows", () => {
         {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
         {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
         {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
-        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2010},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010}
+        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
     ];
 
     const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
@@ -452,7 +452,7 @@ it("can iterate data values and filter rows", () => {
     iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {"year": [{id: "2010", label: "2010"}]},
         (areaId, meta, value) => result.push(value));
 
-    expect(result).toStrictEqual([12, 0.5, 14, 0.6, 14]);
+    expect(result).toStrictEqual([12, 0.5, 14]);
 });
 
 it("handles iterating data values where there are no selected filter options", () => {
@@ -472,8 +472,8 @@ it("handles iterating data values where there are no selected filter options", (
         {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
         {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
         {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
-        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2010},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010}
+        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
+        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
     ];
 
     const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
@@ -482,5 +482,5 @@ it("handles iterating data values where there are no selected filter options", (
     iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {},
         (areaId, meta, value) => result.push(value));
 
-    expect(result).toStrictEqual([]);
+    expect(result).toStrictEqual([12, 0.5, 14, 0.6, 14]);
 });


### PR DESCRIPTION
I'm actually quite surprised by what a difference this one change makes - it takes "excludeRow" from taking up around 50% of the total scripting time to around 9%, and at least with the test data takes the filtering back to feeling snappy and responsive.

It still takes about a second to toggle between map and bubble tabs so will continue to look into that to see if anything can be done.

Edited: ok, yeah so if the colour range is set to "whole data set" then it's still slow (and the bubble plot is slow because it works out the size range by iterating the whole data set) so reducing those iterations should help. I'll do that on a separate branch.