### PR TITLE
mrc-1713 wire up front-end ADR key widget

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 coverage:
   round: down
   precision: 0
+  status:
+    project: no
+    patch: yes

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -31,7 +31,7 @@ class ADRController(private val session: Session,
         val userId = session.getUserProfile().id
         val encryptedKey = encryption.encrypt(key)
         userRepository.saveADRKey(userId, encryptedKey)
-        return SuccessResponse(null).asResponseEntity()
+        return SuccessResponse(key).asResponseEntity()
     }
 
     @DeleteMapping("/key")

--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -47,16 +47,18 @@
                        v-translate="'cancel'"></a>
                 </div>
             </div>
+            <error-alert v-if="error" :error="error"></error-alert>
         </div>
     </div>
 </template>
 <script lang="ts">
     import Vue from "vue";
-    import {mapActionByName, mapActionsByNames, mapMutationByName, mapStateProp} from "../../utils";
-    import {RootMutation} from "../../store/root/mutations";
+    import {mapActionsByNames, mapStateProp} from "../../utils";
+    import {Error} from "../../generated"
     import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
     import i18next from "i18next";
+    import ErrorAlert from "../ErrorAlert.vue";
 
     interface Data {
         editableKey: string | null
@@ -77,7 +79,8 @@
         key: string | null
         currentLanguage: Language
         keyText: string
-        loggedIn: boolean
+        loggedIn: boolean,
+        error: Error | null
     }
 
     declare const currentUser: string;
@@ -97,6 +100,8 @@
                 (state: RootState) => state.adrKey),
             currentLanguage: mapStateProp<RootState, Language>(null,
                 (state: RootState) => state.language),
+            error: mapStateProp<RootState, Error | null>(null,
+                (state: RootState) => state.adrKeyError),
             keyText() {
                 if (this.key) {
                     let str = ""
@@ -139,7 +144,8 @@
             if (this.loggedIn) {
                 this.fetchADRKey();
             }
-        }
+        },
+        components: {ErrorAlert}
     });
 
 </script>

--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -51,7 +51,7 @@
 </template>
 <script lang="ts">
     import Vue from "vue";
-    import {mapMutationByName, mapStateProp} from "../../utils";
+    import {mapActionByName, mapActionsByNames, mapMutationByName, mapStateProp} from "../../utils";
     import {RootMutation} from "../../store/root/mutations";
     import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
@@ -63,7 +63,9 @@
     }
 
     interface Methods {
-        updateADRKey: (key: string | null) => void
+        fetchADRKey: () => void
+        saveADRKey: (key: string | null) => void
+        deleteADRKey: () => void
         edit: (e: Event) => void
         remove: (e: Event) => void
         save: (e: Event) => void
@@ -109,24 +111,29 @@
             }
         },
         methods: {
-            updateADRKey: mapMutationByName(null, RootMutation.UpdateADRKey),
+            ...mapActionsByNames<keyof Methods>(null, ["fetchADRKey", "saveADRKey", "deleteADRKey"]),
             edit(e: Event) {
                 e.preventDefault();
                 this.editing = true;
                 this.editableKey = this.key;
             },
             remove(e: Event) {
-                this.updateADRKey(null);
+                this.deleteADRKey();
                 e.preventDefault();
             },
             save(e: Event) {
                 e.preventDefault();
-                this.updateADRKey(this.editableKey);
+                this.saveADRKey(this.editableKey);
                 this.editing = false;
             },
             cancel(e: Event) {
                 e.preventDefault();
                 this.editing = false;
+            }
+        },
+        created() {
+            if (this.loggedIn) {
+                this.fetchADRKey();
             }
         }
     });

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -1,4 +1,5 @@
 import {MutationPayload, Store, StoreOptions} from "vuex";
+import {Error} from "./generated";
 import {baseline, BaselineState, initialBaselineState} from "./store/baseline/baseline";
 import {versions, VersionsState, initialVersionsState} from "./store/versions/versions";
 import {initialMetadataState, metadata, MetadataState} from "./store/metadata/metadata";
@@ -34,6 +35,7 @@ export interface TranslatableState {
 export interface RootState extends TranslatableState {
     version: string,
     adrKey: string | null,
+    adrKeyError: Error | null,
     baseline: BaselineState,
     metadata: MetadataState,
     surveyAndProgram: SurveyAndProgramState,
@@ -96,6 +98,7 @@ const resetState = (store: Store<RootState>) => {
 export const emptyState = (): RootState => {
     return {
         adrKey: null,
+        adrKeyError: null,
         language: Language.en,
         version: '0.0.0',
         baseline: initialBaselineState(),

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -5,9 +5,14 @@ import {RootMutation} from "./mutations";
 import {LanguageActions} from "../language/language";
 import {changeLanguage} from "../language/actions";
 import i18next from "i18next";
+import {api} from "../../apiService";
+import qs from "qs";
 
 export interface RootActions extends LanguageActions<RootState> {
     validate: (store: ActionContext<RootState, RootState>) => void;
+    fetchADRKey: (store: ActionContext<RootState, RootState>) => void;
+    saveADRKey: (store: ActionContext<RootState, RootState>, key: string) => void;
+    deleteADRKey: (store: ActionContext<RootState, RootState>) => void;
 }
 
 export const actions: ActionTree<RootState, RootState> & RootActions = {
@@ -52,5 +57,27 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
 
     async changeLanguage(context, payload) {
         await changeLanguage<RootState>(context, payload)
+    },
+
+    async fetchADRKey(context) {
+        await api<RootMutation, RootMutation>(context)
+            .withSuccess(RootMutation.UpdateADRKey)
+            .get("/adr/key/");
+    },
+
+    async saveADRKey(context, key) {
+        await api<RootMutation, RootMutation>(context)
+            .withSuccess(RootMutation.UpdateADRKey)
+            .postAndReturn("/adr/key/", qs.stringify({key}));
+    },
+
+    async deleteADRKey(context) {
+        await api<RootMutation, RootMutation>(context)
+            .delete("/adr/key/")
+            .then((response) => {
+                if (response) {
+                   context.commit(RootMutation.UpdateADRKey, {payload: null})
+                }
+            });
     }
 };

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -61,18 +61,23 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
 
     async fetchADRKey(context) {
         await api<RootMutation, RootMutation>(context)
+            .ignoreErrors()
             .withSuccess(RootMutation.UpdateADRKey)
             .get("/adr/key/");
     },
 
     async saveADRKey(context, key) {
+        context.commit({type: RootMutation.SetADRKeyError, payload: null});
         await api<RootMutation, RootMutation>(context)
+            .withError(RootMutation.SetADRKeyError)
             .withSuccess(RootMutation.UpdateADRKey)
             .postAndReturn("/adr/key/", qs.stringify({key}));
     },
 
     async deleteADRKey(context) {
+        context.commit({type: RootMutation.SetADRKeyError, payload: null});
         await api<RootMutation, RootMutation>(context)
+            .withError(RootMutation.SetADRKeyError)
             .withSuccess(RootMutation.UpdateADRKey)
             .delete("/adr/key/")
     }

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -76,7 +76,7 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
             .delete("/adr/key/")
             .then((response) => {
                 if (response) {
-                   context.commit(RootMutation.UpdateADRKey, {payload: null})
+                   context.commit({type: RootMutation.UpdateADRKey, payload: null})
                 }
             });
     }

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -23,8 +23,8 @@ export enum RootMutation {
 }
 
 export const mutations: MutationTree<RootState> = {
-    [RootMutation.UpdateADRKey](state: RootState, payload: string | null) {
-        state.adrKey = payload;
+    [RootMutation.UpdateADRKey](state: RootState, action: PayloadWithType<string | null>) {
+        state.adrKey = action.payload;
     },
 
     [RootMutation.Reset](state: RootState, action: PayloadWithType<number>) {

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -1,5 +1,6 @@
 import {MutationTree} from "vuex";
 import {emptyState, RootState} from "../../root";
+import {Error} from "../../generated";
 import {initialModelOptionsState} from "../modelOptions/modelOptions";
 import {initialModelRunState} from "../modelRun/modelRun";
 import {initialModelOutputState} from "../modelOutput/modelOutput";
@@ -14,17 +15,22 @@ import {mutations as languageMutations} from "../language/mutations";
 import {initialVersionsState} from "../versions/versions";
 
 export enum RootMutation {
-    UpdateADRKey = "UpdateADRKey",
     Reset = "Reset",
     ResetSelectedDataType = "ResetSelectedDataType",
     ResetOptions = "ResetOptions",
     ResetOutputs = "ResetOutputs",
-    SetVersion = "SetVersion"
+    SetADRKeyError = "ADRKeyError",
+    SetVersion = "SetVersion",
+    UpdateADRKey = "UpdateADRKey"
 }
 
 export const mutations: MutationTree<RootState> = {
     [RootMutation.UpdateADRKey](state: RootState, action: PayloadWithType<string | null>) {
         state.adrKey = action.payload;
+    },
+
+    [RootMutation.SetADRKeyError](state: RootState, action: PayloadWithType<Error | null>) {
+        state.adrKeyError = action.payload;
     },
 
     [RootMutation.Reset](state: RootState, action: PayloadWithType<number>) {
@@ -37,6 +43,7 @@ export const mutations: MutationTree<RootState> = {
             version: state.version,
             language: state.language,
             adrKey: state.adrKey,
+            adrKeyError: state.adrKeyError,
             baseline: maxValidStep < 1 ? initialBaselineState() : state.baseline,
             metadata: maxValidStep < 1 ? initialMetadataState() : state.metadata,
             surveyAndProgram: maxValidStep < 2 ? initialSurveyAndProgramState() : state.surveyAndProgram,

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -33,9 +33,9 @@ export const mapActionByName = <T>(namespace: string | null, name: string): Acti
     return (!!namespace && mapActions(namespace, [name])[name]) || mapActions([name])[name]
 };
 
-export const mapActionsByNames = <K extends string>(namespace: string, names: string[]) => {
+export const mapActionsByNames = <K extends string>(namespace: string | null, names: string[]) => {
     type R = { [key in K]: any }
-    return mapActions(namespace, names) as R
+    return (!!namespace && mapActions(namespace, names) || mapActions(names)) as R
 };
 
 export const mapMutationsByNames = <K extends string>(namespace: string, names: string[]) => {

--- a/src/app/static/src/tests/components/adr/ADRKey.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRKey.test.ts
@@ -3,11 +3,13 @@ import {mount, shallowMount} from "@vue/test-utils";
 
 import ADRKey from "../../../app/components/adr/ADRKey.vue";
 import Vuex, {ActionTree} from "vuex";
-import {mockRootState} from "../../mocks";
+import {Error} from "../../../app/generated";
+import {mockError, mockRootState} from "../../mocks";
 import {mutations} from "../../../app/store/root/mutations";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {RootActions} from "../../../app/store/root/actions";
 import {RootState} from "../../../app/root";
+import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 
 declare let currentUser: string;
 
@@ -17,9 +19,9 @@ describe("ADR Key", function () {
     const saveStub = jest.fn();
     const deleteStub = jest.fn();
 
-    const createStore = (key: string = "") => {
+    const createStore = (key: string = "", error: Error | null = null) => {
         const store = new Vuex.Store({
-            state: mockRootState({adrKey: key}),
+            state: mockRootState({adrKey: key, adrKeyError: error}),
             mutations: mutations,
             actions: {
                 fetchADRKey: fetchStub,
@@ -168,6 +170,16 @@ describe("ADR Key", function () {
         await Vue.nextTick();
 
         expect(saveStub.mock.calls.length).toBe(1);
+    });
+
+    it("displays error if it exists", () => {
+        let rendered = shallowMount(ADRKey, {store: createStore("", null)});
+        expect(rendered.findAll(ErrorAlert).length).toBe(0);
+
+        const fakeError = mockError("whatevs")
+        rendered = shallowMount(ADRKey, {store: createStore("", fakeError)});
+        expect(rendered.findAll(ErrorAlert).length).toBe(1);
+        expect(rendered.find(ErrorAlert).props("error")).toEqual(fakeError);
     });
 
 });

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -20,15 +20,15 @@ describe("Root actions", () => {
         const commit = jest.fn();
         await actions.saveADRKey({commit, rootState} as any, "1234");
 
-        expect(commit.mock.calls[0][0]["type"]).toBe(RootMutation.UpdateADRKey);
-        expect(commit.mock.calls[0][0]["payload"]).toBe("1234");
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[1][0]["payload"]).toBe("1234");
     });
 
     it("can delete ADR key", async () => {
         const commit = jest.fn();
         await actions.deleteADRKey({commit, rootState} as any);
 
-        expect(commit.mock.calls[0][0]["type"]).toBe(RootMutation.UpdateADRKey);
-        expect(commit.mock.calls[0][0]["payload"]).toBe(null);
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[1][0]["payload"]).toBe(null);
     });
 });

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -2,7 +2,7 @@ import {actions} from "../../app/store/root/actions";
 import {login, rootState} from "./integrationTest";
 import {RootMutation} from "../../app/store/root/mutations";
 
-describe("Baseline actions", () => {
+describe("Root actions", () => {
 
     beforeAll(async () => {
         await login();
@@ -12,23 +12,23 @@ describe("Baseline actions", () => {
         const commit = jest.fn();
         await actions.fetchADRKey({commit, rootState} as any);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
-        expect(commit.mock.calls[1][0]["payload"]).toBe(null);
+        expect(commit.mock.calls[0][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[0][0]["payload"]).toBe(null);
     });
 
     it("can save ADR key", async () => {
         const commit = jest.fn();
         await actions.saveADRKey({commit, rootState} as any, "1234");
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
-        expect(commit.mock.calls[1][0]["payload"]).toBe("1234");
+        expect(commit.mock.calls[0][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[0][0]["payload"]).toBe("1234");
     });
 
     it("can delete ADR key", async () => {
         const commit = jest.fn();
         await actions.deleteADRKey({commit, rootState} as any);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
-        expect(commit.mock.calls[1][0]["payload"]).toBe(null);
+        expect(commit.mock.calls[0][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[0][0]["payload"]).toBe(null);
     });
 });

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -1,0 +1,34 @@
+import {actions} from "../../app/store/root/actions";
+import {login, rootState} from "./integrationTest";
+import {RootMutation} from "../../app/store/root/mutations";
+
+describe("Baseline actions", () => {
+
+    beforeAll(async () => {
+        await login();
+    });
+
+    it("can fetch ADR key", async () => {
+        const commit = jest.fn();
+        await actions.fetchADRKey({commit, rootState} as any);
+
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[1][0]["payload"]).toBe(null);
+    });
+
+    it("can save ADR key", async () => {
+        const commit = jest.fn();
+        await actions.saveADRKey({commit, rootState} as any, "1234");
+
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[1][0]["payload"]).toBe("1234");
+    });
+
+    it("can delete ADR key", async () => {
+        const commit = jest.fn();
+        await actions.deleteADRKey({commit, rootState} as any);
+
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
+        expect(commit.mock.calls[1][0]["payload"]).toBe(null);
+    });
+});

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -216,6 +216,11 @@ describe("root actions", () => {
 
         expect(commit.mock.calls[0][0])
             .toStrictEqual({
+                type: RootMutation.SetADRKeyError,
+                payload: null
+            });
+        expect(commit.mock.calls[1][0])
+            .toStrictEqual({
                 type: RootMutation.UpdateADRKey,
                 payload: "1234"
             });
@@ -230,6 +235,11 @@ describe("root actions", () => {
         await actions.deleteADRKey({commit, rootState} as any);
 
         expect(commit.mock.calls[0][0])
+            .toStrictEqual({
+                type: RootMutation.SetADRKeyError,
+                payload: null
+            });
+        expect(commit.mock.calls[1][0])
             .toStrictEqual({
                 type: RootMutation.UpdateADRKey,
                 payload: null

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -1,9 +1,16 @@
 import {actions} from "../../app/store/root/actions";
-import {mockStepperState} from "../mocks";
+import {mockAxios, mockRootState, mockStepperState, mockSuccess} from "../mocks";
 import {Language} from "../../app/store/translations/locales";
 import {LanguageMutation} from "../../app/store/language/mutations";
+import {RootMutation} from "../../app/store/root/mutations";
 
 describe("root actions", () => {
+
+    const rootState = mockRootState();
+
+    beforeEach(() => {
+        mockAxios.reset();
+    });
 
     //NB in these tests 'valid' means complete with no preceding incomplete steps, or incomplete with no subsequent
     //complete steps
@@ -183,5 +190,51 @@ describe("root actions", () => {
             payload: "fr"
         })
     });
+
+    it("fetches ADR key", async () => {
+        mockAxios.onGet(`/adr/key/`)
+            .reply(200, mockSuccess("1234"));
+
+        const commit = jest.fn();
+
+        await actions.fetchADRKey({commit, rootState} as any);
+
+        expect(commit.mock.calls[0][0])
+            .toStrictEqual({
+                type: RootMutation.UpdateADRKey,
+                payload: "1234"
+            });
+    });
+
+    it("saves ADR key", async () => {
+        mockAxios.onPost(`/adr/key/`)
+            .reply(200, mockSuccess("1234"));
+
+        const commit = jest.fn();
+
+        await actions.saveADRKey({commit, rootState} as any, "1234");
+
+        expect(commit.mock.calls[0][0])
+            .toStrictEqual({
+                type: RootMutation.UpdateADRKey,
+                payload: "1234"
+            });
+    });
+
+    it("deletes ADR key", async () => {
+        mockAxios.onDelete(`/adr/key/`)
+            .reply(200, mockSuccess(null));
+
+        const commit = jest.fn();
+
+        await actions.deleteADRKey({commit, rootState} as any);
+
+        expect(commit.mock.calls[0][0])
+            .toStrictEqual({
+                type: RootMutation.UpdateADRKey,
+                payload: null
+            });
+    });
+
 
 });

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -231,4 +231,13 @@ describe("Root mutations", () => {
         mutations[RootMutation.UpdateADRKey](state, {payload: null});
         expect(state.adrKey).toBe(null);
     });
+
+    it("can set ADR key error", () => {
+        const state = mockRootState();
+        mutations[RootMutation.SetADRKeyError](state, {payload: mockError("whatevs")});
+        expect(state.adrKeyError!!.detail).toBe("whatevs");
+
+        mutations[RootMutation.SetADRKeyError](state, {payload: null});
+        expect(state.adrKeyError).toBe(null);
+    });
 });

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -225,10 +225,10 @@ describe("Root mutations", () => {
 
     it("can update ADR key", () => {
         const state = mockRootState();
-        mutations[RootMutation.UpdateADRKey](state, "new-key");
+        mutations[RootMutation.UpdateADRKey](state, {payload: "new-key"});
         expect(state.adrKey).toBe("new-key");
 
-        mutations[RootMutation.UpdateADRKey](state, null);
+        mutations[RootMutation.UpdateADRKey](state, {payload: null});
         expect(state.adrKey).toBe(null);
     });
 });


### PR DESCRIPTION
Contains commits from https://github.com/mrc-ide/hint/pull/276 which should be merged first and the base of this PR put back to master.

This PR wires up the ADR API key widget so it actually fetches/saves/removes the key from the backend.