### PR TITLE
mrc-717 fix warnings in js tests

### DIFF
--- a/src/app/static/src/app/store/modelOptions/actions.ts
+++ b/src/app/static/src/app/store/modelOptions/actions.ts
@@ -16,6 +16,7 @@ export const actions: ActionTree<ModelOptionsState, RootState> & ModelOptionsAct
         commit(ModelOptionsMutation.FetchingModelOptions);
         const response = await api<ModelOptionsMutation, ModelOptionsMutation>(context)
             .withSuccess(ModelOptionsMutation.ModelOptionsFetched)
+            .ignoreErrors()
             .get<DynamicFormMeta>("/model/options/");
 
         if (response) {

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -74,6 +74,7 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
 
         commit({type: "RunCancelled", payload: null});
         const apiService = api<ModelRunMutation, ModelRunMutation>(context)
+                    .ignoreSuccess()
                     .ignoreErrors();
 
         await makeCancelRunRequest(apiService,modelRunId)

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -32,6 +32,11 @@ describe("App", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        console.log = jest.fn();
+    });
+
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
     });
 
     const getStore = (ready: boolean = false) => {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -23,6 +23,8 @@ storeOptions.modules!!.baseline!!.actions = baselineActions;
 storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
 storeOptions.modules!!.modelRun!!.actions = modelRunActions;
 
+console.error = jest.fn();
+
 // only import the app after we have replaced action with mocks
 // as the app will call these actions on import
 import {app} from "../../app"
@@ -35,8 +37,9 @@ describe("App", () => {
         console.log = jest.fn();
     });
 
-    afterEach(() => {
+    afterAll(() => {
         (console.log as jest.Mock).mockClear();
+        (console.error as jest.Mock).mockClear();
     });
 
     const getStore = (ready: boolean = false) => {

--- a/src/app/static/src/tests/components/header/userHeader.test.ts
+++ b/src/app/static/src/tests/components/header/userHeader.test.ts
@@ -6,7 +6,6 @@ import LanguageMenu from "../../../app/components/header/LanguageMenu.vue";
 import {Language} from "../../../app/store/translations/locales";
 import {emptyState} from "../../../app/root";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
-import {initialVersionsState} from "../../../app/store/versions/versions";
 
 const localVue = createLocalVue();
 
@@ -26,7 +25,7 @@ describe("user header", () => {
     registerTranslations(store);
 
     const getWrapper = (user: string = "someone@email.com") => {
-        return shallowMount(UserHeader, {propsData: {user, title: "Naomi"}, store});
+        return shallowMount(UserHeader, {propsData: {user, title: "Naomi"}, store, stubs: ["router-link"]});
     };
 
     it("contains logout link if current user is not guest", () => {
@@ -52,29 +51,29 @@ describe("user header", () => {
     });
 
     it("renders file menu", () => {
-        const wrapper = shallowMount(UserHeader, {store});
+        const wrapper = shallowMount(UserHeader, {store, stubs: ["router-link"]});
         expect(wrapper.findAll(FileMenu).length).toBe(1);
     });
 
     it("renders language menu", () => {
-        const wrapper = shallowMount(UserHeader, {store});
+        const wrapper = shallowMount(UserHeader, {store, stubs: ["router-link"]});
         expect(wrapper.findAll(LanguageMenu).length).toBe(1);
     });
 
     it("contains bug report link", () => {
-        const wrapper = shallowMount(UserHeader, {store});
+        const wrapper = shallowMount(UserHeader, {store, stubs: ["router-link"]});
         const bugLink = wrapper.find("a[href='https://forms.gle/QxCT1b4ScLqKPg6a7']");
         expect(bugLink.text()).toBe("Report a bug");
     });
 
     it("computes language", () => {
-        const wrapper = shallowMount(UserHeader, {localVue, store});
+        const wrapper = shallowMount(UserHeader, {localVue, store, stubs: ["router-link"]});
         const vm = (wrapper as any).vm;
         expect(vm.helpFilename).toStrictEqual("Naomi-basic-instructions.pdf");
         expect(vm.troubleFilename).toStrictEqual("index-en.html");
 
         const frStore = createFrenchStore();
-        const frWrapper = shallowMount(UserHeader, {localVue, store: frStore});
+        const frWrapper = shallowMount(UserHeader, {localVue, store: frStore, stubs: ["router-link"]});
         const frVm = (frWrapper as any).vm;
         expect(frVm.helpFilename).toStrictEqual("Naomi-instructions-de-base.pdf");
         expect(frVm.troubleFilename).toStrictEqual("index-fr.html");
@@ -83,12 +82,12 @@ describe("user header", () => {
     it("contains help document links", () => {
         // Reset translations
         registerTranslations(store);
-        const wrapper = shallowMount(UserHeader, {store});
+        const wrapper = shallowMount(UserHeader, {store, stubs: ["router-link"]});
         expect(wrapper.find("a[href='public/resources/Naomi-basic-instructions.pdf']").text()).toBe("Help");
         expect(wrapper.find("a[href='https://mrc-ide.github.io/naomi-troubleshooting/index-en.html']").text()).toBe("Troubleshooting");
 
         const frStore = createFrenchStore();
-        const frWrapper = shallowMount(UserHeader, {store: frStore});
+        const frWrapper = shallowMount(UserHeader, {store: frStore, stubs: ["router-link"]});
         expect(frWrapper.find("a[href='public/resources/Naomi-instructions-de-base.pdf']").text()).toBe("Aide");
         expect(frWrapper.find("a[href='https://mrc-ide.github.io/naomi-troubleshooting/index-fr.html']").text()).toBe("Dépannage");
     });
@@ -96,7 +95,7 @@ describe("user header", () => {
     it("renders Versions link as expected if user is not guest", () => {
         const wrapper = getWrapper();
 
-        const link = wrapper.find("router-link");
+        const link = wrapper.find("router-link-stub");
         expect(link.attributes("to")).toBe("/versions");
         expect(link.text()).toBe("Versions");
     });

--- a/src/app/static/src/tests/components/modelRun/modelRun.test.ts
+++ b/src/app/static/src/tests/components/modelRun/modelRun.test.ts
@@ -57,6 +57,9 @@ describe("Model run component", () => {
 
         mockAxios.onGet(`/model/result/1234`)
             .reply(200, mockSuccess(mockModelResultResponse()));
+
+        mockAxios.onPost(`/model/cancel/123`)
+            .reply(200, mockSuccess(null));
     });
 
     afterEach(() => {

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -1,11 +1,19 @@
 import {mount, shallowMount} from '@vue/test-utils';
 import MapAdjustScale from "../../../app/components/plots/MapAdjustScale.vue";
 import {ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+import Vuex from "vuex";
+import {emptyState} from "../../../app/root";
 
 describe("MapAdjustScale component", () => {
 
+    const store = new Vuex.Store({
+        state: emptyState()
+    });
+    registerTranslations(store);
+
     it("does not render if show is false", () => {
-        const wrapper = shallowMount(MapAdjustScale, {propsData: {
+        const wrapper = shallowMount(MapAdjustScale, {store, propsData: {
                 show: false,
                 colourScale: {}
             }
@@ -15,7 +23,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected with default scale",  () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -36,7 +44,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected with custom scale", () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -64,7 +72,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected with full dynamic scale",  () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -85,7 +93,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected with filtered dynamic scale",  () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -106,7 +114,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("emits update event when type changes", () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -155,7 +163,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("emits update event when custom min or max changes", () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -186,7 +194,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("does not emit update event when type is Custom and custom max is not greater than custom min", () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {
@@ -207,7 +215,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("updates colourScaleToAdjust when colourScale property changes", () => {
-        const wrapper = mount(MapAdjustScale, {propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 show: true,
                 step: 0.1,
                 colourScale: {

--- a/src/app/static/src/tests/components/plots/mapControl.test.ts
+++ b/src/app/static/src/tests/components/plots/mapControl.test.ts
@@ -1,8 +1,15 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils';
 import MapControl from "../../../app/components/plots/MapControl.vue";
 import TreeSelect from '@riophae/vue-treeselect';
+import Vuex from "vuex";
+import {emptyState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
 
 const localVue = createLocalVue();
+const store = new Vuex.Store({
+    state: emptyState()
+});
+registerTranslations(store);
 
 describe("Map control component", () => {
 
@@ -25,7 +32,7 @@ describe("Map control component", () => {
     };
 
     it("renders tree selects with expected properties", () => {
-        const wrapper = shallowMount(MapControl, {localVue, propsData});
+        const wrapper = shallowMount(MapControl, {localVue, propsData, store});
 
         expect(wrapper.findAll(TreeSelect).at(0).props("searchable")).toBe(false);
         expect(wrapper.findAll(TreeSelect).at(0).props("multiple")).toBe(false);
@@ -37,7 +44,7 @@ describe("Map control component", () => {
     });
 
     it("renders indicator options", () => {
-        const wrapper = shallowMount(MapControl, {localVue, propsData});
+        const wrapper = shallowMount(MapControl, {localVue, propsData, store});
 
         expect(wrapper.findAll(TreeSelect).at(0).props("options"))
             .toStrictEqual([{id: "art_coverage", label: "ART coverage"},
@@ -45,23 +52,22 @@ describe("Map control component", () => {
     });
 
     it("renders detail options", () => {
-        const wrapper = shallowMount(MapControl, {localVue, propsData});
+        const wrapper = shallowMount(MapControl, {localVue, propsData, store});
 
         expect(wrapper.findAll(TreeSelect).at(1).props("options"))
             .toStrictEqual([{id: 4, label: "Admin Level 4"},
-                             {id: 5, label: "Admin Level 5"}]);
+                {id: 5, label: "Admin Level 5"}]);
     });
 
 
-
     it("emits indicator-changed event with indicator", () => {
-        const wrapper = shallowMount(MapControl, {localVue, propsData});
+        const wrapper = shallowMount(MapControl, {localVue, propsData, store});
         wrapper.findAll(TreeSelect).at(0).vm.$emit("input", "art_coverage");
         expect(wrapper.emitted("indicator-changed")[0][0]).toBe("art_coverage");
     });
 
     it("emits detail-changed event with detail", () => {
-        const wrapper = shallowMount(MapControl, {localVue, propsData});
+        const wrapper = shallowMount(MapControl, {localVue, propsData, store});
         wrapper.findAll(TreeSelect).at(1).vm.$emit("input", 3);
         expect(wrapper.emitted("detail-changed")[0][0]).toBe(3);
     });

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -8,360 +8,424 @@ import {
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 import {Filter} from "../../../app/generated";
 
-it("colorFunctionFromName returns color function", () => {
-    const result = colorFunctionFromName("interpolateMagma");
-    expect(result).toBe(interpolateMagma);
-});
+describe("plot utils", () => {
 
-it("colorFunctionFromName returns default color function if named function does not exist", () => {
-    const result = colorFunctionFromName("not-a-color-function");
-    expect(result).toBe(interpolateWarm);
-});
+    const warnMock = jest.fn();
 
-it("getColor calculates colour string", () => {
-    const result = getColor(0.5, {
+    beforeEach(() => {
+        console.warn = warnMock;
+    });
+
+    afterEach(() => {
+        (console.warn as jest.Mock).mockClear();
+    });
+
+    it("colorFunctionFromName returns color function", () => {
+        const result = colorFunctionFromName("interpolateMagma");
+        expect(result).toBe(interpolateMagma);
+    });
+
+    it("colorFunctionFromName returns default color function if named function does not exist", () => {
+        const result = colorFunctionFromName("not-a-color-function");
+        expect(result).toBe(interpolateWarm);
+        expect(warnMock).toBeCalledWith("Unknown color function: not-a-color-function");
+    });
+
+    it("getColor calculates colour string", () => {
+        const result = getColor(0.5, {
+                min: 0,
+                max: 1,
+                colour: "interpolateGreys",
+                invert_scale: false,
+                indicator: "test",
+                value_column: "",
+                name: ""
+            },
+            {
+                min: 0,
+                max: 1
+            });
+
+        expect(result).toEqual("rgb(151, 151, 151)");
+    });
+
+    it("getColor avoids dividing by zero if min equals max", () => {
+        const result = getColor(0.5, {
+                min: 0.5,
+                max: 0.5,
+                colour: "interpolateGreys",
+                invert_scale: false,
+                indicator: "test",
+                value_column: "",
+                name: ""
+            },
+            {
+                min: 0.5,
+                max: 0.5
+            });
+
+        expect(result).toEqual("rgb(255, 255, 255)");
+    });
+
+    it("can get indicator range", () => {
+
+        const data = [
+            {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 15},
+            {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 14},
+            {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 13}
+        ];
+
+        const plhiv = {
+            indicator: "plhiv",
+            value_column: "plhiv",
+            name: "PLHIV",
             min: 0,
-            max: 1,
+            max: 0,
             colour: "interpolateGreys",
-            invert_scale: false,
-            indicator: "test",
-            value_column: "",
-            name: ""
-        },
-        {
-            min: 0,
-            max:1
-        });
-
-    expect(result).toEqual("rgb(151, 151, 151)");
-});
-
-it("getColor avoids dividing by zero if min equals max", () => {
-    const result = getColor(0.5, {
-            min: 0.5,
-            max: 0.5,
-            colour: "interpolateGreys",
-            invert_scale: false,
-            indicator: "test",
-            value_column: "",
-            name: ""
-        },
-        {
-            min: 0.5,
-            max: 0.5
-        });
-
-    expect(result).toEqual("rgb(255, 255, 255)");
-});
-
-it("can get indicator range", () => {
-
-    const data = [
-        {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 15},
-        {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 14},
-        {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 13}
-    ];
-
-    const plhiv = {
-        indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
-    };
-
-    let result = getIndicatorRange(data, plhiv);
-
-    expect(result).toStrictEqual({min: 13, max: 15});
-
-    const prev = {
-        indicator: "prevalence", value_column: "prevalence", name: "prevalence", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
-    };
-    result = getIndicatorRange(data, prev);
-
-    expect(result).toStrictEqual({min: 0.5, max: 0.7});
-});
-
-it("can get filtered indicator range", () => {
-    const data = [
-        {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 13, art_cov: 0.2, vls: 0.1, year: "2018"},
-        {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 13, art_cov: 0.3, vls: 0.2, year: "2018"},
-        {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 14, art_cov: 0.4, vls: 0.3, year: "2018"},
-        {area_id: "MWI_1_1", prevalence: 0.6, plhiv: 14, art_cov: 0.2, vls: 0.4, year: "2019"},
-        {area_id: "MWI_1_2", prevalence: 0.7, plhiv: 15, art_cov: 0.3, vls: 0.5, year: "2019"},
-        {area_id: "MWI_1_3", prevalence: 0.8, plhiv: 15, art_cov: 0.4, vls: 0.6, year: "2019"}
-    ];
-
-    const indicatorMeta =
-        {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 1, colour: "interpolateGreys", invert_scale: false
+            invert_scale: false
         };
 
-    const filters = [{id: "year", column_id: "year", label: "Year", options: [{id: "2018", label: ""}, {id: "2019", label: ""}]}];
-    const selectedFilterValues = {year: [{id: "2019", label: "2019"}]};
+        let result = getIndicatorRange(data, plhiv);
 
-    const areaIds = ["MWI_1_1", "MWI_1_2"];
+        expect(result).toStrictEqual({min: 13, max: 15});
 
-    const result = getIndicatorRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
+        const prev = {
+            indicator: "prevalence",
+            value_column: "prevalence",
+            name: "prevalence",
+            min: 0,
+            max: 0,
+            colour: "interpolateGreys",
+            invert_scale: false
+        };
+        result = getIndicatorRange(data, prev);
 
-    expect(result).toStrictEqual({min: 0.6, max: 0.7});
-});
+        expect(result).toStrictEqual({min: 0.5, max: 0.7});
+    });
 
-it("getColor can invert color function", () => {
-    const result = getColor(0, {
+    it("can get filtered indicator range", () => {
+        const data = [
+            {area_id: "MWI_1_1", prevalence: 0.5, plhiv: 13, art_cov: 0.2, vls: 0.1, year: "2018"},
+            {area_id: "MWI_1_2", prevalence: 0.6, plhiv: 13, art_cov: 0.3, vls: 0.2, year: "2018"},
+            {area_id: "MWI_1_3", prevalence: 0.7, plhiv: 14, art_cov: 0.4, vls: 0.3, year: "2018"},
+            {area_id: "MWI_1_1", prevalence: 0.6, plhiv: 14, art_cov: 0.2, vls: 0.4, year: "2019"},
+            {area_id: "MWI_1_2", prevalence: 0.7, plhiv: 15, art_cov: 0.3, vls: 0.5, year: "2019"},
+            {area_id: "MWI_1_3", prevalence: 0.8, plhiv: 15, art_cov: 0.4, vls: 0.6, year: "2019"}
+        ];
+
+        const indicatorMeta =
+            {
+                indicator: "prevalence",
+                value_column: "prevalence",
+                name: "Prevalence",
+                min: 0,
+                max: 1,
+                colour: "interpolateGreys",
+                invert_scale: false
+            };
+
+        const filters = [{
+            id: "year",
+            column_id: "year",
+            label: "Year",
+            options: [{id: "2018", label: ""}, {id: "2019", label: ""}]
+        }];
+        const selectedFilterValues = {year: [{id: "2019", label: "2019"}]};
+
+        const areaIds = ["MWI_1_1", "MWI_1_2"];
+
+        const result = getIndicatorRange(data, indicatorMeta, filters, selectedFilterValues, areaIds);
+
+        expect(result).toStrictEqual({min: 0.6, max: 0.7});
+    });
+
+    it("getColor can invert color function", () => {
+        const result = getColor(0, {
+                min: 0,
+                max: 1,
+                colour: "interpolateGreys",
+                invert_scale: false,
+                indicator: "test",
+                value_column: "",
+                name: ""
+            },
+            {min: 0, max: 1});
+
+        expect(result).toEqual("rgb(255, 255, 255)"); //0 = white in interpolateGreys
+
+        const invertedResult = getColor(0, {
             min: 0,
             max: 1,
+            colour: "interpolateGreys",
+            invert_scale: true,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        }, {min: 0, max: 1});
+        expect(invertedResult).toEqual("rgb(0, 0, 0)");
+    });
+
+    it("getColor can use custom min and max", () => {
+        const result = getColor(0.5, {
+            min: 0.2,
+            max: 2,
             colour: "interpolateGreys",
             invert_scale: false,
             indicator: "test",
             value_column: "",
             name: ""
-        },
-        {min: 0, max: 1});
+        }, {min: 0, max: 1});
 
-    expect(result).toEqual("rgb(255, 255, 255)"); //0 = white in interpolateGreys
-
-    const invertedResult = getColor(0, {
-        min: 0,
-        max: 1,
-        colour: "interpolateGreys",
-        invert_scale: true,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    }, {min: 0, max: 1});
-    expect(invertedResult).toEqual("rgb(0, 0, 0)");
-});
-
-it("getColor can use custom min and max", () => {
-    const result = getColor(0.5, {
-        min: 0.2,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    }, {min: 0, max: 1});
-
-    expect(result).toEqual("rgb(151, 151, 151)");
-});
-
-
-it("getColor can get expected colour when value is less than min", () => {
-    const result = getColor(0.5, {
-        min: 1,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    }, {min: 1, max: 2});
-
-    expect(result).toEqual("rgb(255, 255, 255)");
-});
-
-it("getColor can get expected colour when value is greater than max", () => {
-    const result = getColor(5, {
-        min: 1,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    }, {min: 1, max: 2});
-
-    expect(result).toEqual("rgb(0, 0, 0)");
-});
-
-it("getColor can use negative min and zero max", () => {
-    const metadata = {
-        min: 0,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    };
-    let result = getColor(-0.45, metadata, {min: -0.45, max: 0});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(0, metadata, {min: -0.45, max: 0});
-    expect(result).toEqual("rgb(0, 0, 0)");
-    result = getColor(-0.225, metadata, {min: -0.45, max: 0});
-    expect(result).toEqual("rgb(151, 151, 151)");
-
-    //Test out of range
-    result = getColor(-0.9, metadata, {min: -0.45, max: 0});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(1, metadata, {min: -0.45, max: 0});
-    expect(result).toEqual("rgb(0, 0, 0)");
-});
-
-it("getColor can use negative min and positive max", () => {
-    const metadata = {
-        min: 0,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    };
-    let result = getColor(-10, metadata, {min: -10, max: 10});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(10, metadata, {min: -10, max: 10});
-    expect(result).toEqual("rgb(0, 0, 0)");
-    result = getColor(0, metadata, {min: -10, max: 10});
-    expect(result).toEqual("rgb(151, 151, 151)");
-
-    //Test out of range
-    result = getColor(-10.5, metadata, {min: -10, max: 10});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(11, metadata, {min: -10, max: 10});
-    expect(result).toEqual("rgb(0, 0, 0)");
-});
-
-it("getColor can use negative min and negative max", () => {
-    const metadata = {
-        min: 0,
-        max: 2,
-        colour: "interpolateGreys",
-        invert_scale: false,
-        indicator: "test",
-        value_column: "",
-        name: ""
-    };
-    let result = getColor(-10, metadata, {min: -10, max: -5});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(-5, metadata, {min: -10, max: -5});
-    expect(result).toEqual("rgb(0, 0, 0)");
-    result = getColor(-7.5, metadata, {min: -10, max: -5});
-    expect(result).toEqual("rgb(151, 151, 151)");
-
-    //Test out of range
-    result = getColor(-11, metadata, {min: -10, max: -5});
-    expect(result).toEqual("rgb(255, 255, 255)");
-    result = getColor(0, metadata, {min: -10, max: -5});
-    expect(result).toEqual("rgb(0, 0, 0)");
-});
-
-it("can get indicator name lookup", () => {
-    const indicators = [
-        {
-            indicator: "plhiv", value_column: "plhiv", name: "PLHIV", min: 0, max:0, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "prevalence", value_column: "prevalence", name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-        }
-    ];
-    expect(toIndicatorNameLookup(indicators)).toStrictEqual({
-        plhiv: "PLHIV",
-        prevalence: "Prevalence"
+        expect(result).toEqual("rgb(151, 151, 151)");
     });
-});
-
-it ("round to context rounds values to 1 more decimal place than the context where context is integer", () => {
-    expect(roundToContext(0.1234, [0, 1])).toBe(0.1);
-});
-
-it ("round to context rounds values to 1 more decimal place than the context where context has fewer decimal places than value", () => {
-    expect(roundToContext(0.1234, [0, 0.1])).toBe(0.12);
-});
-
-it ("round to context does not round value if it already has fewer decimal places than context", () => {
-    expect(roundToContext(0.1, [0, 0.12])).toBe(0.1);
-});
-
-it ("round to context does not round value if both values and context are integers", () => {
-    expect(roundToContext(5, [0, 10])).toBe(5);
-});
-
-it ("round to context can round when context includes negative", () => {
-    expect(roundToContext(-0.3614, [-0.45, 0])).toBe(-0.361);
-});
-
-it("colourScaleStepFromMetadata returns expected value", () => {
-    const meta = {
-        min: 0,
-        max: 1
-    };
-    expect(colourScaleStepFromMetadata(meta as any)).toBe(0.1);
-});
-
-it("roundRange rounds as expected", () => {
-    expect(roundRange({min: 0.31432, max: 0.84162})).toStrictEqual({min: 0.31, max: 0.84});
-
-    expect(roundRange({min: 0.031432, max: 0.084162})).toStrictEqual({min: 0.031, max: 0.084});
-
-    expect(roundRange({min: 3.11, max: 4.12})).toStrictEqual({min: 3.1, max: 4.1});
-
-    expect(roundRange({min: 101, max: 201})).toStrictEqual({min: 101, max: 201});
-
-    expect(roundRange({min: 1.1234, max: 1.1235})).toStrictEqual({min: 1.1234, max: 1.1235});
-    expect(roundRange({min: 1.1234566001, max: 1.123457001})).toStrictEqual({min: 1.1234566, max: 1.123457});
-});
-
-it("roundRange can round where max equals min", () => {
-    expect(roundRange({min: 0.314, max: 0.314})).toStrictEqual({min: 0.31, max: 0.31});
-    expect(roundRange({min: 10, max: 10})).toStrictEqual({min: 10, max: 10});
-});
 
 
-it("can iterate data values and filter rows", () => {
+    it("getColor can get expected colour when value is less than min", () => {
+        const result = getColor(0.5, {
+            min: 1,
+            max: 2,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        }, {min: 1, max: 2});
 
-    const indicators = [
-        {
-            indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
-            name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
-            name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-        }
-    ];
+        expect(result).toEqual("rgb(255, 255, 255)");
+    });
 
-    const data = [
-        {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
-        {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
-        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
-    ];
+    it("getColor can get expected colour when value is greater than max", () => {
+        const result = getColor(5, {
+            min: 1,
+            max: 2,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        }, {min: 1, max: 2});
 
-    const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
+        expect(result).toEqual("rgb(0, 0, 0)");
+    });
 
-    const result: number[] = [];
-    iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {"year": [{id: "2010", label: "2010"}]},
-        (areaId, meta, value) => result.push(value));
+    it("getColor can use negative min and zero max", () => {
+        const metadata = {
+            min: 0,
+            max: 2,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        };
+        let result = getColor(-0.45, metadata, {min: -0.45, max: 0});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(0, metadata, {min: -0.45, max: 0});
+        expect(result).toEqual("rgb(0, 0, 0)");
+        result = getColor(-0.225, metadata, {min: -0.45, max: 0});
+        expect(result).toEqual("rgb(151, 151, 151)");
 
-    expect(result).toStrictEqual([12, 0.5, 14]);
-});
+        //Test out of range
+        result = getColor(-0.9, metadata, {min: -0.45, max: 0});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(1, metadata, {min: -0.45, max: 0});
+        expect(result).toEqual("rgb(0, 0, 0)");
+    });
 
-it("handles iterating data values where there are no selected filter options", () => {
+    it("getColor can use negative min and positive max", () => {
+        const metadata = {
+            min: 0,
+            max: 2,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        };
+        let result = getColor(-10, metadata, {min: -10, max: 10});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(10, metadata, {min: -10, max: 10});
+        expect(result).toEqual("rgb(0, 0, 0)");
+        result = getColor(0, metadata, {min: -10, max: 10});
+        expect(result).toEqual("rgb(151, 151, 151)");
 
-    const indicators = [
-        {
-            indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
-            name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-        },
-        {
-            indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
-            name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
-        }
-    ];
+        //Test out of range
+        result = getColor(-10.5, metadata, {min: -10, max: 10});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(11, metadata, {min: -10, max: 10});
+        expect(result).toEqual("rgb(0, 0, 0)");
+    });
 
-    const data = [
-        {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
-        {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
-        {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
-        {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
-    ];
+    it("getColor can use negative min and negative max", () => {
+        const metadata = {
+            min: 0,
+            max: 2,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            indicator: "test",
+            value_column: "",
+            name: ""
+        };
+        let result = getColor(-10, metadata, {min: -10, max: -5});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(-5, metadata, {min: -10, max: -5});
+        expect(result).toEqual("rgb(0, 0, 0)");
+        result = getColor(-7.5, metadata, {min: -10, max: -5});
+        expect(result).toEqual("rgb(151, 151, 151)");
 
-    const fakeFilter: Filter = {id: "year", column_id: "year", label: "year", options: [{id: "2010", label: "2010"}]};
+        //Test out of range
+        result = getColor(-11, metadata, {min: -10, max: -5});
+        expect(result).toEqual("rgb(255, 255, 255)");
+        result = getColor(0, metadata, {min: -10, max: -5});
+        expect(result).toEqual("rgb(0, 0, 0)");
+    });
 
-    const result: number[] = [];
-    iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {},
-        (areaId, meta, value) => result.push(value));
+    it("can get indicator name lookup", () => {
+        const indicators = [
+            {
+                indicator: "plhiv",
+                value_column: "plhiv",
+                name: "PLHIV",
+                min: 0,
+                max: 0,
+                colour: "interpolateGreys",
+                invert_scale: false
+            },
+            {
+                indicator: "prevalence",
+                value_column: "prevalence",
+                name: "Prevalence",
+                min: 0,
+                max: 0,
+                colour: "interpolateGreys",
+                invert_scale: false
+            }
+        ];
+        expect(toIndicatorNameLookup(indicators)).toStrictEqual({
+            plhiv: "PLHIV",
+            prevalence: "Prevalence"
+        });
+    });
 
-    expect(result).toStrictEqual([12, 0.5, 14, 0.6, 14]);
+    it("round to context rounds values to 1 more decimal place than the context where context is integer", () => {
+        expect(roundToContext(0.1234, [0, 1])).toBe(0.1);
+    });
+
+    it("round to context rounds values to 1 more decimal place than the context where context has fewer decimal places than value", () => {
+        expect(roundToContext(0.1234, [0, 0.1])).toBe(0.12);
+    });
+
+    it("round to context does not round value if it already has fewer decimal places than context", () => {
+        expect(roundToContext(0.1, [0, 0.12])).toBe(0.1);
+    });
+
+    it("round to context does not round value if both values and context are integers", () => {
+        expect(roundToContext(5, [0, 10])).toBe(5);
+    });
+
+    it("round to context can round when context includes negative", () => {
+        expect(roundToContext(-0.3614, [-0.45, 0])).toBe(-0.361);
+    });
+
+    it("colourScaleStepFromMetadata returns expected value", () => {
+        const meta = {
+            min: 0,
+            max: 1
+        };
+        expect(colourScaleStepFromMetadata(meta as any)).toBe(0.1);
+    });
+
+    it("roundRange rounds as expected", () => {
+        expect(roundRange({min: 0.31432, max: 0.84162})).toStrictEqual({min: 0.31, max: 0.84});
+
+        expect(roundRange({min: 0.031432, max: 0.084162})).toStrictEqual({min: 0.031, max: 0.084});
+
+        expect(roundRange({min: 3.11, max: 4.12})).toStrictEqual({min: 3.1, max: 4.1});
+
+        expect(roundRange({min: 101, max: 201})).toStrictEqual({min: 101, max: 201});
+
+        expect(roundRange({min: 1.1234, max: 1.1235})).toStrictEqual({min: 1.1234, max: 1.1235});
+        expect(roundRange({min: 1.1234566001, max: 1.123457001})).toStrictEqual({min: 1.1234566, max: 1.123457});
+    });
+
+    it("roundRange can round where max equals min", () => {
+        expect(roundRange({min: 0.314, max: 0.314})).toStrictEqual({min: 0.31, max: 0.31});
+        expect(roundRange({min: 10, max: 10})).toStrictEqual({min: 10, max: 10});
+    });
+
+
+    it("can iterate data values and filter rows", () => {
+
+        const indicators = [
+            {
+                indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
+                name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+            },
+            {
+                indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
+                name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+            }
+        ];
+
+        const data = [
+            {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
+            {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
+            {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
+            {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
+            {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
+        ];
+
+        const fakeFilter: Filter = {
+            id: "year",
+            column_id: "year",
+            label: "year",
+            options: [{id: "2010", label: "2010"}]
+        };
+
+        const result: number[] = [];
+        iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {
+                "year": [{
+                    id: "2010",
+                    label: "2010"
+                }]
+            },
+            (areaId, meta, value) => result.push(value));
+
+        expect(result).toStrictEqual([12, 0.5, 14]);
+    });
+
+    it("handles iterating data values where there are no selected filter options", () => {
+
+        const indicators = [
+            {
+                indicator: "plhiv", value_column: "value", indicator_column: "indicator", indicator_value: "plhiv",
+                name: "PLHIV", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+            },
+            {
+                indicator: "prevalence", value_column: "value", indicator_column: "indicator", indicator_value: "prev",
+                name: "Prevalence", min: 0, max: 0, colour: "interpolateGreys", invert_scale: false
+            }
+        ];
+
+        const data = [
+            {area_id: "MWI_1_1", indicator: "plhiv", value: 12, year: 2010},
+            {area_id: "MWI_1_1", indicator: "prev", value: 0.5, year: 2010},
+            {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2010},
+            {area_id: "MWI_1_2", indicator: "prev", value: 0.6, year: 2011},
+            {area_id: "MWI_1_2", indicator: "plhiv", value: 14, year: 2011}
+        ];
+
+        const fakeFilter: Filter = {
+            id: "year",
+            column_id: "year",
+            label: "year",
+            options: [{id: "2010", label: "2010"}]
+        };
+
+        const result: number[] = [];
+        iterateDataValues(data, indicators, ["MWI_1_1", "MWI_1_2"], [fakeFilter], {},
+            (areaId, meta, value) => result.push(value));
+
+        expect(result).toStrictEqual([12, 0.5, 14, 0.6, 14]);
+    });
 });

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -163,8 +163,6 @@ describe("Stepper component", () => {
         const steps = wrapper.findAll(Step);
 
         expect(wrapper.findAll(Step).length).toBe(6);
-        console.log("HERE IT IS");
-        console.log(wrapper.html());
         expect(steps.at(0).props().textKey).toBe("uploadBaseline");
         expect(steps.at(0).props().active).toBe(true);
         expect(steps.at(0).props().number).toBe(1);

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -5,7 +5,8 @@ import Vuex from 'vuex';
 import SurveyAndProgram from "../../../app/components/surveyAndProgram/SurveyAndProgram.vue";
 import {
     mockAncResponse,
-    mockBaselineState, mockPlottingSelections,
+    mockBaselineState,
+    mockPlottingSelections,
     mockProgramResponse,
     mockSurveyAndProgramState,
     mockSurveyResponse
@@ -17,11 +18,19 @@ import {actions} from "../../../app/store/surveyAndProgram/actions";
 import {mutations} from "../../../app/store/surveyAndProgram/mutations";
 import {getters} from "../../../app/store/surveyAndProgram/getters";
 import {mutations as selectionsMutations} from "../../../app/store/plottingSelections/mutations";
-import {ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {ColourScaleSelections, ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
 
 const localVue = createLocalVue();
 
 describe("Survey and programme component", () => {
+
+    beforeAll(() => {
+        Vue.config.silent = true;
+    });
+
+    afterAll(() => {
+        Vue.config.silent = false;
+    })
 
     testUploadComponent("surveys", 0);
     testUploadComponent("program", 1);
@@ -46,19 +55,32 @@ describe("Survey and programme component", () => {
                             filters: {
                                 level_labels: "TEST LEVEL LABELS",
                                 regions: {id: "country", children: [{id: "region 1"}, {id: "region 2"}]}
-                            } as any} as any
+                            } as any
+                        } as any
                     })
                 },
                 plottingSelections: {
                     namespaced: true,
                     state: mockPlottingSelections({
-                        sapChoropleth: {selectedFilterOptions: "TEST SELECTIONS"} as any}),
+                        sapChoropleth: {selectedFilterOptions: "TEST SELECTIONS"} as any
+                    }),
+                    getters: {
+                        selectedSAPColourScales: () => {
+                            return {prevalence: {
+                                    type: ColourScaleType.Custom,
+                                    customMin: 1,
+                                    customMax: 2
+                                }} as ColourScaleSelections
+                        }
+                    },
                     mutations: selectionsMutations
                 },
                 metadata: {
                     namespaced: true,
                     getters: {
-                        sapIndicatorsMetadata: () => {return ["TEST INDICATORS"]}
+                        sapIndicatorsMetadata: () => {
+                            return ["TEST INDICATORS"]
+                        }
                     }
                 }
             }
@@ -91,7 +113,8 @@ describe("Survey and programme component", () => {
                 "filters": {
                     "year": "TEST YEAR FILTERS"
                 }
-            } as any,});
+            } as any,
+        });
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
         const choro = wrapper.find("choropleth-stub");
         expect(choro.props().includeFilters).toBe(false);
@@ -115,6 +138,11 @@ describe("Survey and programme component", () => {
         expect(choro.props().featureLevels).toBe("TEST LEVEL LABELS");
         expect(choro.props().indicators).toStrictEqual(["TEST INDICATORS"]);
         expect(choro.props().selections).toStrictEqual({selectedFilterOptions: "TEST SELECTIONS"});
+        expect(choro.props().colourScales).toEqual({prevalence: {
+            type: ColourScaleType.Custom,
+                customMin: 1,
+                customMax: 2
+        }});
 
     });
 
@@ -126,7 +154,8 @@ describe("Survey and programme component", () => {
                 "filters": {
                     "year": "TEST YEAR FILTERS"
                 }
-            } as any,});
+            } as any,
+        });
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
         const filters = wrapper.find("filters-stub");
         expect(filters.props().filters[0]).toStrictEqual({
@@ -226,7 +255,8 @@ describe("Survey and programme component", () => {
                 "filters": {
                     "year": "TEST YEAR FILTERS"
                 }
-            } as any,});
+            } as any,
+        });
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
         const table = wrapper.find("table-view-stub");
         expect(table.props().areaFilterId).toBe("area");

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -9,13 +9,15 @@ const rootState = mockRootState();
 describe("Load actions", () => {
 
     beforeEach(() => {
+        mockAxios.reset();
         // stop apiService logging to console
         console.log = jest.fn();
-        mockAxios.reset();
+        console.info = jest.fn();
     });
 
     afterEach(() => {
         (console.log as jest.Mock).mockClear();
+        (console.info as jest.Mock).mockClear();
     });
 
     it("load reads blob and dispatches setFiles action", (done) => {

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -18,11 +18,13 @@ describe("Model run actions", () => {
     beforeEach(() => {
         // stop apiService logging to console
         console.log = jest.fn();
+        console.info = jest.fn();
         mockAxios.reset();
     });
 
     afterEach(() => {
         (console.log as jest.Mock).mockClear();
+        (console.info as jest.Mock).mockClear();
     });
 
     it("passes model options and version from state", async () => {

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -1,7 +1,27 @@
 import {router} from '../app/router';
+import {storeOptions} from "../app/root";
+
+const baselineActions = {
+    getBaselineData: jest.fn()
+};
+
+const surveyAndProgramActions = {
+    getSurveyAndProgramData: jest.fn()
+};
+
+const modelRunActions = {
+    getResult: jest.fn()
+};
+
+storeOptions.modules!!.baseline!!.actions = baselineActions;
+storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
+storeOptions.modules!!.modelRun!!.actions = modelRunActions;
+
+// only import the app after we have replaced action with mocks
+// as the app will call these actions on import
+import {app} from "../app";
 import Stepper from "../app/components/Stepper.vue";
 import Versions from "../app/components/versions/Versions.vue";
-import {app} from "../app/index";
 
 describe("Router", () => {
     it("has expected properties", () => {

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -17,6 +17,8 @@ storeOptions.modules!!.baseline!!.actions = baselineActions;
 storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
 storeOptions.modules!!.modelRun!!.actions = modelRunActions;
 
+console.error = jest.fn();
+
 // only import the app after we have replaced action with mocks
 // as the app will call these actions on import
 import {app} from "../app";
@@ -24,6 +26,11 @@ import Stepper from "../app/components/Stepper.vue";
 import Versions from "../app/components/versions/Versions.vue";
 
 describe("Router", () => {
+
+    afterAll(() => {
+        (console.error as jest.Mock).mockClear();
+    });
+
     it("has expected properties", () => {
         expect(app.$router).toBe(router);
         expect(router.mode).toBe("history");

--- a/src/app/static/src/tests/setup.ts
+++ b/src/app/static/src/tests/setup.ts
@@ -30,3 +30,4 @@ i18next.init({
 });
 
 Vue.use(Vuex);
+Vue.config.productionTip = false;

--- a/src/app/static/src/tests/setup.ts
+++ b/src/app/static/src/tests/setup.ts
@@ -31,3 +31,7 @@ i18next.init({
 
 Vue.use(Vuex);
 Vue.config.productionTip = false;
+
+global.console.error = (message: any) => {
+    throw (message instanceof Error ? message : new Error(message))
+}

--- a/src/app/static/src/tests/versions/actions.test.ts
+++ b/src/app/static/src/tests/versions/actions.test.ts
@@ -7,7 +7,15 @@ import {serialiseState} from "../../app/localStorageManager";
 
 describe("Versions actions", () => {
     beforeEach(() => {
-        mockAxios.reset();
+        mockAxios.reset();  
+        // stop apiService logging to console
+        console.log = jest.fn();
+        console.info = jest.fn();
+    });
+
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
+        (console.info as jest.Mock).mockClear();
     });
 
     const rootState = mockRootState();

--- a/src/app/static/src/tests/versions/mutations.test.ts
+++ b/src/app/static/src/tests/versions/mutations.test.ts
@@ -2,6 +2,17 @@ import {mockVersionsState} from "../mocks";
 import {mutations, VersionsMutations} from "../../app/store/versions/mutations";
 
 describe("Versions mutations", () => {
+
+    const consoleSpy = jest.fn();
+
+    beforeEach(() => {
+        console.error = consoleSpy;
+    });
+
+    afterEach(() => {
+        (console.error as jest.Mock).mockClear();
+    })
+
     it("sets loading", () => {
         const state = mockVersionsState();
 
@@ -29,8 +40,6 @@ describe("Versions mutations", () => {
     });
 
     it("SnapshotUploadError logs error to console", () => {
-        const consoleSpy = jest.spyOn(console, 'error');
-
         const state = mockVersionsState();
         mutations[VersionsMutations.SnapshotUploadError](state, {payload: "test error"});
 


### PR DESCRIPTION
An excessive number of warnings in the jest tests have been making it very difficult to read the test output and work out what's going on when a build fails (see e.g. https://travis-ci.com/github/mrc-ide/hint/jobs/368343813#L1021) This PR fixes all the warnings by either fixing the cause, or in the case where Vue is warning about incorrect props that are being deliberately used for test purposes (`surveyAndProgram.test.ts`), temporarily silences warnings.