### PR TITLE
mrc-1707 get datasets from ADR

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -7,6 +7,7 @@ import java.net.URL
 import java.util.*
 
 interface AppProperties {
+    val adrSchema: String
     val adrUrl: String
     val apiUrl: String
     val applicationTitle: String
@@ -30,6 +31,7 @@ class HintProperties: Properties()
 
 @Component
 class ConfiguredAppProperties(private val props: HintProperties = properties): AppProperties {
+    override val adrSchema = propString("adr_schema")
     override val adrUrl = propString("adr_url")
     override val apiUrl = propString("hintr_url")
     override val applicationTitle = propString("application_title")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRClient.kt
@@ -13,7 +13,7 @@ class ADRClientBuilder(val appProperties: AppProperties,
                        val session: Session,
                        val userRepository: UserRepository) {
 
-    fun build(): ADRClient {
+    fun build(): HttpClient {
 
         val userId = this.session.getUserProfile().id
         val encryptedKey = this.userRepository.getADRKey(userId)?: throw UserException("noADRKey")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -6,11 +6,15 @@ import com.github.kittinunf.fuel.httpPost
 import org.imperial.mrc.hint.asResponseEntity
 import org.springframework.http.ResponseEntity
 
-abstract class FuelClient(protected val baseUrl: String) {
+interface HttpClient {
+    fun get(url: String): ResponseEntity<String>
+}
+
+abstract class FuelClient(protected val baseUrl: String): HttpClient {
 
     abstract fun standardHeaders(): Map<String, Any>
 
-    fun get(url: String): ResponseEntity<String> {
+    override fun get(url: String): ResponseEntity<String> {
         return "$baseUrl/$url".httpGet()
                 .header(standardHeaders())
                 .addTimeouts()

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -8,6 +8,7 @@ import org.imperial.mrc.hint.models.SuccessResponse
 import org.imperial.mrc.hint.models.asResponseEntity
 import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -59,7 +60,11 @@ class ADRController(private val session: Session,
             "$url&hide_inaccessible_resources=true"
         }
         val response = adr.get(url)
-        val data = objectMapper.readTree(response.body!!)["data"]["results"]
-        return SuccessResponse(data.filter { it["resources"].count() > 0 }).asResponseEntity()
+        return if (response.statusCode != HttpStatus.OK) {
+            response
+        } else {
+            val data = objectMapper.readTree(response.body!!)["data"]["results"]
+            SuccessResponse(data.filter { it["resources"].count() > 0 }).asResponseEntity()
+        }
     }
 }

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -1,3 +1,4 @@
+adr_schema=inputs-unaids-estimates
 adr_url=https://dev.adr.fjelltopp.org/api/3/action
 application_title=Naomi
 application_url=http://localhost:8080

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -56,6 +56,31 @@ class ADRTests : SecureIntegrationTests() {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
+    fun `can get ADR datasets`(isAuthorized: IsAuthorized) {
+        testRestTemplate.postForEntity<String>("/adr/key", getPostEntity())
+        val result = testRestTemplate.getForEntity<String>("/adr/datasets")
+
+        assertSecureWithSuccess(isAuthorized, result, null)
+
+        if (isAuthorized == IsAuthorized.TRUE) {
+            val data = ObjectMapper().readTree(result.body!!)["data"]
+            assertThat(data.isArray).isTrue()
+            // we used a fake key so no results will come back
+            assertThat(data.count()).isEqualTo(0)
+        }
+
+        val resultWithResources = testRestTemplate.getForEntity<String>("/adr/datasets?showInaccessible=true")
+        if (isAuthorized == IsAuthorized.TRUE) {
+            val data = ObjectMapper().readTree(resultWithResources.body!!)["data"]
+            assertThat(data.isArray).isTrue()
+            // with the showInaccessible flag set, we can see packages
+            // that aren't actually accessible to our fake user
+            assertThat(data.count()).isEqualTo(3)
+        }
+    }
+
     private fun getPostEntity(): HttpEntity<LinkedMultiValueMap<String, String>> {
         val map = LinkedMultiValueMap<String, String>()
         map.add("key", "testkey")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -77,7 +77,7 @@ class ADRTests : SecureIntegrationTests() {
             assertThat(data.isArray).isTrue()
             // with the showInaccessible flag set, we can see packages
             // that aren't actually accessible to our fake user
-            assertThat(data.count()).isEqualTo(3)
+            assertThat(data.count()).isGreaterThan(0)
         }
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.clients.ADRClientBuilder
 import org.imperial.mrc.hint.ConfiguredAppProperties
+import org.imperial.mrc.hint.clients.ADRClient
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.exceptions.UserException
 import org.imperial.mrc.hint.security.Encryption
@@ -38,7 +39,7 @@ class ADRClientBuilderTests {
     @Test
     fun `creates client with correct auth header`() {
         val sut = ADRClientBuilder(ConfiguredAppProperties(), encryption, mockSession, mockRepo)
-        val result = sut.build()
+        val result = sut.build() as ADRClient
         val headers = result.standardHeaders()
         Assertions.assertThat(headers["Authorization"]).isEqualTo(TEST_KEY)
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -15,6 +15,7 @@ import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
 import org.junit.jupiter.api.Test
 import org.pac4j.core.profile.CommonProfile
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 
 class ADRControllerTests {
@@ -126,6 +127,27 @@ class ADRControllerTests {
         assertThat(data.isArray).isTrue()
         assertThat(data.count()).isEqualTo(1)
         assertThat(data[0]["resources"].count()).isEqualTo(2)
+    }
+
+    @Test
+    fun `passes error responses along`() {
+        val badResponse = ResponseEntity<String>(HttpStatus.BAD_REQUEST)
+        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
+        val mockClient = mock<HttpClient> {
+            on { get(expectedUrl) } doReturn badResponse
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(
+                mockSession,
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties)
+        val result = sut.getDatasets()
+        assertThat(result).isEqualTo(badResponse)
     }
 
     private fun makeFakeSuccessResponse(): ResponseEntity<String> {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -6,55 +6,114 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.hint.clients.ADRClientBuilder
+import org.imperial.mrc.hint.clients.HttpClient
 import org.imperial.mrc.hint.controllers.ADRController
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
 import org.junit.jupiter.api.Test
 import org.pac4j.core.profile.CommonProfile
+import org.springframework.http.ResponseEntity
 
 class ADRControllerTests {
 
+    private val mockSession = mock<Session> {
+        on { getUserProfile() } doReturn CommonProfile().apply { id = "test" }
+    }
+
+    private val mockEncryption = mock<Encryption> {
+        on { encrypt(any()) } doReturn "encrypted".toByteArray()
+        on { decrypt(any()) } doReturn "decrypted"
+    }
+
+    private val objectMapper = ObjectMapper()
+
     @Test
     fun `encrypts key before saving it`() {
-        val mockSession = mock<Session> {
-            on { getUserProfile() } doReturn CommonProfile().apply { id = "test" }
-        }
-        val mockEncryption = mock<Encryption> {
-            on { encrypt(any()) } doReturn "encrypted".toByteArray()
-        }
         val mockRepo = mock<UserRepository>()
-        val sut = ADRController(mockSession, mockEncryption, mockRepo)
+        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock())
         sut.saveAPIKey("plainText")
         verify(mockRepo).saveADRKey("test", "encrypted".toByteArray())
     }
 
     @Test
     fun `decrypts key before returning it`() {
-        val mockSession = mock<Session> {
-            on { getUserProfile() } doReturn CommonProfile().apply { id = "test" }
-        }
-        val mockEncryption = mock<Encryption> {
-            on { decrypt(any()) } doReturn "decrypted"
-        }
         val mockRepo = mock<UserRepository>() {
-            on {getADRKey("test")} doReturn "encrypted".toByteArray()
+            on { getADRKey("test") } doReturn "encrypted".toByteArray()
         }
-        val sut = ADRController(mockSession, mockEncryption, mockRepo)
+        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock())
         val result = sut.getAPIKey()
-        val data = ObjectMapper().readTree(result.body!!)["data"].asText()
+        val data = objectMapper.readTree(result.body!!)["data"].asText()
         assertThat(data).isEqualTo("decrypted")
     }
 
     @Test
     fun `returns null if key does not exist`() {
-        val mockSession = mock<Session> {
-            on { getUserProfile() } doReturn CommonProfile().apply { id = "test" }
-        }
-        val sut = ADRController(mockSession, mock(), mock())
+        val sut = ADRController(mockSession, mock(), mock(), mock(), mock())
         val result = sut.getAPIKey()
-        val data = ObjectMapper().readTree(result.body!!)["data"]
+        val data = objectMapper.readTree(result.body!!)["data"]
         assertThat(data.isNull).isTrue()
+    }
+
+    @Test
+    fun `gets datasets without inaccessible resources by default`() {
+        val expectedUrl = "package_search?q=type:inputs-unaids-estimates&hide_inaccessible_resources=true"
+        val mockClient = mock<HttpClient> {
+            on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val result = sut.getDatasets()
+        val data = objectMapper.readTree(result.body!!)["data"]
+        assertThat(data.isArray).isTrue()
+        assertThat(data[0]["resources"].count()).isEqualTo(2)
+    }
+
+    @Test
+    fun `gets datasets including inaccessible resources if flag is passed`() {
+        val expectedUrl = "package_search?q=type:inputs-unaids-estimates"
+        val mockClient = mock<HttpClient> {
+            on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val result = sut.getDatasets(true)
+        val data = objectMapper.readTree(result.body!!)["data"]
+        assertThat(data.isArray).isTrue()
+        assertThat(data[0][0]).isEqualTo(1)
+        assertThat(data[0][0]).isEqualTo(2)
+    }
+
+    @Test
+    fun `filters datasets to only those with resources`() {
+        val expectedUrl = "package_search?q=type:inputs-unaids-estimates&hide_inaccessible_resources=true"
+        val mockClient = mock<HttpClient> {
+            on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val result = sut.getDatasets()
+        val data = objectMapper.readTree(result.body!!)["data"]
+        assertThat(data.isArray).isTrue()
+        assertThat(data.count()).isEqualTo(1)
+        assertThat(data[0]["resources"].count()).isEqualTo(2)
+    }
+
+    private fun makeFakeSuccessResponse(): ResponseEntity<String> {
+        val resultWithResources = mapOf("resources" to listOf(1, 2))
+        val resultWithoutResources = mapOf("resources" to listOf<Any>())
+        val data = mapOf("results" to listOf(resultWithResources, resultWithoutResources))
+        val body = mapOf("data" to data)
+        return ResponseEntity
+                .ok()
+                .body(objectMapper.writeValueAsString(body))
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.clients.ADRClientBuilder
 import org.imperial.mrc.hint.clients.HttpClient
 import org.imperial.mrc.hint.controllers.ADRController
@@ -27,12 +28,16 @@ class ADRControllerTests {
         on { decrypt(any()) } doReturn "decrypted"
     }
 
+    private val mockProperties = mock<AppProperties> {
+        on { adrSchema } doReturn "adr-schema"
+    }
+
     private val objectMapper = ObjectMapper()
 
     @Test
     fun `encrypts key before saving it`() {
         val mockRepo = mock<UserRepository>()
-        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock())
+        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock(), mock())
         sut.saveAPIKey("plainText")
         verify(mockRepo).saveADRKey("test", "encrypted".toByteArray())
     }
@@ -42,7 +47,7 @@ class ADRControllerTests {
         val mockRepo = mock<UserRepository>() {
             on { getADRKey("test") } doReturn "encrypted".toByteArray()
         }
-        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock())
+        val sut = ADRController(mockSession, mockEncryption, mockRepo, mock(), mock(), mock())
         val result = sut.getAPIKey()
         val data = objectMapper.readTree(result.body!!)["data"].asText()
         assertThat(data).isEqualTo("decrypted")
@@ -50,7 +55,7 @@ class ADRControllerTests {
 
     @Test
     fun `returns null if key does not exist`() {
-        val sut = ADRController(mockSession, mock(), mock(), mock(), mock())
+        val sut = ADRController(mockSession, mock(), mock(), mock(), mock(), mock())
         val result = sut.getAPIKey()
         val data = objectMapper.readTree(result.body!!)["data"]
         assertThat(data.isNull).isTrue()
@@ -58,14 +63,20 @@ class ADRControllerTests {
 
     @Test
     fun `gets datasets without inaccessible resources by default`() {
-        val expectedUrl = "package_search?q=type:inputs-unaids-estimates&hide_inaccessible_resources=true"
+        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
         val mockClient = mock<HttpClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
             on { build() } doReturn mockClient
         }
-        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val sut = ADRController(
+                mockSession,
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties)
         val result = sut.getDatasets()
         val data = objectMapper.readTree(result.body!!)["data"]
         assertThat(data.isArray).isTrue()
@@ -74,31 +85,42 @@ class ADRControllerTests {
 
     @Test
     fun `gets datasets including inaccessible resources if flag is passed`() {
-        val expectedUrl = "package_search?q=type:inputs-unaids-estimates"
+        val expectedUrl = "package_search?q=type:adr-schema"
         val mockClient = mock<HttpClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
             on { build() } doReturn mockClient
         }
-        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val sut = ADRController(
+                mockSession,
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties)
         val result = sut.getDatasets(true)
         val data = objectMapper.readTree(result.body!!)["data"]
         assertThat(data.isArray).isTrue()
-        assertThat(data[0][0]).isEqualTo(1)
-        assertThat(data[0][0]).isEqualTo(2)
+        assertThat(data[0]["resources"].count()).isEqualTo(2)
     }
 
     @Test
     fun `filters datasets to only those with resources`() {
-        val expectedUrl = "package_search?q=type:inputs-unaids-estimates&hide_inaccessible_resources=true"
+        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
         val mockClient = mock<HttpClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
             on { build() } doReturn mockClient
         }
-        val sut = ADRController(mockSession, mock(), mock(), mockBuilder, objectMapper)
+        val sut = ADRController(
+                mockSession,
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties)
         val result = sut.getDatasets()
         val data = objectMapper.readTree(result.body!!)["data"]
         assertThat(data.isArray).isTrue()


### PR DESCRIPTION
This PR adds an endpoint to retrieve all datasets matching the appropriate ADR schema, and that the currently logged in user can access resources for. This is for use in a typeahead in the front-end allowing the user to select a dataset.