### PR TITLE
mrc-1708

### DIFF
--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-sm-6 col-md-8">
                 <form>
-                    <new-file-upload label="PJNZ"
+                    <manage-file label="PJNZ"
                                      :valid="pjnz.valid"
                                      :error="pjnz.error || plottingMetadataError"
                                      :upload="uploadPJNZ"
@@ -12,7 +12,7 @@
                                      accept="PJNZ,pjnz,.pjnz,.PJNZ,.zip,zip,ZIP,.ZIP"
                                      name="pjnz">
                         <label v-if="country"><strong v-translate="'country'"></strong>: {{country}}</label>
-                    </new-file-upload>
+                    </manage-file>
                     <file-upload label="shape"
                                  :valid="shape.valid"
                                  :error="shape.error"
@@ -53,7 +53,7 @@
     import {MetadataState} from "../../store/metadata/metadata";
     import ErrorAlert from "../ErrorAlert.vue";
     import LoadingSpinner from "../LoadingSpinner.vue";
-    import NewFileUpload from "../files/FileSelect.vue";
+    import ManageFile from "../files/ManageFile.vue";
 
     const namespace: string = 'baseline';
 
@@ -99,7 +99,7 @@
             FileUpload,
             ErrorAlert,
             LoadingSpinner,
-            NewFileUpload
+            ManageFile
         }
     })
 </script>

--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -13,7 +13,7 @@
                                      name="pjnz">
                         <label v-if="country"><strong v-translate="'country'"></strong>: {{country}}</label>
                     </manage-file>
-                    <file-upload label="shape"
+                    <manage-file label="shape"
                                  :valid="shape.valid"
                                  :error="shape.error"
                                  :upload="uploadShape"
@@ -21,8 +21,8 @@
                                  :existingFileName="shape.existingFileName"
                                  accept="geojson,.geojson,GEOJSON,.GEOJSON"
                                  name="shape">
-                    </file-upload>
-                    <file-upload label="population"
+                    </manage-file>
+                    <manage-file label="population"
                                  :valid="population.valid"
                                  :error="population.error"
                                  :upload="uploadPopulation"
@@ -30,7 +30,7 @@
                                  :existingFileName="population.existingFileName"
                                  accept="csv,.csv"
                                  name="population">
-                    </file-upload>
+                    </manage-file>
                 </form>
                 <div v-if="validating" id="baseline-validating">
                     <loading-spinner size="xs"></loading-spinner>

--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -3,16 +3,16 @@
         <div class="row">
             <div class="col-sm-6 col-md-8">
                 <form>
-                    <file-upload label="PJNZ"
-                                 :valid="pjnz.valid"
-                                 :error="pjnz.error || plottingMetadataError"
-                                 :upload="uploadPJNZ"
-                                 :delete-file="deletePJNZ"
-                                 :existingFileName="pjnz.existingFileName"
-                                 accept="PJNZ,pjnz,.pjnz,.PJNZ,.zip,zip,ZIP,.ZIP"
-                                 name="pjnz">
+                    <new-file-upload label="PJNZ"
+                                     :valid="pjnz.valid"
+                                     :error="pjnz.error || plottingMetadataError"
+                                     :upload="uploadPJNZ"
+                                     :delete-file="deletePJNZ"
+                                     :existingFileName="pjnz.existingFileName"
+                                     accept="PJNZ,pjnz,.pjnz,.PJNZ,.zip,zip,ZIP,.ZIP"
+                                     name="pjnz">
                         <label v-if="country"><strong v-translate="'country'"></strong>: {{country}}</label>
-                    </file-upload>
+                    </new-file-upload>
                     <file-upload label="shape"
                                  :valid="shape.valid"
                                  :error="shape.error"
@@ -53,6 +53,7 @@
     import {MetadataState} from "../../store/metadata/metadata";
     import ErrorAlert from "../ErrorAlert.vue";
     import LoadingSpinner from "../LoadingSpinner.vue";
+    import NewFileUpload from "../files/FileSelect.vue";
 
     const namespace: string = 'baseline';
 
@@ -97,7 +98,8 @@
         components: {
             FileUpload,
             ErrorAlert,
-            LoadingSpinner
+            LoadingSpinner,
+            NewFileUpload
         }
     })
 </script>

--- a/src/app/static/src/app/components/files/ADRSelect.vue
+++ b/src/app/static/src/app/components/files/ADRSelect.vue
@@ -1,0 +1,14 @@
+<template>
+    <b-dropdown-item disabled>ADR</b-dropdown-item>
+</template>
+
+<script lang="ts">
+    import Vue from "vue";
+    import {BDropdownItem} from "bootstrap-vue";
+
+    export default Vue.extend({
+        components: {
+            BDropdownItem
+        }
+    })
+</script>

--- a/src/app/static/src/app/components/files/FileSelect.vue
+++ b/src/app/static/src/app/components/files/FileSelect.vue
@@ -1,0 +1,133 @@
+<template>
+    <div class="form-group">
+        <label class="font-weight-bold" v-translate="label"></label>
+        <tick color="#e31837" v-if="valid" width="20px"></tick>
+        <slot></slot>
+        <label v-if="existingFileName"><strong v-translate="'file'"></strong>: {{existingFileName}}</label>
+        <a v-if="existingFileName"
+           class="small float-right"
+           href="#"
+           v-on:click="handleFileDelete"
+           v-translate="'remove'"></a>
+        <loading-spinner v-if="uploading" size="xs"></loading-spinner>
+        <error-alert v-if="hasError" :error="error"></error-alert>
+        <div>
+            <b-dropdown text="Select file from" variant="red">
+                <file-upload :accept="accept"
+                             :name="name"
+                             :upload="upload"
+                             @uploading="handleUploading"></file-upload>
+                <adr-select></adr-select>
+            </b-dropdown>
+        </div>
+        <reset-confirmation :continue-editing="deleteSelectedFile"
+                            :cancel-editing="cancelEdit"
+                            :open="showDeleteConfirmation"></reset-confirmation>
+    </div>
+</template>
+<script lang="ts">
+    import Vue from "vue";
+    import {BDropdown} from "bootstrap-vue";
+    import AdrSelect from "./ADRSelect.vue";
+    import FileUpload from "./FileUpload.vue";
+    import LoadingSpinner from "../LoadingSpinner.vue";
+    import Tick from "../Tick.vue";
+    import ErrorAlert from "../ErrorAlert.vue";
+    import ResetConfirmation from "../ResetConfirmation.vue";
+    import {mapGetterByName} from "../../utils";
+    import {Error} from "../../generated";
+
+    interface Data {
+        uploading: boolean
+        showDeleteConfirmation: boolean
+    }
+
+    interface Computed {
+        hasError: boolean
+        editsRequireConfirmation: boolean
+    }
+
+    interface Methods {
+        deleteSelectedFile: () => void
+        handleFileDelete: () => void
+        cancelEdit: () => void
+        handleUploading: () => void
+    }
+
+    interface Props {
+        upload: (formData: FormData) => void,
+        deleteFile: () => void,
+        accept: string,
+        label: string,
+        valid: boolean,
+        error: Error,
+        existingFileName: string,
+        name: string
+    }
+
+    export default Vue.extend<Data, Methods, Computed, Props>({
+        name: "FileSelect",
+        props: {
+            "upload": Function,
+            "deleteFile": Function,
+            "accept": String,
+            "label": String,
+            "valid": Boolean,
+            "error": Object,
+            "existingFileName": String,
+            "name": String
+        },
+        data(): Data {
+            return {
+                uploading: false,
+                showDeleteConfirmation: false
+            }
+        },
+        computed: {
+            editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation"),
+            hasError: function () {
+                return !!this.error
+            }
+        },
+        components: {
+            BDropdown,
+            FileUpload,
+            AdrSelect,
+            LoadingSpinner,
+            Tick,
+            ErrorAlert,
+            ResetConfirmation
+        },
+        methods: {
+            handleUploading() {
+                this.uploading = true;
+            },
+            handleFileDelete() {
+                if (this.editsRequireConfirmation) {
+                    this.showDeleteConfirmation = true;
+                } else {
+                    this.deleteSelectedFile();
+                }
+            },
+            deleteSelectedFile() {
+                this.deleteFile();
+                this.showDeleteConfirmation = false;
+            },
+            cancelEdit() {
+                this.showDeleteConfirmation = false;
+            }
+        },
+        watch: {
+            valid: function (newVal: boolean) {
+                if (newVal) {
+                    this.uploading = false;
+                }
+            },
+            error: function (newVal: string) {
+                if (newVal) {
+                    this.uploading = false;
+                }
+            }
+        }
+    });
+</script>

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -7,7 +7,6 @@
                        :ref="name"
                        :id="name"
                        :accept="accept"
-                       @click="$emit('input-opened')"
                        v-on:change="handleFileSelect"/>
                 This computer
             </a>

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-dropdown text="Select file from" variant="red">
+        <b-dropdown text="Select file from" variant="white">
             <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
                 <input type="file"
                        style="display:none"

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -7,6 +7,7 @@
                        :ref="name"
                        :id="name"
                        :accept="accept"
+                       @click="$emit('input-opened')"
                        v-on:change="handleFileSelect"/>
                 This computer
             </a>

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -1,18 +1,20 @@
 <template>
     <div>
-        <b-dropdown text="Select file from" variant="white">
-            <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
-                <input type="file"
-                       style="display:none"
-                       :ref="name"
-                       :id="name"
-                       :accept="accept"
-                       v-on:change="handleFileSelect"
-                       @click="$emit('input-opened')"/>
-                <!-- emit input-opened event so that tests can verify that this
-                is triggered -->
-                This computer
-            </a>
+        <b-dropdown text="Select file from" variant="white" :ref="'dropdown-' + name">
+            <li>
+                <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
+                    <input type="file"
+                           style="display:none"
+                           :ref="name"
+                           :id="name"
+                           :accept="accept"
+                           v-on:change="handleFileSelect"
+                           @click="$emit('input-opened')"/>
+                    <!-- emit input-opened event so that tests can verify that this
+                    is triggered -->
+                    This computer
+                </a>
+            </li>
             <adr-select></adr-select>
         </b-dropdown>
         <reset-confirmation :continue-editing="uploadSelectedFile"
@@ -76,6 +78,7 @@
                 }
             },
             uploadSelectedFile() {
+                (this.$refs[`dropdown-${this.name}`] as BDropdown).hide(true);
                 const fileInput = this.$refs[this.name] as HTMLInputElement;
                 const selectedFile = fileInput.files!![0]!!;
                 const formData = new FormData();

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -1,20 +1,29 @@
 <template>
-    <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
-        <input type="file"
-               style="display:none"
-               :ref="name"
-               :id="name"
-               :accept="accept"
-               v-on:change="handleFileSelect"/>
-        This computer
-    </a>
+    <div>
+        <b-dropdown text="Select file from" variant="red">
+            <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
+                <input type="file"
+                       style="display:none"
+                       :ref="name"
+                       :id="name"
+                       :accept="accept"
+                       v-on:change="handleFileSelect"/>
+                This computer
+            </a>
+            <adr-select></adr-select>
+        </b-dropdown>
+        <reset-confirmation :continue-editing="uploadSelectedFile"
+                            :cancel-editing="cancelEdit"
+                            :open="showUploadConfirmation"></reset-confirmation>
+    </div>
 </template>
 
 <script lang="ts">
     import Vue from "vue";
-    import {BDropdownItem} from "bootstrap-vue";
+    import {BDropdown} from "bootstrap-vue";
     import {mapGetterByName} from "../../utils";
     import ResetConfirmation from "../ResetConfirmation.vue";
+    import AdrSelect from "./ADRSelect.vue";
 
     interface Methods {
         handleFileSelect: () => void
@@ -48,8 +57,9 @@
             }
         },
         components: {
-            BDropdownItem,
-            ResetConfirmation
+            BDropdown,
+            ResetConfirmation,
+            AdrSelect
         },
         computed: {
             editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation")

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -1,0 +1,81 @@
+<template>
+    <a class="dropdown-item" href="#" v-on:mousedown="$refs[name].click()">
+        <input type="file"
+               style="display:none"
+               :ref="name"
+               :id="name"
+               :accept="accept"
+               v-on:change="handleFileSelect"/>
+        This computer
+    </a>
+</template>
+
+<script lang="ts">
+    import Vue from "vue";
+    import {BDropdownItem} from "bootstrap-vue";
+    import {mapGetterByName} from "../../utils";
+    import ResetConfirmation from "../ResetConfirmation.vue";
+
+    interface Methods {
+        handleFileSelect: () => void
+        uploadSelectedFile: () => void
+        cancelEdit: () => void
+    }
+
+    interface Data {
+        showUploadConfirmation: boolean
+    }
+
+    interface Computed {
+        editsRequireConfirmation: boolean
+    }
+
+    interface Props {
+        upload: (formData: FormData) => void,
+        accept: string,
+        name: string
+    }
+
+    export default Vue.extend<Data, Methods, Computed, Props>({
+        props: {
+            "upload": Function,
+            "accept": String,
+            "name": String
+        },
+        data(): Data {
+            return {
+                showUploadConfirmation: false
+            }
+        },
+        components: {
+            BDropdownItem,
+            ResetConfirmation
+        },
+        computed: {
+            editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation")
+        },
+        methods: {
+            handleFileSelect() {
+                if (this.editsRequireConfirmation) {
+                    this.showUploadConfirmation = true;
+                } else {
+                    this.uploadSelectedFile();
+                }
+            },
+            uploadSelectedFile() {
+                const fileInput = this.$refs[this.name] as HTMLInputElement;
+                const selectedFile = fileInput.files!![0]!!;
+                const formData = new FormData();
+                formData.append('file', selectedFile);
+                this.$emit("uploading");
+                this.upload(formData);
+                fileInput.value = "";
+                this.showUploadConfirmation = false;
+            },
+            cancelEdit() {
+                this.showUploadConfirmation = false
+            }
+        }
+
+    })
+</script>

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -7,7 +7,10 @@
                        :ref="name"
                        :id="name"
                        :accept="accept"
-                       v-on:change="handleFileSelect"/>
+                       v-on:change="handleFileSelect"
+                       @click="$emit('input-opened')"/>
+                <!-- emit input-opened event so that tests can verify that this
+                is triggered -->
                 This computer
             </a>
             <adr-select></adr-select>

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -3,7 +3,7 @@
         <label class="font-weight-bold" v-translate="label"></label>
         <tick color="#e31837" v-if="valid" width="20px"></tick>
         <slot></slot>
-        <label v-if="existingFileName">
+        <label v-if="existingFileName" class="file-name">
             <strong v-translate="'file'"></strong>: {{existingFileName}}
         </label>
         <a v-if="existingFileName"

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -3,23 +3,20 @@
         <label class="font-weight-bold" v-translate="label"></label>
         <tick color="#e31837" v-if="valid" width="20px"></tick>
         <slot></slot>
-        <label v-if="existingFileName"><strong v-translate="'file'"></strong>: {{existingFileName}}</label>
+        <label v-if="existingFileName">
+            <strong v-translate="'file'"></strong>: {{existingFileName}}
+        </label>
         <a v-if="existingFileName"
            class="small float-right"
            href="#"
            v-on:click="handleFileDelete"
            v-translate="'remove'"></a>
         <loading-spinner v-if="uploading" size="xs"></loading-spinner>
+        <file-upload :name="name"
+                     :accept="accept"
+                     :upload="upload"
+                     @uploading="handleUploading"></file-upload>
         <error-alert v-if="hasError" :error="error"></error-alert>
-        <div>
-            <b-dropdown text="Select file from" variant="red">
-                <file-upload :accept="accept"
-                             :name="name"
-                             :upload="upload"
-                             @uploading="handleUploading"></file-upload>
-                <adr-select></adr-select>
-            </b-dropdown>
-        </div>
         <reset-confirmation :continue-editing="deleteSelectedFile"
                             :cancel-editing="cancelEdit"
                             :open="showDeleteConfirmation"></reset-confirmation>
@@ -28,7 +25,6 @@
 <script lang="ts">
     import Vue from "vue";
     import {BDropdown} from "bootstrap-vue";
-    import AdrSelect from "./ADRSelect.vue";
     import FileUpload from "./FileUpload.vue";
     import LoadingSpinner from "../LoadingSpinner.vue";
     import Tick from "../Tick.vue";
@@ -92,7 +88,6 @@
         components: {
             BDropdown,
             FileUpload,
-            AdrSelect,
             LoadingSpinner,
             Tick,
             ErrorAlert,

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -2,15 +2,17 @@
     <div class="form-group">
         <label class="font-weight-bold" v-translate="label"></label>
         <tick color="#e31837" v-if="valid" width="20px"></tick>
+        <br/>
         <slot></slot>
         <label v-if="existingFileName" class="file-name">
-            <strong v-translate="'file'"></strong>: {{existingFileName}}
+            <span>
+                <strong v-translate="'file'"></strong>: {{existingFileName}}
+            </span>
+            <a class="small float-right"
+               href="#"
+               v-on:click="handleFileDelete"
+               v-translate="'remove'"></a>
         </label>
-        <a v-if="existingFileName"
-           class="small float-right"
-           href="#"
-           v-on:click="handleFileDelete"
-           v-translate="'remove'"></a>
         <loading-spinner v-if="uploading" size="xs"></loading-spinner>
         <file-upload :name="name"
                      :accept="accept"

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -3,7 +3,7 @@
         <div class="row">
             <div :class="showChoropleth ? 'col-md-3' : 'col-sm-6 col-md-8'" class="upload-section">
                 <form>
-                    <new-file-upload label="survey"
+                    <manage-file label="survey"
                                  :valid="survey.valid"
                                  :error="survey.error"
                                  :upload="uploadSurvey"
@@ -11,7 +11,7 @@
                                  :existingFileName="survey.existingFileName"
                                  accept="csv,.csv"
                                  name="survey">
-                    </new-file-upload>
+                    </manage-file>
                     <file-upload label="ART"
                                  :valid="programme.valid"
                                  :error="programme.error"
@@ -89,7 +89,7 @@
     import {Metadata, ChoroplethIndicatorMetadata} from "../../generated";
     import {mapGettersByNames} from "../../utils";
     import {ChoroplethSelections} from "../../store/plottingSelections/plottingSelections";
-    import NewFileUpload from "../files/FileSelect.vue";
+    import ManageFile from "../files/ManageFile.vue";
 
     const namespace: string = 'surveyAndProgram';
 
@@ -185,7 +185,7 @@
             Choropleth,
             Filters,
             TableView,
-            NewFileUpload
+            ManageFile
         }
     })
 </script>

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -12,7 +12,7 @@
                                  accept="csv,.csv"
                                  name="survey">
                     </manage-file>
-                    <file-upload label="ART"
+                    <manage-file label="ART"
                                  :valid="programme.valid"
                                  :error="programme.error"
                                  :upload="uploadProgram"
@@ -20,8 +20,8 @@
                                  :existingFileName="programme.existingFileName"
                                  accept="csv,.csv"
                                  name="program">
-                    </file-upload>
-                    <file-upload label="ANC"
+                    </manage-file>
+                    <manage-file label="ANC"
                                  :valid="anc.valid"
                                  :error="anc.error"
                                  :upload="uploadANC"
@@ -29,7 +29,7 @@
                                  :existingFileName="anc.existingFileName"
                                  accept="csv,.csv"
                                  name="anc">
-                    </file-upload>
+                    </manage-file>
                 </form>
                 <filters v-if="showChoropleth"
                          :filters="filters"

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -3,7 +3,7 @@
         <div class="row">
             <div :class="showChoropleth ? 'col-md-3' : 'col-sm-6 col-md-8'" class="upload-section">
                 <form>
-                    <file-upload label="survey"
+                    <new-file-upload label="survey"
                                  :valid="survey.valid"
                                  :error="survey.error"
                                  :upload="uploadSurvey"
@@ -11,7 +11,7 @@
                                  :existingFileName="survey.existingFileName"
                                  accept="csv,.csv"
                                  name="survey">
-                    </file-upload>
+                    </new-file-upload>
                     <file-upload label="ART"
                                  :valid="programme.valid"
                                  :error="programme.error"
@@ -89,6 +89,7 @@
     import {Metadata, ChoroplethIndicatorMetadata} from "../../generated";
     import {mapGettersByNames} from "../../utils";
     import {ChoroplethSelections} from "../../store/plottingSelections/plottingSelections";
+    import NewFileUpload from "../files/FileSelect.vue";
 
     const namespace: string = 'surveyAndProgram';
 
@@ -183,7 +184,8 @@
             FileUpload,
             Choropleth,
             Filters,
-            TableView
+            TableView,
+            NewFileUpload
         }
     })
 </script>

--- a/src/app/static/src/scss/partials/files.scss
+++ b/src/app/static/src/scss/partials/files.scss
@@ -1,0 +1,7 @@
+.file-name {
+  width: 100%;
+  span {
+    overflow-wrap: break-word;
+    display: inline;
+  }
+}

--- a/src/app/static/src/scss/partials/header.scss
+++ b/src/app/static/src/scss/partials/header.scss
@@ -34,18 +34,18 @@ header {
   .dropdown-menu {
     top: 31px;
     left: -10px;
+  }
+}
 
-    .dropdown-item {
-      color: $theme-red !important;
-      cursor: pointer;
+.dropdown-item {
+  color: $theme-red !important;
+  cursor: pointer;
 
-      &:focus {
-        outline: none !important;
-      }
+  &:focus {
+    outline: none !important;
+  }
 
-      &:hover, &.active, :active {
-        background-color: $gray-200;
-      }
-    }
+  &:hover, &.active, :active {
+    background-color: $gray-200;
   }
 }

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -8,6 +8,7 @@
 @import "partials/header";
 @import "partials/tooltips";
 @import "partials/progress";
+@import "partials/files";
 
 a {
   color: $theme-red;
@@ -68,22 +69,6 @@ a {
 
 }
 
-.custom-file-label.uploading::after {
-  content: "..." !important;
-  width: 78px;
-  text-align: center;
-}
-
-.fr {
-  .custom-file-label:not(.uploading)::after {
-    content: "Parcourir" !important;
-  }
-
-  .custom-file-label.uploading::after {
-    width: 90px;
-  }
-}
-
 .lds-spin.xs {
   margin-top: -15px;
 }
@@ -99,10 +84,6 @@ a {
 
 .reset-password-form {
   width: 30em;
-}
-
-.custom-file, .custom-file label {
-  overflow: hidden;
 }
 
 a.up::after {

--- a/src/app/static/src/tests/components/baseline/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline/baseline.test.ts
@@ -1,11 +1,10 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils';
-import Vue from 'vue';
 import Vuex from 'vuex';
 import {BaselineActions} from "../../../app/store/baseline/actions";
 import {mockBaselineState, mockError, mockMetadataState, mockPopulationResponse, mockShapeResponse} from "../../mocks";
 import {BaselineState} from "../../../app/store/baseline/baseline";
 import Baseline from "../../../app/components/baseline/Baseline.vue";
-import FileUpload from "../../../app/components/FileUpload.vue";
+import ManageFile from "../../../app/components/files/ManageFile.vue";
 import {MetadataState} from "../../../app/store/metadata/metadata";
 import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 import LoadingSpinner from "../../../app/components/LoadingSpinner.vue";
@@ -54,40 +53,40 @@ describe("Baseline upload component", () => {
     it("pjnz upload accepts pjnz or zip files", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().accept).toBe("PJNZ,pjnz,.pjnz,.PJNZ,.zip,zip,ZIP,.ZIP");
+        expect(wrapper.findAll(ManageFile).at(0).props().accept).toBe("PJNZ,pjnz,.pjnz,.PJNZ,.zip,zip,ZIP,.ZIP");
     });
 
     it("pjnz is not valid if country is not present", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().valid).toBe(false);
-        expect(wrapper.findAll(FileUpload).at(0).findAll("label").length).toBe(0);
+        expect(wrapper.findAll(ManageFile).at(0).props().valid).toBe(false);
+        expect(wrapper.findAll(ManageFile).at(0).findAll("label").length).toBe(0);
     });
 
     it("pjnz is valid if country is present", () => {
         const store = createSut({country: "Malawi"});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().valid).toBe(true);
+        expect(wrapper.findAll(ManageFile).at(0).props().valid).toBe(true);
     });
 
     it("country name is passed to file upload component if country is present", () => {
         const store = createSut({country: "Malawi"});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).find("label").text()).toBe("Country: Malawi");
+        expect(wrapper.findAll(ManageFile).at(0).find("label").text()).toBe("Country: Malawi");
     });
 
     it("passes pjnz error to file upload", () => {
         const error = mockError("File upload went wrong");
         const store = createSut({pjnzError: error});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().error).toBe(error);
+        expect(wrapper.findAll(ManageFile).at(0).props().error).toBe(error);
     });
 
     it("shows metadata error if present", () => {
         const plottingMetadataError = mockError("Metadata went wrong");
         const store = createSut({}, {plottingMetadataError});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().error).toBe(plottingMetadataError);
+        expect(wrapper.findAll(ManageFile).at(0).props().error).toBe(plottingMetadataError);
     });
 
     it("shows pjnz error, not metadata error, if both are present", () => {
@@ -95,7 +94,7 @@ describe("Baseline upload component", () => {
         const plottingMetadataError = mockError("Metadata went wrong");
         const store = createSut({pjnzError},{plottingMetadataError});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(0).props().error).toBe(pjnzError);
+        expect(wrapper.findAll(ManageFile).at(0).props().error).toBe(pjnzError);
     });
 
     it("shows baseline error if present", () => {
@@ -116,51 +115,51 @@ describe("Baseline upload component", () => {
     it("shape is not valid if shape is not present", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(1).props().valid).toBe(false);
+        expect(wrapper.findAll(ManageFile).at(1).props().valid).toBe(false);
     });
 
     it("shape is valid if shape is present", () => {
         const store = createSut({shape: mockShapeResponse()});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(1).props().valid).toBe(true);
+        expect(wrapper.findAll(ManageFile).at(1).props().valid).toBe(true);
     });
 
     it("passes shape error to file upload", () => {
         const error = mockError("File upload went wrong");
         const store = createSut({shapeError: error});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(1).props().error).toBe(error);
+        expect(wrapper.findAll(ManageFile).at(1).props().error).toBe(error);
     });
 
     it("shape upload accepts geojson", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(1).props().accept).toBe("geojson,.geojson,GEOJSON,.GEOJSON");
+        expect(wrapper.findAll(ManageFile).at(1).props().accept).toBe("geojson,.geojson,GEOJSON,.GEOJSON");
     });
 
     it("population is not valid if population is not present", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(2).props().valid).toBe(false);
+        expect(wrapper.findAll(ManageFile).at(2).props().valid).toBe(false);
     });
 
     it("population is valid if population is present", () => {
         const store = createSut({population: mockPopulationResponse()});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(2).props().valid).toBe(true);
+        expect(wrapper.findAll(ManageFile).at(2).props().valid).toBe(true);
     });
 
     it("passes population error to file upload", () => {
         const error = mockError("File upload went wrong")
         const store = createSut({populationError: error});
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(2).props().error).toBe(error);
+        expect(wrapper.findAll(ManageFile).at(2).props().error).toBe(error);
     });
 
     it("population upload accepts csv", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(2).props().accept).toBe("csv,.csv");
+        expect(wrapper.findAll(ManageFile).at(2).props().accept).toBe("csv,.csv");
     });
 
     it("upload pjnz dispatches baseline/uploadPJNZ", (done) => {
@@ -193,7 +192,7 @@ describe("Baseline upload component", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
 
-        wrapper.findAll(FileUpload).at(index).props().upload({name: "TEST"});
+        wrapper.findAll(ManageFile).at(index).props().upload({name: "TEST"});
         setTimeout(() => {
             expect(action().mock.calls[0][1]).toStrictEqual({name: "TEST"});
             done();
@@ -206,7 +205,7 @@ describe("Baseline upload component", () => {
         const store = createSut();
         const wrapper = shallowMount(Baseline, {store, localVue});
 
-        wrapper.findAll(FileUpload).at(index).props().deleteFile();
+        wrapper.findAll(ManageFile).at(index).props().deleteFile();
         setTimeout(() => {
             expect(action().mock.calls.length).toBe(1);
             done();

--- a/src/app/static/src/tests/components/files/fileUpload.test.ts
+++ b/src/app/static/src/tests/components/files/fileUpload.test.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import {shallowMount, Slots} from '@vue/test-utils';
+import {createWrapper, shallowMount, Slots} from '@vue/test-utils';
 
 import FileUpload from "../../../app/components/files/FileUpload.vue";
 import {mockFile} from "../../mocks";
@@ -51,6 +51,15 @@ describe("File upload component", () => {
         expect(input.attributes().accept).toBe("csv");
         expect(input.attributes().id).toBe("test-name");
         expect(wrapper.find({ref: "test-name"})).toStrictEqual(input);
+    });
+
+    it("trigger click on hidden input when dropdown link is clicked", () => {
+        const wrapper = createSut({
+            name: "test-name"
+        });
+        wrapper.find(".dropdown-item").trigger("mousedown");
+
+        expect(wrapper.emitted()['input-opened'].length).toBe(1);
     });
 
     it("calls upload when file is selected", (done) => {

--- a/src/app/static/src/tests/components/files/fileUpload.test.ts
+++ b/src/app/static/src/tests/components/files/fileUpload.test.ts
@@ -1,0 +1,108 @@
+import Vue from "vue";
+import {shallowMount, Slots} from '@vue/test-utils';
+
+import FileUpload from "../../../app/components/files/FileUpload.vue";
+import {mockFile} from "../../mocks";
+import Vuex from "vuex";
+import {emptyState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+
+describe("File upload component", () => {
+
+    const mockGetters = {
+        editsRequireConfirmation: () => false,
+        laterCompleteSteps: () => [{number: 4, text: "Run model"}]
+    };
+
+    const createStore = () => {
+        const store = new Vuex.Store({
+            state: emptyState(),
+            modules: {
+                stepper: {
+                    namespaced: true,
+                    getters: mockGetters
+                }
+            }
+        });
+        registerTranslations(store);
+        return store;
+    };
+
+    const createSut = (props?: any, slots?: Slots) => {
+        return shallowMount(FileUpload, {
+            store: createStore(),
+            propsData: {
+                upload: jest.fn(),
+                name: "pjnz",
+                accept: "csv",
+                ...props
+            },
+            slots: slots
+        });
+    };
+
+    const testFile = mockFile("TEST FILE NAME", "TEST CONTENTS");
+
+    it("renders hidden input", () => {
+        const wrapper = createSut({
+            name: "test-name"
+        });
+        const input = wrapper.find("input");
+        expect(input.attributes().accept).toBe("csv");
+        expect(input.attributes().id).toBe("test-name");
+        expect(wrapper.find({ref: "test-name"})).toStrictEqual(input);
+    });
+
+    it("calls upload when file is selected", (done) => {
+
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        const vm = wrapper.vm;
+        (vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        wrapper.find("input").trigger("change");
+
+        setTimeout(() => {
+            const formData = uploader.mock.calls[0][0] as FormData;
+            expect(formData.get('file')).toBe(testFile);
+            done();
+        });
+
+    });
+
+    it("calls upload function with formData", (done) => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        (wrapper.vm as any).handleFileSelect();
+
+        setTimeout(() => {
+            expect(uploader.mock.calls[0][0] instanceof FormData).toBe(true);
+            done();
+        });
+    });
+
+    it("emits uploading event while uploading", async () => {
+        const wrapper = createSut();
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+        (wrapper.vm as any).handleFileSelect();
+
+        await Vue.nextTick();
+
+        expect(wrapper.emitted().uploading.length).toBe(1);
+    });
+});

--- a/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
+++ b/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
@@ -1,0 +1,97 @@
+import Vuex from "vuex";
+import {mount, Wrapper} from '@vue/test-utils';
+import FileUpload from "../../../app/components/files/FileUpload.vue";
+import ResetConfirmation from "../../../app/components/ResetConfirmation.vue";
+import {mockFile} from "../../mocks";
+import {emptyState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+
+describe("File upload component", () => {
+
+    const mockGetters = {
+        editsRequireConfirmation: () => true,
+        laterCompleteSteps: () => [{number: 4, textKey: "runModel"}]
+    };
+
+    const createStore = () => {
+        const store = new Vuex.Store({
+            state: emptyState(),
+            modules: {
+                stepper: {
+                    namespaced: true,
+                    getters: mockGetters
+                }
+            }
+        });
+        registerTranslations(store);
+        return store;
+    };
+
+    const createSut = (props?: any) => {
+        return mount(FileUpload, {
+            store: createStore(),
+            propsData: {
+                upload: jest.fn(),
+                name: "pjnz",
+                accept: "csv",
+                ...props
+            }
+        });
+    };
+
+    const testFile = mockFile("TEST FILE NAME", "TEST CONTENTS");
+
+    function uploadConfirmationModal(wrapper: Wrapper<FileUpload>) {
+        return wrapper.findAll(ResetConfirmation).at(0)
+    }
+
+    it("opens confirmation modal when new file is selected", () => {
+        const wrapper = createSut();
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+        (wrapper.vm as any).handleFileSelect();
+        expect(uploadConfirmationModal(wrapper).props("open")).toBe(true);
+    });
+
+    it("uploads file if user confirms edit", (done) => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        (wrapper.vm as any).handleFileSelect();
+        uploadConfirmationModal(wrapper).find(".btn-white").trigger("click");
+
+        setTimeout(() => {
+            expect(uploader.mock.calls.length).toBe(1);
+            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
+            done();
+        });
+    });
+
+    it("does not upload file if user cancels edit", (done) => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader
+        });
+
+        (wrapper.vm.$refs as any).pjnz = {
+            files: [testFile]
+        };
+
+        (wrapper.vm as any).handleFileSelect();
+        uploadConfirmationModal(wrapper).find(".btn-red").trigger("click");
+
+        setTimeout(() => {
+            expect(uploader.mock.calls.length).toBe(0);
+            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
+            done();
+        });
+    });
+
+});

--- a/src/app/static/src/tests/components/files/manageFile.test.ts
+++ b/src/app/static/src/tests/components/files/manageFile.test.ts
@@ -1,0 +1,179 @@
+import Vue from "vue";
+import {shallowMount, Slots} from '@vue/test-utils';
+
+import ErrorAlert from "../../../app/components/ErrorAlert.vue";
+import Tick from "../../../app/components/Tick.vue";
+import FileUpload from "../../../app/components/files/FileUpload.vue";
+import ManageFile from "../../../app/components/files/ManageFile.vue";
+import {mockError, mockFile} from "../../mocks";
+import LoadingSpinner from "../../../app/components/LoadingSpinner.vue";
+import Vuex from "vuex";
+import {emptyState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+
+describe("Manage file component", () => {
+
+    const mockGetters = {
+        editsRequireConfirmation: () => false,
+        laterCompleteSteps: () => [{number: 4, text: "Run model"}]
+    };
+
+    const createStore = () => {
+        const store = new Vuex.Store({
+            state: emptyState(),
+            modules: {
+                stepper: {
+                    namespaced: true,
+                    getters: mockGetters
+                }
+            }
+        });
+        registerTranslations(store);
+        return store;
+    };
+
+    const createSut = (props?: any, slots?: Slots) => {
+        return shallowMount(ManageFile, {
+            store: createStore(),
+            propsData: {
+                error: null,
+                label: "PJNZ",
+                valid: true,
+                upload: jest.fn(),
+                deleteFile: jest.fn(),
+                name: "pjnz",
+                accept: "csv",
+                ...props
+            },
+            slots: slots
+        });
+    };
+
+    const testFile = mockFile("TEST FILE NAME", "TEST CONTENTS");
+
+    it("renders label", () => {
+        const wrapper = createSut({
+            label: "Some title"
+        });
+        expect(wrapper.find("label").text()).toBe("Some title");
+    });
+
+    it("renders file upload", () => {
+        const uploadFn = jest.fn();
+        const wrapper = createSut({
+            name: "test-name",
+            upload: uploadFn
+        });
+        const input = wrapper.find(FileUpload);
+        expect(input.props().accept).toBe("csv");
+        expect(input.props().name).toBe("test-name");
+        expect(input.props().upload).toBe(uploadFn);
+    });
+
+    it("renders existing file name if present", () => {
+        const wrapper = createSut({
+            existingFileName: "existing-name.csv"
+        });
+        expect(wrapper.find("label.file-name").text()).toBe("File: existing-name.csv");
+    });
+
+    it("does not render tick if valid is false", () => {
+        const wrapper = createSut({
+            valid: false
+        });
+        expect(wrapper.findAll(Tick).length).toBe(0);
+    });
+
+    it("renders tick if valid is true", () => {
+        const wrapper = createSut({
+            valid: true
+        });
+        expect(wrapper.findAll(Tick).length).toBe(1);
+    });
+
+    it("does not render remove link if filename is not present", () => {
+        const wrapper = createSut({
+            existingFileName: null
+        });
+        expect(wrapper.findAll("a").length).toBe(0);
+    });
+
+    it("renders remove link if existing filename is present", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            existingFileName: "File.csv",
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+
+        removeLink.trigger("click");
+
+        expect(removeHandler.mock.calls.length).toBe(1);
+    });
+
+    it("renders error message if error is present", () => {
+        const error = mockError("File upload went wrong");
+        const wrapper = createSut({error});
+        expect(wrapper.find(ErrorAlert).props().error).toBe(error);
+    });
+
+    it("does not render error message if no error is present", () => {
+        const wrapper = createSut();
+        expect(wrapper.findAll(ErrorAlert).length).toBe(0);
+    });
+
+    it("renders slot before filename", () => {
+
+        const wrapper = createSut({
+            existingFileName: "test.pjnz"
+        }, {
+            default: '<div class="fake-slot"></div>'
+        });
+        const slot = wrapper.find(".fake-slot");
+        expect(slot.element!!.nextElementSibling!!.classList[0]).toBe("file-name");
+    });
+
+    it("renders loading spinner while uploading with success", async () => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader,
+            valid: false
+        });
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
+        expect(wrapper.findAll(Tick).length).toBe(0);
+
+        wrapper.find(FileUpload).vm.$emit("uploading")
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
+        expect(wrapper.findAll(Tick).length).toBe(0);
+
+        wrapper.setProps({valid: true});
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
+        expect(wrapper.findAll(Tick).length).toBe(1);
+    });
+
+    it("renders loading spinner while uploading with error", async () => {
+        const uploader = jest.fn();
+        const wrapper = createSut({
+            upload: uploader,
+            valid: false,
+            error: null
+        });
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
+        expect(wrapper.findAll(Tick).length).toBe(0);
+
+        wrapper.find(FileUpload).vm.$emit("uploading")
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
+        expect(wrapper.findAll(Tick).length).toBe(0);
+
+        wrapper.setProps({error: "Some error"});
+
+        expect(wrapper.findAll(LoadingSpinner).length).toBe(0);
+        expect(wrapper.findAll(Tick).length).toBe(0);
+    });
+});

--- a/src/app/static/src/tests/components/files/manageFile.test.ts
+++ b/src/app/static/src/tests/components/files/manageFile.test.ts
@@ -74,7 +74,7 @@ describe("Manage file component", () => {
         const wrapper = createSut({
             existingFileName: "existing-name.csv"
         });
-        expect(wrapper.find("label.file-name").text()).toBe("File: existing-name.csv");
+        expect(wrapper.find("label.file-name").text()).toContain("File: existing-name.csv");
     });
 
     it("does not render tick if valid is false", () => {

--- a/src/app/static/src/tests/components/files/manageFilewithDeleteConfirmation.test.ts
+++ b/src/app/static/src/tests/components/files/manageFilewithDeleteConfirmation.test.ts
@@ -1,0 +1,94 @@
+import Vuex from "vuex";
+import {mount, Slots, Wrapper} from '@vue/test-utils';
+import FileUpload from "../../../app/components/files/FileUpload.vue";
+import ManageFile from "../../../app/components/files/ManageFile.vue";
+import ResetConfirmation from "../../../app/components/ResetConfirmation.vue";
+import {mockFile} from "../../mocks";
+import {emptyState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+
+describe("File upload component", () => {
+
+    const mockGetters = {
+        editsRequireConfirmation: () => true,
+        laterCompleteSteps: () => [{number: 4, textKey: "runModel"}]
+    };
+
+    const createStore = () => {
+        const store = new Vuex.Store({
+            state: emptyState(),
+            modules: {
+                stepper: {
+                    namespaced: true,
+                    getters: mockGetters
+                }
+            }
+        });
+        registerTranslations(store);
+        return store;
+    };
+
+    const createSut = (props?: any, slots?: Slots) => {
+        return mount(ManageFile, {
+            store: createStore(),
+            propsData: {
+                error: null,
+                label: "PJNZ",
+                valid: true,
+                upload: jest.fn(),
+                deleteFile: jest.fn(),
+                name: "pjnz",
+                accept: "csv",
+                ...props
+            },
+            slots: slots
+        });
+    };
+
+    const testFile = mockFile("TEST FILE NAME", "TEST CONTENTS");
+
+    function deleteConfirmationModal(wrapper: Wrapper<FileUpload>) {
+        return wrapper.findAll(ResetConfirmation).at(1)
+    }
+
+    it("opens confirmation modal when remove is clicked", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            existingFileName: "test.pjnz",
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(true);
+    });
+
+    it("deletes file if user confirms edit", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            existingFileName: "test.pjnz",
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-white").trigger("click");
+        expect(removeHandler.mock.calls.length).toBe(1);
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
+    });
+
+    it("does not delete file if user cancels edit", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            existingFileName: "test.pjnz",
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+        removeLink.trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-red").trigger("click");
+        expect(removeHandler.mock.calls.length).toBe(0);
+        expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
+    });
+
+});

--- a/src/app/static/src/tests/components/surveyAndProgram/fileUploads.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/fileUploads.ts
@@ -1,7 +1,7 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
 import SurveyAndProgram from "../../../app/components/surveyAndProgram/SurveyAndProgram.vue";
-import FileUpload from "../../../app/components/FileUpload.vue";
+import ManageFile from "../../../app/components/files/ManageFile.vue";
 import {SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
 import {SurveyAndProgramActions} from "../../../app/store/surveyAndProgram/actions";
 import {mockBaselineState, mockError, mockPlottingSelections, mockSurveyAndProgramState} from "../../mocks";
@@ -107,26 +107,26 @@ export function testUploadComponent(name: string, position: number) {
     it(`${name} upload is valid if data is present`, () => {
         const store = createSut(successState);
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(position).props().valid).toBe(true);
+        expect(wrapper.findAll(ManageFile).at(position).props().valid).toBe(true);
     });
 
     it(`${name} upload is invalid if data is null`, () => {
         const store = createSut();
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(position).props().valid).toBe(false);
+        expect(wrapper.findAll(ManageFile).at(position).props().valid).toBe(false);
     });
 
     it(`passes ${name} upload error to file upload`, () => {
         const store = createSut(errorState);
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
-        expect(wrapper.findAll(FileUpload).at(position).props().error).toStrictEqual(mockError("File upload went wrong"));
+        expect(wrapper.findAll(ManageFile).at(position).props().error).toStrictEqual(mockError("File upload went wrong"));
     });
 
     it(`upload ${name} dispatches surveyAndProgram/upload${name}`, (done) => {
         const store = createSut();
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
 
-        wrapper.findAll(FileUpload).at(position).props().upload({name: "TEST"});
+        wrapper.findAll(ManageFile).at(position).props().upload({name: "TEST"});
         setTimeout(() => {
             expect(expectedUploadAction.mock.calls[0][1]).toStrictEqual({name: "TEST"});
             done();
@@ -137,7 +137,7 @@ export function testUploadComponent(name: string, position: number) {
         const store = createSut();
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
 
-        wrapper.findAll(FileUpload).at(position).props().deleteFile();
+        wrapper.findAll(ManageFile).at(position).props().deleteFile();
         setTimeout(() => {
             expect(expectedDeleteAction.mock.calls.length).toBe(1);
             done();


### PR DESCRIPTION
This is a large changeset although very little is original logic - I've split the existing `FileUpload` component into 2 components: `ManageFile` which displays the filename, tick/loading icon and remove link, and `FileUpload` which handles selecting a new file from the computer. The internal logic of these 2 components (and the tests) is almost entirely copy pasted from the existing component. The primary change is to the styling of the `FileUpload` part, from a normal file input to a dropdown with 2 options as per the mockup: https://docs.google.com/presentation/d/1Eg9OlYSljHQuHfdoFuPFqCblU23b4-_o4XODXpGaa8w/edit#slide=id.g8ea8bb15f6_7_240

Having said that, if there's a way to split up this changeset that you think will make it easier to review please let me know and I'll do that.

Omitted here (to be done in further tickets): 
* translations
* optional styling of the ADR link so that it is disabled for guest users or for users without an API key with a tooltip to explain why