### PR TITLE
mrc-1444 further performance improvement

### DIFF
--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -256,9 +256,6 @@
                         };
                     case ColourScaleType.Default:
                     default:
-                        if (!this.initialised) {
-                            return {max: 1, min: 0}
-                        }
                         return {max: this.colorIndicator.max, min: this.colorIndicator.min}
                 }
             },

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -132,7 +132,7 @@
     interface Computed {
         initialised: boolean,
         currentLevelFeatureIds: string[],
-        featureIndicators: Dict<BubbleIndicatorValuesDict>,
+        featureIndicators: BubbleIndicatorValuesDict,
         featuresByLevel: { [k: number]: Feature[] },
         currentFeatures: Feature[],
         maxLevel: number,
@@ -267,7 +267,8 @@
                 return getFeatureIndicators(
                     this.chartdata,
                     this.selectedAreaIds,
-                    [this.sizeIndicator, this.colorIndicator],
+                    this.sizeIndicator,
+                    this.colorIndicator,
                     this.sizeRange,
                     this.colourRange,
                     this.nonAreaFilters,
@@ -366,14 +367,14 @@
             showBubble(feature: Feature) {
                 return !!this.featureIndicators[feature.properties!!.area_id] &&
                     !!this.featureIndicators[feature.properties!!.area_id]
-                    && !!this.featureIndicators[feature.properties!!.area_id][this.selections.sizeIndicatorId]
-                    && !!this.featureIndicators[feature.properties!!.area_id][this.selections.colorIndicatorId]
+                    && !!this.featureIndicators[feature.properties!!.area_id].value
+                    && !!this.featureIndicators[feature.properties!!.area_id].sizeValue
             },
             getRadius: function (feature: Feature) {
-                return this.featureIndicators[feature.properties!!.area_id][this.selections.sizeIndicatorId].radius;
+                return this.featureIndicators[feature.properties!!.area_id].radius;
             },
             getColor: function (feature: Feature) {
-                return this.featureIndicators[feature.properties!!.area_id][this.selections.colorIndicatorId].color;
+                return this.featureIndicators[feature.properties!!.area_id].color;
             },
             getTooltip: function (feature: Feature) {
                 const area_id = feature.properties && feature.properties["area_id"];
@@ -382,8 +383,8 @@
                 const values = this.featureIndicators[area_id];
                 const colorIndicator = this.selections.colorIndicatorId;
                 const sizeIndicator = this.selections.sizeIndicatorId;
-                const colorValue = values && values[colorIndicator] && values[colorIndicator]!!.value;
-                const sizeValue = values && values[sizeIndicator] && values[sizeIndicator]!!.value;
+                const colorValue = values && values!!.value;
+                const sizeValue = values && values!!.sizeValue;
 
                 const colorIndicatorName = this.indicatorNameLookup[colorIndicator];
                 const sizeIndicatorName = this.indicatorNameLookup[sizeIndicator];

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -87,7 +87,7 @@
         ColourScaleType
     } from "../../../store/plottingSelections/plottingSelections";
     import {getFeatureIndicators} from "./utils";
-    import {getDynamicFilteredColourRange, getIndicatorRange, toIndicatorNameLookup} from "../utils";
+    import {getIndicatorRange, toIndicatorNameLookup} from "../utils";
     import {BubbleIndicatorValuesDict, Dict, Filter, LevelLabel, NumericRange} from "../../../types";
     import {flattenOptions, flattenToIdSet} from "../../../utils";
     import SizeLegend from "./SizeLegend.vue";
@@ -242,7 +242,7 @@
                     case ColourScaleType.DynamicFiltered:
                         const selectedCurrentLevelAreaIds = this.selectedAreaIds
                             .filter(a => this.currentLevelFeatureIds.indexOf(a) > -1);
-                        return getDynamicFilteredColourRange(
+                        return getIndicatorRange(
                             this.chartdata,
                             this.colorIndicator,
                             this.nonAreaFilters,

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -214,6 +214,9 @@
                 return this.currentFeatures.map(f => f.properties!!["area_id"]);
             },
             sizeRange() {
+                if (!this.initialised) {
+                    return {max: 1, min: 0}
+                }
                 const sizeId = this.selections.sizeIndicatorId;
                 if (!this.fullIndicatorRanges.hasOwnProperty(sizeId)) {
                     // cache the result in the fullIndicatorRanges object for future lookups
@@ -250,6 +253,9 @@
                         };
                     case ColourScaleType.Default:
                     default:
+                        if (!this.initialised) {
+                            return {max: 1, min: 0}
+                        }
                         return {max: this.colorIndicator.max, min: this.colorIndicator.min}
                 }
             },
@@ -258,12 +264,10 @@
                 return Array.from(selectedAreaIdSet)
             },
             featureIndicators() {
-                const colorId = this.selections.colorIndicatorId;
-                const sizeId = this.selections.sizeIndicatorId;
                 return getFeatureIndicators(
                     this.chartdata,
                     this.selectedAreaIds,
-                    this.indicators.filter(i => i.indicator == colorId || i.indicator == sizeId),
+                    [this.sizeIndicator, this.colorIndicator],
                     this.sizeRange,
                     this.colourRange,
                     this.nonAreaFilters,
@@ -361,7 +365,9 @@
             },
             showBubble(feature: Feature) {
                 return !!this.featureIndicators[feature.properties!!.area_id] &&
-                    !!this.featureIndicators[feature.properties!!.area_id] && !!this.featureIndicators[feature.properties!!.area_id][this.selections.sizeIndicatorId]
+                    !!this.featureIndicators[feature.properties!!.area_id]
+                    && !!this.featureIndicators[feature.properties!!.area_id][this.selections.sizeIndicatorId]
+                    && !!this.featureIndicators[feature.properties!!.area_id][this.selections.colorIndicatorId]
             },
             getRadius: function (feature: Feature) {
                 return this.featureIndicators[feature.properties!!.area_id][this.selections.sizeIndicatorId].radius;

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -239,7 +239,7 @@
                                 getIndicatorRange(this.chartdata, this.colorIndicator)
                         }
                         return this.fullIndicatorRanges[colorId];
-                    case  ColourScaleType.DynamicFiltered:
+                    case ColourScaleType.DynamicFiltered:
                         const selectedCurrentLevelAreaIds = this.selectedAreaIds
                             .filter(a => this.currentLevelFeatureIds.indexOf(a) > -1);
                         return getDynamicFilteredColourRange(

--- a/src/app/static/src/app/components/plots/bubble/utils.ts
+++ b/src/app/static/src/app/components/plots/bubble/utils.ts
@@ -1,4 +1,4 @@
-import {BubbleIndicatorValuesDict, Dict, Filter, NumericRange} from "../../../types";
+import {BubbleIndicatorValues, BubbleIndicatorValuesDict, Dict, Filter, NumericRange} from "../../../types";
 import {getColor, iterateDataValues} from "../utils";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../../generated";
 
@@ -11,24 +11,28 @@ export const getRadius = function (value: number, minValue: number, maxValue: nu
 
 export const getFeatureIndicators = function (data: any[],
                                               selectedAreaIds: string[],
-                                              indicatorsMeta: ChoroplethIndicatorMetadata[],
+                                              sizeIndicator: ChoroplethIndicatorMetadata,
+                                              colorIndicator: ChoroplethIndicatorMetadata,
                                               sizeRange: NumericRange,
                                               colourRange: NumericRange,
                                               filters: Filter[],
                                               selectedFilterValues: Dict<FilterOption[]>,
                                               minRadius: number,
-                                              maxRadius: number): Dict<BubbleIndicatorValuesDict> {
+                                              maxRadius: number): BubbleIndicatorValuesDict {
 
-    const result = {} as Dict<BubbleIndicatorValuesDict>;
-    iterateDataValues(data, indicatorsMeta, selectedAreaIds, filters, selectedFilterValues,
+    const result = {} as BubbleIndicatorValuesDict;
+    iterateDataValues(data, [sizeIndicator, colorIndicator], selectedAreaIds, filters, selectedFilterValues,
         (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number) => {
             if (!result[areaId]) {
-                result[areaId] = {}
+                result[areaId] = {} as BubbleIndicatorValues
             }
-            result[areaId][indicatorMeta.indicator] = {
-                value: value,
-                color: getColor(value, indicatorMeta, colourRange),
-                radius: getRadius(value, sizeRange.min, sizeRange.max, minRadius, maxRadius)
+            if (indicatorMeta.indicator == colorIndicator.indicator) {
+                result[areaId].value = value;
+                result[areaId].color = getColor(value, indicatorMeta, colourRange)
+            }
+            if (indicatorMeta.indicator == sizeIndicator.indicator) {
+                result[areaId].sizeValue = value;
+                result[areaId].radius = getRadius(value, sizeRange.min, sizeRange.max, minRadius, maxRadius)
             }
         });
 

--- a/src/app/static/src/app/components/plots/bubble/utils.ts
+++ b/src/app/static/src/app/components/plots/bubble/utils.ts
@@ -2,7 +2,7 @@ import {BubbleIndicatorValuesDict, Dict, Filter, NumericRange} from "../../../ty
 import {getColor, iterateDataValues} from "../utils";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../../generated";
 
-export const getRadius = function(value: number, minValue: number, maxValue: number, minRadius: number, maxRadius: number){
+export const getRadius = function (value: number, minValue: number, maxValue: number, minRadius: number, maxRadius: number) {
     //where is value on a scale of 0-1 between minValue and maxValue
     const scalePoint = (value - minValue) / (maxValue - minValue);
 
@@ -12,11 +12,10 @@ export const getRadius = function(value: number, minValue: number, maxValue: num
 export const getFeatureIndicators = function (data: any[],
                                               selectedAreaIds: string[],
                                               indicatorsMeta: ChoroplethIndicatorMetadata[],
-                                              indicatorRanges: Dict<NumericRange>,
-                                              colourRanges: Dict<NumericRange>,
+                                              sizeRange: NumericRange,
+                                              colourRange: NumericRange,
                                               filters: Filter[],
                                               selectedFilterValues: Dict<FilterOption[]>,
-                                              selectedIndicatorIds: string[],
                                               minRadius: number,
                                               maxRadius: number): Dict<BubbleIndicatorValuesDict> {
 
@@ -24,19 +23,12 @@ export const getFeatureIndicators = function (data: any[],
     iterateDataValues(data, indicatorsMeta, selectedAreaIds, filters, selectedFilterValues,
         (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number) => {
             if (!result[areaId]) {
-                result[areaId] = {} as BubbleIndicatorValuesDict;
+                result[areaId] = {}
             }
-
-            const indicator = indicatorMeta.indicator;
-            const indicatorRange = indicatorRanges[indicator];
-
-            if (selectedIndicatorIds.includes(indicator)) {
-                const regionValues = result[areaId];
-                regionValues[indicator] = {
-                    value: value,
-                    color: getColor(value, indicatorMeta, colourRanges[indicator]),
-                    radius: getRadius(value, indicatorRange.min, indicatorRange.max, minRadius, maxRadius)
-                }
+            result[areaId][indicatorMeta.indicator] = {
+                value: value,
+                color: getColor(value, indicatorMeta, colourRange),
+                radius: getRadius(value, sizeRange.min, sizeRange.max, minRadius, maxRadius)
             }
         });
 

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -45,7 +45,7 @@
         ColourScaleSettings,
         ColourScaleType
     } from "../../../store/plottingSelections/plottingSelections";
-    import {getDynamicFilteredColourRange, getIndicatorRange, toIndicatorNameLookup} from "../utils";
+    import {getIndicatorRange, toIndicatorNameLookup} from "../utils";
     import {getFeatureIndicator, initialiseColourScaleFromMetadata} from "./utils";
     import {Dict, Filter, IndicatorValuesDict, LevelLabel, NumericRange} from "../../../types";
     import {flattenOptions, flattenToIdSet} from "../../../utils";
@@ -170,7 +170,7 @@
                         return this.fullIndicatorRanges[indicator];
                     case  ColourScaleType.DynamicFiltered:
                         const selectedCurrentLevelAreaIds = this.selectedAreaIds.filter(a => this.currentLevelFeatureIds.indexOf(a) > -1);
-                        return getDynamicFilteredColourRange(
+                        return getIndicatorRange(
                             this.chartdata,
                             this.colorIndicator,
                             this.nonAreaFilters,

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -184,6 +184,9 @@
                         };
                     case ColourScaleType.Default:
                     default:
+                        if (!this.initialised) {
+                            return {max: 1, min: 0}
+                        }
                         return {max: this.colorIndicator.max, min: this.colorIndicator.min}
                 }
             },

--- a/src/app/static/src/app/components/plots/choropleth/utils.ts
+++ b/src/app/static/src/app/components/plots/choropleth/utils.ts
@@ -1,38 +1,28 @@
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../../generated";
-import {IndicatorValuesDict, Dict, Filter, NumericRange} from "../../../types";
+import {Dict, Filter, IndicatorValuesDict, NumericRange} from "../../../types";
 import {getColor, iterateDataValues} from "../utils";
 import {initialColourScaleSettings} from "../../../store/plottingSelections/plottingSelections";
 
-export const getFeatureIndicators = function (data: any[],
-                                              selectedAreaIds: string[],
-                                              indicatorsMeta: ChoroplethIndicatorMetadata[],
-                                              colourRanges: Dict<NumericRange>,
-                                              filters: Filter[],
-                                              selectedFilterValues: Dict<FilterOption[]>,
-                                              selectedIndicatorIds: string[]) : Dict<IndicatorValuesDict> {
+export const getFeatureIndicator = function (data: any[],
+                                             selectedAreaIds: string[],
+                                             indicatorMeta: ChoroplethIndicatorMetadata,
+                                             colourRange: NumericRange,
+                                             filters: Filter[],
+                                             selectedFilterValues: Dict<FilterOption[]>): IndicatorValuesDict {
 
-    const result = {} as Dict<IndicatorValuesDict>;
-    iterateDataValues(data, indicatorsMeta, selectedAreaIds, filters, selectedFilterValues,
+    const result = {} as IndicatorValuesDict;
+    iterateDataValues(data, [indicatorMeta], selectedAreaIds, filters, selectedFilterValues,
         (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number) => {
-            if (!result[areaId]) {
-                result[areaId] = {} as IndicatorValuesDict;
-            }
-
-            const indicator = indicatorMeta.indicator;
-
-            if (selectedIndicatorIds.includes(indicator)) {
-                const regionValues = result[areaId];
-                regionValues[indicator] = {
-                    value: value,
-                    color: getColor(value, indicatorMeta, colourRanges[indicator])
-                }
+            result[areaId] = {
+                value: value,
+                color: getColor(value, indicatorMeta, colourRange)
             }
         });
 
     return result;
 };
 
-export const initialiseColourScaleFromMetadata = function(meta: ChoroplethIndicatorMetadata) {
+export const initialiseColourScaleFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
     const result = initialColourScaleSettings();
     if (meta) {
         result.customMin = meta.min;

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -1,7 +1,6 @@
 import * as d3ScaleChromatic from "d3-scale-chromatic";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
 import {Dict, Filter, NumericRange} from "../../types";
-import {ColourScaleSelections} from "../../store/plottingSelections/plottingSelections";
 
 export const getColor = (value: number, metadata: ChoroplethIndicatorMetadata,
                          colourRange: NumericRange) => {
@@ -59,19 +58,9 @@ export const getIndicatorRange = function (data: any,
                 result.max = Math.max(result.max, value);
             }
         });
-    return result;
-};
-
-export const getDynamicFilteredColourRange = function (data: any,
-                                                       indicatorMeta: ChoroplethIndicatorMetadata,
-                                                       filters: Filter[],
-                                                       selectedFilterValues: Dict<FilterOption[]>,
-                                                       selectedAreaIds: string[]) {
-    const filteredIndicatorRange = getIndicatorRange(data, indicatorMeta, filters, selectedFilterValues, selectedAreaIds);
-
     return roundRange({
-        min: filteredIndicatorRange ? filteredIndicatorRange.min : 0,
-        max: filteredIndicatorRange ? filteredIndicatorRange.max : 0
+        min: result ? result.min : 0,
+        max: result ? result.max : 0
     });
 };
 

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -17,6 +17,7 @@ export interface IndicatorValues {
 
 export interface BubbleIndicatorValues extends IndicatorValues {
     radius: number;
+    sizeValue: number;
 }
 
 export interface LevelLabel {

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -9,7 +9,7 @@ import registerTranslations from "../../../../app/store/translations/registerTra
 import Vuex from "vuex";
 import Treeselect from '@riophae/vue-treeselect';
 import {emptyState} from "../../../../app/root";
-import {Vue} from "vue/types/vue";
+import Vue from "vue";
 import MapLegend from "../../../../app/components/plots/MapLegend.vue";
 import SizeLegend from "../../../../app/components/plots/bubble/SizeLegend.vue";
 import {expectFilter, plhiv, prev, testData} from "../testHelpers"
@@ -42,7 +42,7 @@ const propsData = {
     }
 };
 
-const allAreaIds = ["MWI", "MWI_3_1", "MWI_4_1", "MWI_4_2", "MWI_4_3"];
+const allAreaIds = ["MWI", "MWI_3_1", "MWI_3_2", "MWI_4_1", "MWI_4_2"];
 
 const getWrapper = (customPropsData: any = {}) => {
 
@@ -103,10 +103,11 @@ describe("BubblePlot component", () => {
 
     it("renders area filter", () => {
         const wrapper = getWrapper();
-        expectFilter(wrapper, "area-filter", [], "Area", true, [{id: "MWI_3_1", label: "3.1"},
+        expectFilter(wrapper, "area-filter", [], "Area", true, [
+            {id: "MWI_3_1", label: "3.1"},
+            {id: "MWI_3_2", label: "3.2"},
             {id: "MWI_4_1", label: "4.1"},
-            {id: "MWI_4_2", label: "4.2"},
-            {id: "MWI_4_3", label: "4.3"}]);
+            {id: "MWI_4_2", label: "4.2"}]);
     });
 
     it("renders non-area filters", () => {
@@ -150,14 +151,74 @@ describe("BubblePlot component", () => {
         });
     });
 
-    it("computes colourRange", () => {
+    it("computes colourRange", async () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
         expect(vm.colourRange).toStrictEqual({
             min: 0,
             max: 0.8
         });
+
+        wrapper.setProps({
+            colourScales: {
+                prevalence: {
+                    type: ColourScaleType.Custom,
+                    customMin: 1,
+                    customMax: 2
+                }
+            }
+        });
+
+        await Vue.nextTick();
+        expect(vm.colourRange).toStrictEqual({
+            min: 1,
+            max: 2
+        });
+
+        wrapper.setProps({
+            colourScales: {
+                prevalence: {
+                    type: ColourScaleType.DynamicFull,
+                    customMin: 1,
+                    customMax: 2
+                }
+            }
+        });
+
+        await Vue.nextTick();
+        expect(vm.colourRange).toStrictEqual({
+            min: 0,
+            max: 0.9
+        });
+
+        wrapper.setProps({
+            colourScales: {
+                prevalence: {
+                    type: ColourScaleType.DynamicFiltered,
+                    customMin: 1,
+                    customMax: 2
+                }
+            },
+            selections: {
+                colorIndicatorId: "prevalence",
+                sizeIndicatorId: "plhiv",
+                detail: 4,
+                selectedFilterOptions: {
+                    age: [{id: "0:15", label: "0-15"}],
+                    sex: [{id: "male", label: "Male"}],
+                    area: []
+                }
+            }
+        });
+
+        await Vue.nextTick();
+        expect(vm.colourRange).toStrictEqual({
+            min: 0.1,
+            max: 0.9
+        });
+
     });
+
 
     it("computes currentLevelFeatureIds", () => {
         const wrapper = getWrapper();
@@ -183,7 +244,7 @@ describe("BubblePlot component", () => {
             prev,
             sizeRange,
             colorRange,
-            [propsData.filters[1]],
+            [propsData.filters[1], propsData.filters[2]],
             propsData.selections.selectedFilterOptions,
             10,
             70));
@@ -229,15 +290,15 @@ describe("BubblePlot component", () => {
             "MWI": {
                 id: "MWI", label: "Malawi", children: [
                     {id: "MWI_3_1", label: "3.1"},
+                    {id: "MWI_3_2", label: "3.2"},
                     {id: "MWI_4_1", label: "4.1"},
-                    {id: "MWI_4_2", label: "4.2"},
-                    {id: "MWI_4_3", label: "4.3"}
+                    {id: "MWI_4_2", label: "4.2"}
                 ]
             },
             "MWI_3_1": {id: "MWI_3_1", label: "3.1"},
+            "MWI_3_2": {id: "MWI_3_2", label: "3.2"},
             "MWI_4_1": {id: "MWI_4_1", label: "4.1"},
             "MWI_4_2": {id: "MWI_4_2", label: "4.2"},
-            "MWI_4_3": {id: "MWI_4_3", label: "4.3"}
         });
     });
 

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -2,7 +2,7 @@ import {createLocalVue, shallowMount, Wrapper} from "@vue/test-utils";
 import BubblePlot from "../../../../app/components/plots/bubble/BubblePlot.vue";
 import {LCircleMarker, LGeoJson, LTooltip} from "vue2-leaflet";
 import {getFeatureIndicators, getRadius} from "../../../../app/components/plots/bubble/utils";
-import {getColor, getIndicatorRange} from "../../../../app/components/plots/utils";
+import {getColor} from "../../../../app/components/plots/utils";
 import MapControl from "../../../../app/components/plots/MapControl.vue";
 import {NestedFilterOption} from "../../../../app/generated";
 import registerTranslations from "../../../../app/store/translations/registerTranslations";
@@ -12,7 +12,7 @@ import {emptyState} from "../../../../app/root";
 import {Vue} from "vue/types/vue";
 import MapLegend from "../../../../app/components/plots/MapLegend.vue";
 import SizeLegend from "../../../../app/components/plots/bubble/SizeLegend.vue";
-import {expectFilter, testData} from "../testHelpers"
+import {expectFilter, plhiv, prev, testData} from "../testHelpers"
 import {ColourScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
 const localVue = createLocalVue();
@@ -144,15 +144,18 @@ describe("BubblePlot component", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
 
-        expect(vm.sizeRange).toStrictEqual({max: 1, min: 0});
+        expect(vm.sizeRange).toStrictEqual({
+            min: 1,
+            max: 20
+        });
     });
 
     it("computes colourRange", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
         expect(vm.colourRange).toStrictEqual({
-            min: propsData.colourScales["prevalence"].customMin,
-            max: propsData.colourScales["prevalence"].customMax
+            min: 0,
+            max: 0.8
         });
     });
 
@@ -166,11 +169,18 @@ describe("BubblePlot component", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
 
-        const sizeRange = {min: 0, max: 1};
-        const colorRange = {min: 0, max: 1};
+        const sizeRange = {
+            min: 1,
+            max: 20
+        };
+        const colorRange = {
+            min: 0,
+            max: 0.8
+        };
         expect(vm.featureIndicators).toStrictEqual(getFeatureIndicators(propsData.chartdata,
             allAreaIds,
-            propsData.indicators,
+            plhiv,
+            prev,
             sizeRange,
             colorRange,
             [propsData.filters[1]],

--- a/src/app/static/src/tests/components/plots/bubble/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/utils.test.ts
@@ -1,28 +1,25 @@
-import {
-    getFeatureIndicators,
-    getRadius
-} from "../../../../app/components/plots/bubble/utils";
+import {getFeatureIndicators, getRadius} from "../../../../app/components/plots/bubble/utils";
 import {getColor} from "../../../../app/components/plots/utils";
 
 describe("Bubble plot utils", () => {
 
-    const indicators = [
-        {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:1, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
-        }
-    ];
-
-    const indicatorRanges = {
-        plhiv: {min: 1, max: 100},
-        prevalence: {min: 0, max: 0.8}
+    const plhiv = {
+        indicator: "plhiv",
+        value_column: "plhiv",
+        name: "PLHIV",
+        min: 0,
+        max: 1,
+        colour: "interpolateGreys",
+        invert_scale: false
     };
-
-    const colourRanges = {
-        plhiv: {min: 0, max: 1},
-        prevalence: {min: 0, max: 1}
+    const prev = {
+        indicator: "prevalence",
+        value_column: "prevalence",
+        name: "Prevalence",
+        min: 0,
+        max: 1,
+        colour: "interpolateGreys",
+        invert_scale: false
     };
 
     const selectedFeatureIds = ["MWI_1_1", "MWI_1_2"];
@@ -31,31 +28,20 @@ describe("Bubble plot utils", () => {
     const maxRadius = 1000;
 
     const colourRange = {min: 0, max: 1};
+    const sizeRange = {min: 1, max: 100};
 
     const expectedFeatureIndicators = {
         MWI_1_1: {
-            plhiv: {
-                value: 12,
-                color: getColor(12, indicators[0], colourRange),
-                radius: getRadius(12, 1, 100, minRadius, maxRadius)
-            },
-            prevalence: {
-                value: 0.5,
-                color: getColor(0.5, indicators[1], colourRange),
-                radius: getRadius(0.5, 0, 0.8, minRadius, maxRadius)
-            }
+            sizeValue: 12,
+            value: 0.5,
+            color: getColor(0.5, prev, colourRange),
+            radius: getRadius(12, 1, 100, minRadius, maxRadius)
         },
         MWI_1_2: {
-            plhiv: {
-                value: 14,
-                color: getColor(14,indicators[0], colourRange),
-                radius: getRadius(14, 1, 100, minRadius, maxRadius)
-            },
-            prevalence: {
-                value: 0.6,
-                color: getColor(0.6,indicators[1], colourRange),
-                radius: getRadius(0.6, 0, 0.8, minRadius, maxRadius)
-            }
+            sizeValue: 14,
+            radius: getRadius(14, 1, 100, minRadius, maxRadius),
+            value: 0.6,
+            color: getColor(0.6, prev, colourRange)
         }
     };
 
@@ -66,25 +52,21 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 16} //should not be included, not in selectedFeatures
         ];
 
-        const colorRange = {min: 0, max: 1};
-        const sizeRange = {min: 1, max: 2};
-        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, colorRange, sizeRange,
+        const result = getFeatureIndicators(data, selectedFeatureIds, plhiv, prev, sizeRange, colourRange,
             [], {}, minRadius, maxRadius);
 
         expect(result).toStrictEqual(expectedFeatureIndicators);
     });
 
     it("can get feature indicators from long format data", () => {
-        const longIndicators = [
-            {
-                indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
-                name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-            },
-            {
-                indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
-                name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-            }
-        ];
+        const plhivLong = {
+            indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
+            name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        };
+        const prevLong = {
+            indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
+            name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+        };
 
         const data = [
             {area_id: "MWI_1_1", indicator: "plhiv", value: 12},
@@ -94,18 +76,25 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_3", indicator: "plhiv", value: 14} //should not be included, not in selectedFeatures
         ];
 
-        const colorRange = {min: 0, max: 1};
-        const sizeRange = {min: 1, max: 2};
-
-        const result = getFeatureIndicators(data, selectedFeatureIds, longIndicators, colorRange, sizeRange,
-            [],{}, minRadius, maxRadius);
+        const result = getFeatureIndicators(data, selectedFeatureIds, plhivLong, prevLong, sizeRange, colourRange,
+            [], {}, minRadius, maxRadius);
         expect(result).toStrictEqual(expectedFeatureIndicators);
     });
 
     it("can exclude rows based on filters", () => {
         const filters = [
-            {id: "age", label: "Age", column_id: "age", options: [{id: "0:15", label: "0-15"}, {id: "15:30", label: "15-30"}]},
-            {id: "sex", label: "Sex", column_id: "sex", options: [{id: "female", label: "F"}, {id: "male", label: "M"}]},
+            {
+                id: "age",
+                label: "Age",
+                column_id: "age",
+                options: [{id: "0:15", label: "0-15"}, {id: "15:30", label: "15-30"}]
+            },
+            {
+                id: "sex",
+                label: "Sex",
+                column_id: "sex",
+                options: [{id: "female", label: "F"}, {id: "male", label: "M"}]
+            },
             {id: "survey", label: "Survey", column_id: "survey_id", options: []}//should not exclude for filters with no options
         ];
 
@@ -122,10 +111,7 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_1", prevalence: 0.2, plhiv: 20, sex: "female", age: "30:45"}, //not included: no age filter match
         ];
 
-        const colorRange = {min: 0, max: 1};
-        const sizeRange = {min: 1, max: 2};
-
-        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, colorRange, sizeRange, filters,
+        const result = getFeatureIndicators(data, selectedFeatureIds, plhiv, prev, sizeRange, colourRange, filters,
             selectedFilterValues, minRadius, maxRadius);
 
         expect(result).toStrictEqual(expectedFeatureIndicators);
@@ -136,39 +122,36 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_1", prevalence: 0.5},
             {area_id: "MWI_1_2", plhiv: 14},
         ];
-        const colorRange = {min: 0, max: 1};
-        const sizeRange = {min: 1, max: 2};
-        const result = getFeatureIndicators(partialData, selectedFeatureIds, indicators, colorRange, sizeRange,
+        const result = getFeatureIndicators(partialData, selectedFeatureIds, plhiv, prev, sizeRange, colourRange,
             [], {},
             minRadius, maxRadius);
 
         expect(result).toStrictEqual({
             MWI_1_1: {
-                prevalence: {
-                    value: 0.5,
-                    color: getColor(0.5, indicators[1], colourRange),
-                    radius: getRadius(0.5, 0, 0.8, minRadius, maxRadius)
-                }
+                value: 0.5,
+                color: getColor(0.5, prev, colourRange)
+
             },
             MWI_1_2: {
-                plhiv: {
-                    value: 14,
-                    color: getColor(14, indicators[0], colourRange),
-                    radius: getRadius(14, 1, 100, minRadius, maxRadius)
-                }
+                radius: getRadius(14, 1, 100, minRadius, maxRadius),
+                sizeValue: 14
             }
         });
     });
 
-    const radiusToArea = (r: number) => {return Math.PI * r *r};
-    const areaToRadius = (x: number) => {return Math.sqrt(x/Math.PI)};
+    const radiusToArea = (r: number) => {
+        return Math.PI * r * r
+    };
+    const areaToRadius = (x: number) => {
+        return Math.sqrt(x / Math.PI)
+    };
     const minArea = radiusToArea(5);
     const maxArea = radiusToArea(10);
-    it ("can get radius", () => {
+    it("can get radius", () => {
         expect(getRadius(1, 1, 10, 5, 10)).toBe(5);
         expect(getRadius(10, 1, 10, 5, 10)).toBe(10);
 
-        const expectedArea = minArea + ((4/9) * (maxArea - minArea));
+        const expectedArea = minArea + ((4 / 9) * (maxArea - minArea));
         const expectedRadius = areaToRadius(expectedArea);
         expect(getRadius(5, 1, 10, 5, 10)).toBeCloseTo(expectedRadius, 5);
     });
@@ -182,7 +165,7 @@ describe("Bubble plot utils", () => {
         expect(getRadius(5, 0, 10, 5, 10)).toBeCloseTo(expectedRadius, 5);
     });
 
-    it ("can get radius where min area is 0", () => {
+    it("can get radius where min area is 0", () => {
         expect(getRadius(0, 0, 10, 0, 10)).toBe(0);
         expect(getRadius(10, 0, 10, 0, 10)).toBe(10);
 

--- a/src/app/static/src/tests/components/plots/bubble/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/utils.test.ts
@@ -66,8 +66,10 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 16} //should not be included, not in selectedFeatures
         ];
 
-        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, indicatorRanges, colourRanges,
-            [], {}, ["prevalence", "plhiv"], minRadius, maxRadius);
+        const colorRange = {min: 0, max: 1};
+        const sizeRange = {min: 1, max: 2};
+        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, colorRange, sizeRange,
+            [], {}, minRadius, maxRadius);
 
         expect(result).toStrictEqual(expectedFeatureIndicators);
     });
@@ -92,8 +94,11 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_3", indicator: "plhiv", value: 14} //should not be included, not in selectedFeatures
         ];
 
-        const result = getFeatureIndicators(data, selectedFeatureIds, longIndicators, indicatorRanges, colourRanges,
-            [],{},["prevalence", "plhiv"], minRadius, maxRadius);
+        const colorRange = {min: 0, max: 1};
+        const sizeRange = {min: 1, max: 2};
+
+        const result = getFeatureIndicators(data, selectedFeatureIds, longIndicators, colorRange, sizeRange,
+            [],{}, minRadius, maxRadius);
         expect(result).toStrictEqual(expectedFeatureIndicators);
     });
 
@@ -117,8 +122,11 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_1", prevalence: 0.2, plhiv: 20, sex: "female", age: "30:45"}, //not included: no age filter match
         ];
 
-        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, indicatorRanges, colourRanges, filters,
-            selectedFilterValues, ["prevalence", "plhiv"], minRadius, maxRadius);
+        const colorRange = {min: 0, max: 1};
+        const sizeRange = {min: 1, max: 2};
+
+        const result = getFeatureIndicators(data, selectedFeatureIds, indicators, colorRange, sizeRange, filters,
+            selectedFilterValues, minRadius, maxRadius);
 
         expect(result).toStrictEqual(expectedFeatureIndicators);
     });
@@ -128,9 +136,10 @@ describe("Bubble plot utils", () => {
             {area_id: "MWI_1_1", prevalence: 0.5},
             {area_id: "MWI_1_2", plhiv: 14},
         ];
-
-        const result = getFeatureIndicators(partialData, selectedFeatureIds, indicators, indicatorRanges, colourRanges,
-            [], {}, ["prevalence", "plhiv"],
+        const colorRange = {min: 0, max: 1};
+        const sizeRange = {min: 1, max: 2};
+        const result = getFeatureIndicators(partialData, selectedFeatureIds, indicators, colorRange, sizeRange,
+            [], {},
             minRadius, maxRadius);
 
         expect(result).toStrictEqual({

--- a/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
@@ -1,8 +1,7 @@
 import {createLocalVue, shallowMount} from "@vue/test-utils";
 import Choropleth from "../../../../app/components/plots/choropleth/Choropleth.vue";
 import {LGeoJson} from "vue2-leaflet";
-import {getFeatureIndicators} from "../../../../app/components/plots/choropleth/utils";
-import {getColourRanges, getIndicatorRanges} from "../../../../app/components/plots/utils";
+import {getFeatureIndicator} from "../../../../app/components/plots/choropleth/utils";
 import MapControl from "../../../../app/components/plots/MapControl.vue";
 import registerTranslations from "../../../../app/store/translations/registerTranslations";
 import Vuex from "vuex";
@@ -24,8 +23,8 @@ const propsData = {
         indicatorId: "prevalence",
         detail: 4,
         selectedFilterOptions: {
-            age: [{id: "0:15", label:"0-15"}],
-            sex: [{id: "female", label:"Female"}],
+            age: [{id: "0:15", label: "0-15"}],
+            sex: [{id: "female", label: "Female"}],
             area: []
         }
     },
@@ -41,7 +40,7 @@ const propsData = {
 
 const allAreaIds = ["MWI", "MWI_3_1", "MWI_4_1", "MWI_4_2", "MWI_4_3"];
 
-const getWrapper  = (customPropsData: any = {}) => {
+const getWrapper = (customPropsData: any = {}) => {
     return shallowMount(Choropleth, {propsData: {...propsData, ...customPropsData}, localVue});
 };
 
@@ -82,15 +81,12 @@ describe("Choropleth component", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
 
-        const colourRanges = getColourRanges(propsData.chartdata, propsData.indicators, propsData.colourScales,
-            propsData.filters, propsData.selections.selectedFilterOptions, allAreaIds);
-        expect(vm.featureIndicators).toStrictEqual(getFeatureIndicators(propsData.chartdata,
+        expect(vm.featureIndicators).toStrictEqual(getFeatureIndicator(propsData.chartdata,
             allAreaIds,
-            propsData.indicators,
-            colourRanges,
+            propsData.indicators[0],
+            {min: propsData.colourScales["prevalence"].customMin, max: propsData.colourScales["prevalence"].customMax},
             [propsData.filters[1]],
-            propsData.selections.selectedFilterOptions,
-            ["prevalence"]
+            propsData.selections.selectedFilterOptions
         ));
     });
 
@@ -108,22 +104,23 @@ describe("Choropleth component", () => {
     });
 
     it("computes selectedAreaIds with area selection", () => {
-        const wrapper = getWrapper({selections: {
-            ...propsData.selections,
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
                 selectedFilterOptions: {
                     ...propsData.selections.selectedFilterOptions,
                     area: [{id: "MWI_4_1", label: ""}]
                 }
-        }});
+            }
+        });
         const vm = wrapper.vm as any;
         expect(vm.selectedAreaIds).toStrictEqual(["MWI_4_1"]);
     });
 
-    it("computes colourRanges", () => {
+    it("computes colourRange", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
-        expect(vm.colourRanges).toStrictEqual(getColourRanges(propsData.chartdata,propsData.indicators,
-            propsData.colourScales, propsData.filters, propsData.selections.selectedFilterOptions, allAreaIds));
+        expect(vm.colourRange).toStrictEqual({min: propsData.indicators[0].min, max: propsData.indicators[0].max});
     });
 
     it("computes featuresByLevel", () => {
@@ -163,12 +160,14 @@ describe("Choropleth component", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
         expect(vm.flattenedAreas).toStrictEqual({
-            "MWI": {id: "MWI", label: "Malawi", children: [
+            "MWI": {
+                id: "MWI", label: "Malawi", children: [
                     {id: "MWI_3_1", label: "3.1"},
                     {id: "MWI_4_1", label: "4.1"},
                     {id: "MWI_4_2", label: "4.2"},
                     {id: "MWI_4_3", label: "4.3"}
-                ]},
+                ]
+            },
             "MWI_3_1": {id: "MWI_3_1", label: "3.1"},
             "MWI_4_1": {id: "MWI_4_1", label: "4.1"},
             "MWI_4_2": {id: "MWI_4_2", label: "4.2"},
@@ -188,8 +187,8 @@ describe("Choropleth component", () => {
             },
             filters: [
                 propsData.filters[0], //area
-                { id: "age", label: "Age", column_id: "age", options: []},
-                { id: "sex", label: "Sex", column_id: "sex", options: []}
+                {id: "age", label: "Age", column_id: "age", options: []},
+                {id: "sex", label: "Sex", column_id: "sex", options: []}
             ],
         });
 
@@ -258,7 +257,12 @@ describe("Choropleth component", () => {
 
     it("computes empty selectedAreaFeatures with empty area options", () => {
         const wrapper = getWrapper({
-            filters: [{ id: "area", label: "Area", column_id: "area_id",options: []}, propsData.filters[1], propsData.filters[2]]
+            filters: [{
+                id: "area",
+                label: "Area",
+                column_id: "area_id",
+                options: []
+            }, propsData.filters[1], propsData.filters[2]]
         });
         expect((wrapper.vm as any).selectedAreaFeatures).toStrictEqual([]);
     });
@@ -278,11 +282,13 @@ describe("Choropleth component", () => {
     });
 
     it("initialises from empty selections and emits updates", () => {
-        const wrapper = getWrapper({selections: {
+        const wrapper = getWrapper({
+            selections: {
                 detail: -1,
                 indicatorId: null,
                 selectedFilterOptions: {}
-            }});
+            }
+        });
 
         const updates = wrapper.emitted("update");
         expect(wrapper.emitted("update")[0][0]).toStrictEqual({detail: 4});
@@ -376,8 +382,8 @@ describe("Choropleth component", () => {
             },
             filters: [
                 propsData.filters[0], //area
-                { id: "age", label: "Age", column_id: "age", options: []},
-                { id: "sex", label: "Sex", column_id: "sex", options: []}
+                {id: "age", label: "Age", column_id: "age", options: []},
+                {id: "sex", label: "Sex", column_id: "sex", options: []}
             ],
             colourScales: {}
         });

--- a/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
@@ -7,7 +7,7 @@ import registerTranslations from "../../../../app/store/translations/registerTra
 import Vuex from "vuex";
 import {emptyState} from "../../../../app/root";
 import MapLegend from "../../../../app/components/plots/MapLegend.vue";
-import {testData} from "../testHelpers";
+import {prev, testData} from "../testHelpers";
 import Filters from "../../../../app/components/plots/Filters.vue";
 import {ColourScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
@@ -31,7 +31,7 @@ const propsData = {
     includeFilters: true,
     colourScales: {
         prevalence: {
-            type: ColourScaleType.Default,
+            type: ColourScaleType.Custom,
             customMin: 1,
             customMax: 2
         }
@@ -83,7 +83,7 @@ describe("Choropleth component", () => {
 
         expect(vm.featureIndicators).toStrictEqual(getFeatureIndicator(propsData.chartdata,
             allAreaIds,
-            propsData.indicators[0],
+            prev,
             {min: propsData.colourScales["prevalence"].customMin, max: propsData.colourScales["prevalence"].customMax},
             [propsData.filters[1]],
             propsData.selections.selectedFilterOptions
@@ -120,7 +120,10 @@ describe("Choropleth component", () => {
     it("computes colourRange", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;
-        expect(vm.colourRange).toStrictEqual({min: propsData.indicators[0].min, max: propsData.indicators[0].max});
+        expect(vm.colourRange).toStrictEqual({
+            min: propsData.colourScales["prevalence"].customMin,
+            max: propsData.colourScales["prevalence"].customMax
+        });
     });
 
     it("computes featuresByLevel", () => {

--- a/src/app/static/src/tests/components/plots/testHelpers.ts
+++ b/src/app/static/src/tests/components/plots/testHelpers.ts
@@ -87,7 +87,7 @@ export const testData = {
             "type": "Feature",
             "properties": {
                 "iso3": "MWI",
-                "area_id": "MWI_4_3",
+                "area_id": "MWI_3_2",
                 "area_name": "North North East",
                 "area_level": 3,
                 "center_x": 35.7084,
@@ -115,7 +115,13 @@ export const testData = {
             area_id: "MWI_4_2", plhiv: 20, prevalence: 0.2, age: "0:15", sex: "female"
         },
         {
-            area_id: "MWI_4_3", plhiv: 20, prevalence: 0, age: "0:15", sex: "female"
+            area_id: "MWI_3_2", plhiv: 20, prevalence: 0, age: "0:15", sex: "female"
+        },
+        {
+            area_id: "MWI_4_2", plhiv: 20, prevalence: 0.1, age: "0:15", sex: "male"
+        },
+        {
+            area_id: "MWI_4_1", plhiv: 20, prevalence: 0.9, age: "0:15", sex: "male"
         }
     ],
     indicators: [
@@ -128,9 +134,9 @@ export const testData = {
             options: [{
                 id: "MWI", label: "Malawi", children: [
                     {id: "MWI_3_1", label: "3.1"},
+                    {id: "MWI_3_2", label: "3.2"},
                     {id: "MWI_4_1", label: "4.1"},
-                    {id: "MWI_4_2", label: "4.2"},
-                    {id: "MWI_4_3", label: "4.3"}
+                    {id: "MWI_4_2", label: "4.2"}
                 ]
             }
             ]

--- a/src/app/static/src/tests/components/plots/testHelpers.ts
+++ b/src/app/static/src/tests/components/plots/testHelpers.ts
@@ -1,13 +1,38 @@
 import {Wrapper} from "@vue/test-utils";
 import {Vue} from "vue/types/vue";
-import {FilterOption} from "../../../app/generated";;
+import {FilterOption} from "../../../app/generated";
 import FilterSelect from "../../../app/components/plots/FilterSelect.vue";
 
+export const plhiv = {
+    indicator: "plhiv",
+    value_column: "plhiv",
+    name: "PLHIV",
+    min: 1,
+    max: 100,
+    colour: "interpolateGreys",
+    invert_scale: false
+};
+export const prev = {
+    indicator: "prevalence",
+    value_column: "prevalence",
+    name: "Prevalence",
+    min: 0,
+    max: 0.8,
+    colour: "interpolateGreys",
+    invert_scale: false
+}
 export const testData = {
     features: [
         {
             "type": "Feature",
-            "properties": {"iso3": "MWI", "area_id": "MWI", "area_name": "Malawi", "area_level": 0, "center_x": 35.7082, "center_y": -15.2046},
+            "properties": {
+                "iso3": "MWI",
+                "area_id": "MWI",
+                "area_name": "Malawi",
+                "area_level": 0,
+                "center_x": 35.7082,
+                "center_y": -15.2046
+            },
             "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [[[[35.7, -15.2], [35.8, -15.1], [35.9, -15.3]]]]
@@ -15,7 +40,14 @@ export const testData = {
         },
         {
             "type": "Feature",
-            "properties": {"iso3": "MWI", "area_id": "MWI_3_1", "area_name": "North", "area_level": 3, "center_x": 35.7082, "center_y": -15.2046},
+            "properties": {
+                "iso3": "MWI",
+                "area_id": "MWI_3_1",
+                "area_name": "North",
+                "area_level": 3,
+                "center_x": 35.7082,
+                "center_y": -15.2046
+            },
             "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [[[[35.7083, -15.2047], [35.7117, -15.2066], [35.7108, -15.2117]]]]
@@ -23,7 +55,14 @@ export const testData = {
         },
         {
             "type": "Feature",
-            "properties": {"iso3": "MWI", "area_id": "MWI_4_1", "area_name": "North West", "area_level": 4, "center_x": 35.7083, "center_y": -15.2047},
+            "properties": {
+                "iso3": "MWI",
+                "area_id": "MWI_4_1",
+                "area_name": "North West",
+                "area_level": 4,
+                "center_x": 35.7083,
+                "center_y": -15.2047
+            },
             "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [[[[35.7083, -15.2047], [35.7117, -15.2066], [35.7108, -15.2117]]]]
@@ -31,7 +70,14 @@ export const testData = {
         },
         {
             "type": "Feature",
-            "properties": {"iso3": "MWI", "area_id": "MWI_4_2", "area_name": "North East", "area_level": 4, "center_x": 35.7084, "center_y": -15.2048},
+            "properties": {
+                "iso3": "MWI",
+                "area_id": "MWI_4_2",
+                "area_name": "North East",
+                "area_level": 4,
+                "center_x": 35.7084,
+                "center_y": -15.2048
+            },
             "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [[[[35.7083, -15.2047], [35.7117, -15.2066], [35.7108, -15.2117]]]]
@@ -39,7 +85,14 @@ export const testData = {
         },
         {
             "type": "Feature",
-            "properties": {"iso3": "MWI", "area_id": "MWI_4_3", "area_name": "North North East", "area_level": 3, "center_x": 35.7084, "center_y": -15.2048},
+            "properties": {
+                "iso3": "MWI",
+                "area_id": "MWI_4_3",
+                "area_name": "North North East",
+                "area_level": 3,
+                "center_x": 35.7084,
+                "center_y": -15.2048
+            },
             "geometry": {
                 "type": "MultiPolygon",
                 "coordinates": [[[[35.7083, -15.2047], [35.7117, -15.2066], [35.7108, -15.2117]]]]
@@ -66,25 +119,34 @@ export const testData = {
         }
     ],
     indicators: [
-        {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 1, max: 100, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 0.8, colour: "interpolateGreys", invert_scale: false
-        }
+       {...plhiv}, {...prev}
     ],
     areaFilterId: "area",
     filters: [
-        { id: "area", label: "Area", column_id: "area_id",
-            options: [{id: "MWI", label: "Malawi", children: [
+        {
+            id: "area", label: "Area", column_id: "area_id",
+            options: [{
+                id: "MWI", label: "Malawi", children: [
                     {id: "MWI_3_1", label: "3.1"},
                     {id: "MWI_4_1", label: "4.1"},
                     {id: "MWI_4_2", label: "4.2"},
                     {id: "MWI_4_3", label: "4.3"}
-                ]}
-            ]},
-        { id: "age", label: "Age", column_id: "age", options: [{id: "0:15", label:"0-15"}, {id: "15:30", label: "15-30"}]},
-        { id: "sex", label: "Sex", column_id: "sex", options: [{id: "female", label:"Female"}, {id: "male", label: "Male"}]}
+                ]
+            }
+            ]
+        },
+        {
+            id: "age",
+            label: "Age",
+            column_id: "age",
+            options: [{id: "0:15", label: "0-15"}, {id: "15:30", label: "15-30"}]
+        },
+        {
+            id: "sex",
+            label: "Sex",
+            column_id: "sex",
+            options: [{id: "female", label: "Female"}, {id: "male", label: "Male"}]
+        }
     ]
 };
 

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -1,13 +1,11 @@
 import {
     colorFunctionFromName,
     getColor,
-    getIndicatorRanges,
+    getIndicatorRange,
     toIndicatorNameLookup,
-    roundToContext, colourScaleStepFromMetadata, getColourRanges, roundRange
+    roundToContext, colourScaleStepFromMetadata, roundRange, getDynamicFilteredColourRange
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
-import {ChoroplethIndicatorMetadata, FilterOption} from "../../../app/generated";
-import {ColourScaleSelections, ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
 
 const indicators = [
     {
@@ -64,14 +62,14 @@ it("getColor avoids dividing by zero if min equals max", () => {
     expect(result).toEqual("rgb(255, 255, 255)");
 });
 
-it("can get indicator ranges", () => {
+it("can get indicator range", () => {
     const data = [
         {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 15},
         {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 14},
         {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 13}
     ];
 
-    const result = getIndicatorRanges(data, indicators);
+    const result = getIndicatorRange(data, indicators[0]);
 
     expect(result).toStrictEqual({
         plhiv: {min: 13, max: 15},
@@ -79,72 +77,29 @@ it("can get indicator ranges", () => {
     });
 });
 
-it("can get colour ranges", () => {
+it("can get dynamic filtered colour range", () => {
     const data = [
         {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 13, art_cov: 0.2, vls: 0.1, year: "2018"},
         {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 13, art_cov: 0.3, vls: 0.2, year: "2018"},
         {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 14, art_cov: 0.4, vls: 0.3, year: "2018"},
-        {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 14, art_cov: 0.2, vls: 0.4, year: "2019"},
-        {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 15, art_cov: 0.3, vls: 0.5, year: "2019"},
-        {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 15, art_cov: 0.4, vls: 0.6, year: "2019"}
+        {area_id: "MWI_1_1", prevalence: 0.6, plhiv: 14, art_cov: 0.2, vls: 0.4, year: "2019"},
+        {area_id: "MWI_1_2", prevalence: 0.7, plhiv: 15, art_cov: 0.3, vls: 0.5, year: "2019"},
+        {area_id: "MWI_1_3", prevalence: 0.8, plhiv: 15, art_cov: 0.4, vls: 0.6, year: "2019"}
     ];
 
-    const indicatorsMeta = [
+    const indicatorMeta =
         {
             indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:20, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "art_cov", value_column: "art_cov", name: "ART coverage", min: 0, max:20, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "vls", value_column: "vls", name: "Viral Load Suppression", min: 0, max:21, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "nonexistent_full", value_column: "ne_full", name: "Not In Data", min: 0, max:1, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "nonexistent_filtered", value_column: "ne_filtered", name: "Not In Data", min: 0, max:1, colour: "interpolateGreys", invert_scale: false
-        }
-    ];
-
-    const colourScales = {
-        prevalence: {type: ColourScaleType.Default, customMin: 0, customMax: 0},
-        plhiv: {type: ColourScaleType.DynamicFull, customMin: 0, customMax: 1},
-        art_cov: {type: ColourScaleType.Custom, customMin: 0.1, customMax: 0.9},
-        vls: {type: ColourScaleType.DynamicFiltered, customMin: 0, customMax: 0.1},
-        nonexistent_full: {type: ColourScaleType.DynamicFull, customMin: 0, customMax: 1},
-        nonexistent_filtered: {type: ColourScaleType.DynamicFiltered, customMin: 0, customMax: 1}
-    };
+        };
 
     const filters = [{id: "year", column_id: "year", label: "Year", options: [{id: "2018", label: ""}, {id: "2019", label: ""}]}];
     const selectedFilterValues = {year: [{id: "2019", label: "2019"}]};
 
     const areaIds = ["MWI_1_1", "MWI_1_2"];
 
-    const result = getColourRanges(data, indicatorsMeta, colourScales, filters, selectedFilterValues, areaIds);
+    const result = getDynamicFilteredColourRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
 
-    expect(result).toStrictEqual({
-        prevalence: {min: 0, max: 1},
-        plhiv: {min: 13, max: 15},
-        art_cov: {min: 0.1, max: 0.9},
-        vls: {min: 0.4, max: 0.5},
-        nonexistent_full: {min: 0, max: 0},
-        nonexistent_filtered: {min: 0, max: 0}
-    });
-});
-
-it("getColouRanges for unknown scale type returns nothing", () => {
-    const indicatorsMeta = [{
-            indicator: "fakeIndicator", value_column: "fake", name: "fake", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
-    }];
-    const colourScales = {
-      fakeIndicator: {type: 99 as ColourScaleType, customMin: 0, customMax: 0}
-    };
-    const result = getColourRanges([], indicatorsMeta, colourScales, [], {}, []);
-    expect(result).toStrictEqual({});
+    expect(result).toStrictEqual({min: 0.6, max: 0.8});
 });
 
 it("getColor can invert color function", () => {

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -3,7 +3,7 @@ import {
     getColor,
     getIndicatorRange,
     toIndicatorNameLookup,
-    roundToContext, colourScaleStepFromMetadata, roundRange, getDynamicFilteredColourRange, iterateDataValues
+    roundToContext, colourScaleStepFromMetadata, roundRange, iterateDataValues
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 import {Filter} from "../../../app/generated";
@@ -78,7 +78,7 @@ it("can get indicator range", () => {
     expect(result).toStrictEqual({min: 0.5, max: 0.7});
 });
 
-it("can get dynamic filtered colour range", () => {
+it("can get filtered indicator range", () => {
     const data = [
         {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 13, art_cov: 0.2, vls: 0.1, year: "2018"},
         {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 13, art_cov: 0.3, vls: 0.2, year: "2018"},
@@ -98,7 +98,7 @@ it("can get dynamic filtered colour range", () => {
 
     const areaIds = ["MWI_1_1", "MWI_1_2"];
 
-    const result = getDynamicFilteredColourRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
+    const result = getIndicatorRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
 
     expect(result).toStrictEqual({min: 0.6, max: 0.7});
 });

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -7,15 +7,6 @@ import {
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 
-const indicators = [
-    {
-        indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
-    },
-    {
-        indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-    }
-];
-
 it("colorFunctionFromName returns color function", () => {
     const result = colorFunctionFromName("interpolateMagma");
     expect(result).toBe(interpolateMagma);
@@ -63,18 +54,27 @@ it("getColor avoids dividing by zero if min equals max", () => {
 });
 
 it("can get indicator range", () => {
+
     const data = [
         {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 15},
         {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 14},
         {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 13}
     ];
 
-    const result = getIndicatorRange(data, indicators[0]);
+    const plhiv = {
+        indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
+    };
 
-    expect(result).toStrictEqual({
-        plhiv: {min: 13, max: 15},
-        prevalence: {min: 0.5, max: 0.7}
-    });
+    let result = getIndicatorRange(data, plhiv);
+
+    expect(result).toStrictEqual({min: 13, max: 15});
+
+    const prev = {
+        indicator: "prevalence", value_column: "prevalence", name: "prevalence", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
+    };
+    result = getIndicatorRange(data, prev);
+
+    expect(result).toStrictEqual({min: 0.5, max: 0.7});
 });
 
 it("can get dynamic filtered colour range", () => {
@@ -99,7 +99,7 @@ it("can get dynamic filtered colour range", () => {
 
     const result = getDynamicFilteredColourRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
 
-    expect(result).toStrictEqual({min: 0.6, max: 0.8});
+    expect(result).toStrictEqual({min: 0.6, max: 0.7});
 });
 
 it("getColor can invert color function", () => {


### PR DESCRIPTION
The output file is >20MB and there are 10 indicators, so iterating all the rows x 10 indicators is just too much. So this PR changes things from fetching colors and values for all indicators at once and storing them in a big dict, to just requesting colors and values (and radius in bubble case) for the currently selected indicator. 

This branch inherits from https://github.com/mrc-ide/hint/pull/253 so that should be merged first.

It's a lot of lines of code changed, sorry, but a lot of it is tests and hopefully since you're so familiar with this code it should still be parseable for review.