### PR TITLE
mrc-1726 select ADR dataset front-end

### DIFF
--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -37,7 +37,7 @@
         </div>
         <div v-if="!loading" class="content">
             <div class="pt-4">
-                <adr-key v-if="isActive(1)"></adr-key>
+                <adr-integration v-if="isActive(1)"></adr-integration>
                 <baseline v-if="isActive(1)"></baseline>
                 <survey-and-program v-if="isActive(2)"></survey-and-program>
                 <model-options v-if="isActive(3)"></model-options>
@@ -53,7 +53,7 @@
 
     import Vue from "vue";
     import {mapActions} from "vuex";
-    import AdrKey from "./adr/ADRKey.vue";
+    import AdrIntegration from "./adr/ADRIntegration.vue";
     import Step from "./Step.vue";
     import Baseline from "./baseline/Baseline.vue";
     import SurveyAndProgram from "./surveyAndProgram/SurveyAndProgram.vue";
@@ -128,7 +128,7 @@
             }
         },
         components: {
-            AdrKey,
+            AdrIntegration,
             Step,
             Baseline,
             SurveyAndProgram,

--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -37,7 +37,7 @@
         </div>
         <div v-if="!loading" class="content">
             <div class="pt-4">
-                <adr-key v-if="isActive(1) || isActive(2)"></adr-key>
+                <adr-key v-if="isActive(1)"></adr-key>
                 <baseline v-if="isActive(1)"></baseline>
                 <survey-and-program v-if="isActive(2)"></survey-and-program>
                 <model-options v-if="isActive(3)"></model-options>

--- a/src/app/static/src/app/components/adr/ADRIntegration.vue
+++ b/src/app/static/src/app/components/adr/ADRIntegration.vue
@@ -23,11 +23,17 @@
                 (state: RootState) => state.adrKey)
         },
         methods: {
-           fetchADRKey: mapActionByName(null, "fetchADRKey")
+            getDatasets: mapActionByName(null, 'getADRDatasets'),
+            fetchADRKey: mapActionByName(null, "fetchADRKey")
         },
         created() {
             if (this.loggedIn) {
                 this.fetchADRKey();
+            }
+        },
+        watch: {
+            key() {
+                this.getDatasets();
             }
         }
     })

--- a/src/app/static/src/app/components/adr/ADRIntegration.vue
+++ b/src/app/static/src/app/components/adr/ADRIntegration.vue
@@ -1,0 +1,34 @@
+<template>
+    <div v-if="loggedIn" class="mb-5">
+        <adr-key></adr-key>
+        <select-dataset v-if="key"></select-dataset>
+    </div>
+</template>
+<script lang="ts">
+    import Vue from "vue";
+    import {mapActionByName, mapStateProp} from "../../utils";
+    import {RootState} from "../../root";
+    import adrKey from "./ADRKey.vue";
+    import SelectDataset from "./SelectDataset.vue";
+
+    declare const currentUser: string;
+
+    export default Vue.extend({
+        components: {adrKey, SelectDataset},
+        computed: {
+            loggedIn() {
+                return currentUser != "guest"
+            },
+            key: mapStateProp<RootState, string | null>(null,
+                (state: RootState) => state.adrKey)
+        },
+        methods: {
+           fetchADRKey: mapActionByName(null, "fetchADRKey")
+        },
+        created() {
+            if (this.loggedIn) {
+                this.fetchADRKey();
+            }
+        }
+    })
+</script>

--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -1,5 +1,4 @@
 <template>
-    <div v-if="loggedIn" class="mb-5">
         <div class="row">
             <div class="col-8">
                 <div class="d-flex">
@@ -51,8 +50,6 @@
                 <error-alert v-if="error" :error="error"></error-alert>
             </div>
         </div>
-        <select-dataset v-if="key"></select-dataset>
-    </div>
 </template>
 <script lang="ts">
     import Vue from "vue";
@@ -62,7 +59,6 @@
     import {Language} from "../../store/translations/locales";
     import i18next from "i18next";
     import ErrorAlert from "../ErrorAlert.vue";
-    import SelectDataset from "./SelectDataset.vue";
 
     interface Data {
         editableKey: string | null
@@ -70,7 +66,6 @@
     }
 
     interface Methods {
-        fetchADRKey: () => void
         saveADRKey: (key: string | null) => void
         deleteADRKey: () => void
         edit: (e: Event) => void
@@ -83,11 +78,8 @@
         key: string | null
         currentLanguage: Language
         keyText: string
-        loggedIn: boolean,
         error: Error | null
     }
-
-    declare const currentUser: string;
 
     export default Vue.extend<Data, Methods, Computed, {}>({
         data() {
@@ -97,9 +89,6 @@
             }
         },
         computed: {
-            loggedIn() {
-                return currentUser != "guest"
-            },
             key: mapStateProp<RootState, string | null>(null,
                 (state: RootState) => state.adrKey),
             currentLanguage: mapStateProp<RootState, Language>(null,
@@ -121,7 +110,7 @@
             }
         },
         methods: {
-            ...mapActionsByNames<keyof Methods>(null, ["fetchADRKey", "saveADRKey", "deleteADRKey"]),
+            ...mapActionsByNames<keyof Methods>(null, ["saveADRKey", "deleteADRKey"]),
             edit(e: Event) {
                 e.preventDefault();
                 this.editing = true;
@@ -144,12 +133,7 @@
                 this.editing = false;
             }
         },
-        created() {
-            if (this.loggedIn) {
-                this.fetchADRKey();
-            }
-        },
-        components: {ErrorAlert, SelectDataset}
+        components: {ErrorAlert}
     });
 
 </script>

--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="loggedIn" class="mb-3">
+    <div v-if="loggedIn" class="mb-5">
         <div class="row">
             <div class="col-8">
                 <div class="d-flex">

--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -1,54 +1,57 @@
 <template>
-    <div class="row mb-3" v-if="loggedIn">
-        <div class="col-8">
-            <div class="d-flex">
-                <label for="key"
-                       class="font-weight-bold align-self-stretch"
-                       v-translate="'adrKey'">
-                </label>
-                <div class="align-self-stretch pl-2">
-                    <div v-if="!editing">
-                        <span class="pr-2">{{keyText}}</span>
-                        <a href="#" v-if="!key"
-                           @click="edit"
-                           v-translate="'add'"></a>
-                        <a href="#" v-if="key"
-                           @click="edit"
-                           v-translate="'edit'"> </a>
-                        <span v-if="key">/</span>
-                        <a href="#"
-                           v-if="key"
-                           @click="remove"
-                           v-translate="'remove'"></a>
-                    </div>
-                    <div class="input-group"
-                         style="margin-top: -11px; min-width: 390px"
-                         v-if="editing">
-                        <input id="key"
-                               ref="keyInput"
-                               class="form-control"
-                               v-model="editableKey"
-                               type="text"
-                               placeholder="Enter key"/>
-                        <div class="input-group-append">
-                            <button class="btn btn-red"
-                                    type="button"
-                                    v-translate="'save'"
-                                    :disabled="!editableKey"
-                                    @click="save">
-                            </button>
+    <div v-if="loggedIn" class="mb-3">
+        <div class="row">
+            <div class="col-8">
+                <div class="d-flex">
+                    <label for="key"
+                           class="font-weight-bold align-self-stretch"
+                           v-translate="'adrKey'">
+                    </label>
+                    <div class="align-self-stretch pl-2">
+                        <div v-if="!editing">
+                            <span class="pr-2">{{keyText}}</span>
+                            <a href="#" v-if="!key"
+                               @click="edit"
+                               v-translate="'add'"></a>
+                            <a href="#" v-if="key"
+                               @click="edit"
+                               v-translate="'edit'"> </a>
+                            <span v-if="key">/</span>
+                            <a href="#"
+                               v-if="key"
+                               @click="remove"
+                               v-translate="'remove'"></a>
+                        </div>
+                        <div class="input-group"
+                             style="margin-top: -11px; min-width: 390px"
+                             v-if="editing">
+                            <input id="key"
+                                   ref="keyInput"
+                                   class="form-control"
+                                   v-model="editableKey"
+                                   type="text"
+                                   placeholder="Enter key"/>
+                            <div class="input-group-append">
+                                <button class="btn btn-red"
+                                        type="button"
+                                        v-translate="'save'"
+                                        :disabled="!editableKey"
+                                        @click="save">
+                                </button>
+                            </div>
                         </div>
                     </div>
+                    <div class="align-self-stretch pl-2">
+                        <a href="#"
+                           v-if="editing"
+                           @click="cancel"
+                           v-translate="'cancel'"></a>
+                    </div>
                 </div>
-                <div class="align-self-stretch pl-2">
-                    <a href="#"
-                       v-if="editing"
-                       @click="cancel"
-                       v-translate="'cancel'"></a>
-                </div>
+                <error-alert v-if="error" :error="error"></error-alert>
             </div>
-            <error-alert v-if="error" :error="error"></error-alert>
         </div>
+        <select-dataset v-if="key"></select-dataset>
     </div>
 </template>
 <script lang="ts">
@@ -59,6 +62,7 @@
     import {Language} from "../../store/translations/locales";
     import i18next from "i18next";
     import ErrorAlert from "../ErrorAlert.vue";
+    import SelectDataset from "./SelectDataset.vue";
 
     interface Data {
         editableKey: string | null
@@ -145,7 +149,7 @@
                 this.fetchADRKey();
             }
         },
-        components: {ErrorAlert}
+        components: {ErrorAlert, SelectDataset}
     });
 
 </script>

--- a/src/app/static/src/app/components/adr/SelectDataset.vue
+++ b/src/app/static/src/app/components/adr/SelectDataset.vue
@@ -1,0 +1,88 @@
+<template>
+    <div>
+        <button class="btn btn-red" @click="toggleModal">Select ADR dataset</button>
+        <modal id="dataset" :open="open">
+            <h4>Browse ADR</h4>
+            <tree-select :multiple="false" :searchable="true" :options="datasetOptions">
+                <label slot="option-label"
+                       slot-scope="{ node }"
+                       v-html="node.raw.customLabel">
+                </label>
+            </tree-select>
+            <template v-slot:footer>
+                <button type="button"
+                        class="btn btn-white"
+                        @click="importDataset">
+                    Import
+                </button>
+                <button type="button"
+                        class="btn btn-white"
+                        @click="toggleModal">
+                    Cancel
+                </button>
+            </template>
+        </modal>
+    </div>
+</template>
+<script lang="ts">
+    import Vue from "vue"
+    import TreeSelect from '@riophae/vue-treeselect'
+    import {mapActionByName, mapStateProp} from "../../utils";
+    import {RootState} from "../../root";
+    import Modal from "../Modal.vue";
+
+    interface Methods {
+        getDatasets: () => void
+        importDataset: () => void
+        toggleModal: () => void
+    }
+
+    interface Computed {
+        datasets: any[]
+        datasetOptions: any[]
+    }
+
+    export default Vue.extend<{ open: boolean }, Methods, Computed, {}>({
+        data() {
+            return {
+                open: false
+            }
+        },
+        components: {Modal, TreeSelect},
+        computed: {
+            datasets: mapStateProp<RootState, any[]>(null,
+                (state: RootState) => state.adrDatasets),
+            datasetOptions() {
+                return this.datasets.map(d => ({
+                    id: d.id,
+                    label: d.title,
+                    customLabel: `${d.title}
+                        <div class="text-muted small" style="margin-top:-5px; line-height: 0.8rem">
+                            (${d.name})<br/>
+                            <span class="font-weight-bold">${d.organization.title}</span>
+                        </div>`
+                }))
+            }
+        },
+        methods: {
+            getDatasets: mapActionByName(null, 'getADRDatasets'),
+            importDataset() {
+                // set loading spinner
+                // set selected dataset in store
+                // import each file
+                // await all
+                // stop loading spinner & close modal
+            },
+            toggleModal() {
+                this.open = !this.open;
+            }
+        },
+        watch: {
+            open(newVal: boolean) {
+                if (newVal) {
+                    this.getDatasets()
+                }
+            }
+        }
+    })
+</script>

--- a/src/app/static/src/app/components/adr/SelectDataset.vue
+++ b/src/app/static/src/app/components/adr/SelectDataset.vue
@@ -27,12 +27,11 @@
 <script lang="ts">
     import Vue from "vue"
     import TreeSelect from '@riophae/vue-treeselect'
-    import {mapActionByName, mapStateProp} from "../../utils";
+    import {mapStateProp} from "../../utils";
     import {RootState} from "../../root";
     import Modal from "../Modal.vue";
 
     interface Methods {
-        getDatasets: () => void
         importDataset: () => void
         toggleModal: () => void
     }
@@ -65,7 +64,6 @@
             }
         },
         methods: {
-            getDatasets: mapActionByName(null, 'getADRDatasets'),
             importDataset() {
                 // set loading spinner
                 // set selected dataset in store
@@ -75,13 +73,6 @@
             },
             toggleModal() {
                 this.open = !this.open;
-            }
-        },
-        watch: {
-            open(newVal: boolean) {
-                if (newVal) {
-                    this.getDatasets()
-                }
             }
         }
     })

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -34,6 +34,7 @@ export interface TranslatableState {
 
 export interface RootState extends TranslatableState {
     version: string,
+    adrDatasets: any[],
     adrKey: string | null,
     adrKeyError: Error | null,
     baseline: BaselineState,
@@ -99,6 +100,7 @@ export const emptyState = (): RootState => {
     return {
         adrKey: null,
         adrKeyError: null,
+        adrDatasets: [],
         language: Language.en,
         version: '0.0.0',
         baseline: initialBaselineState(),

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -13,6 +13,7 @@ export interface RootActions extends LanguageActions<RootState> {
     fetchADRKey: (store: ActionContext<RootState, RootState>) => void;
     saveADRKey: (store: ActionContext<RootState, RootState>, key: string) => void;
     deleteADRKey: (store: ActionContext<RootState, RootState>) => void;
+    getADRDatasets: (store: ActionContext<RootState, RootState>) => void;
 }
 
 export const actions: ActionTree<RootState, RootState> & RootActions = {
@@ -80,5 +81,13 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
             .withError(RootMutation.SetADRKeyError)
             .withSuccess(RootMutation.UpdateADRKey)
             .delete("/adr/key/")
+    },
+
+    async getADRDatasets(context) {
+        await api<RootMutation, RootMutation>(context)
+            .ignoreErrors()
+            .withSuccess(RootMutation.SetADRDatasets)
+            .get("/adr/datasets/")
     }
+
 };

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -5,11 +5,11 @@ import {initialModelOptionsState} from "../modelOptions/modelOptions";
 import {initialModelRunState} from "../modelRun/modelRun";
 import {initialModelOutputState} from "../modelOutput/modelOutput";
 import {initialPlottingSelectionsState} from "../plottingSelections/plottingSelections";
-import {initialLoadState, LoadState} from "../load/load";
+import {initialLoadState} from "../load/load";
 import {initialMetadataState} from "../metadata/metadata";
 import {initialErrorsState} from "../errors/errors";
 import {initialBaselineState} from "../baseline/baseline";
-import {initialSurveyAndProgramState, DataType} from "../surveyAndProgram/surveyAndProgram";
+import {DataType, initialSurveyAndProgramState} from "../surveyAndProgram/surveyAndProgram";
 import {PayloadWithType, Version} from "../../types";
 import {mutations as languageMutations} from "../language/mutations";
 import {initialVersionsState} from "../versions/versions";
@@ -22,7 +22,8 @@ export enum RootMutation {
     ResetOutputs = "ResetOutputs",
     SetADRKeyError = "ADRKeyError",
     SetVersion = "SetVersion",
-    UpdateADRKey = "UpdateADRKey"
+    UpdateADRKey = "UpdateADRKey",
+    SetADRDatasets = "SetADRDatasets"
 }
 
 export const mutations: MutationTree<RootState> = {
@@ -34,6 +35,10 @@ export const mutations: MutationTree<RootState> = {
         state.adrKeyError = action.payload;
     },
 
+    [RootMutation.SetADRDatasets](state: RootState, action: PayloadWithType<any[]>) {
+        state.adrDatasets = action.payload;
+    },
+
     [RootMutation.Reset](state: RootState, action: PayloadWithType<number>) {
 
         const maxValidStep = action.payload;
@@ -41,6 +46,7 @@ export const mutations: MutationTree<RootState> = {
         //We treat the final group of steps 4-6 together - all rely on modelRun and its result. If we're calling Reset
         //at all we assume that these steps will be invalidated but earlier steps may be retainable
         const resetState: RootState = {
+            adrDatasets: state.adrDatasets,
             version: state.version,
             language: state.language,
             adrKey: state.adrKey,
@@ -59,7 +65,7 @@ export const mutations: MutationTree<RootState> = {
         };
         Object.assign(state, resetState);
 
-        const maxAccessibleStep = maxValidStep < 4 ? Math.max(maxValidStep,1) : 4;
+        const maxAccessibleStep = maxValidStep < 4 ? Math.max(maxValidStep, 1) : 4;
         if (state.stepper.activeStep > maxAccessibleStep) {
             state.stepper.activeStep = maxAccessibleStep;
         }

--- a/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
@@ -1,0 +1,66 @@
+import {Error} from "../../../app/generated";
+import Vuex, {ActionTree} from "vuex";
+import {mockRootState} from "../../mocks";
+import {RootActions} from "../../../app/store/root/actions";
+import {RootState} from "../../../app/root";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+import {shallowMount} from "@vue/test-utils";
+import ADRKey from "../../../app/components/adr/ADRKey.vue";
+import ADRIntegration from "../../../app/components/adr/ADRIntegration.vue";
+import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
+
+declare let currentUser: string;
+
+describe("adr integration", () => {
+
+    const fetchStub = jest.fn();
+
+    const createStore = (key: string = "", error: Error | null = null) => {
+        const store = new Vuex.Store({
+            state: mockRootState({adrKey: key, adrKeyError: error}),
+            actions: {
+                fetchADRKey: fetchStub
+            } as Partial<RootActions> & ActionTree<RootState, RootState>
+        });
+        registerTranslations(store);
+        return store;
+    }
+
+    beforeEach(() => {
+        currentUser = "some.user@example.com"
+        jest.resetAllMocks();
+    });
+
+    it("does not render if not logged in", () => {
+        currentUser = "guest";
+        const rendered = shallowMount(ADRIntegration, {store: createStore()});
+        expect(rendered.findAll("div").length).toBe(0);
+    });
+
+    it("fetches ADR key if logged in", () => {
+        shallowMount(ADRIntegration, {store: createStore()});
+        expect(fetchStub.mock.calls.length).toBe(1);
+    });
+
+    it("does not fetch ADR key if not logged in", () => {
+        currentUser = "guest";
+        shallowMount(ADRIntegration, {store: createStore()});
+        expect(fetchStub.mock.calls.length).toBe(0);
+    });
+
+    it("renders adr-key widget", () => {
+        const rendered = shallowMount(ADRIntegration, {store: createStore()});
+        expect(rendered.findAll(ADRKey).length).toBe(1);
+    });
+
+    it("does not render select dataset widget if key is not present", () => {
+        const rendered = shallowMount(ADRIntegration, {store: createStore()});
+        expect(rendered.findAll(SelectDataset).length).toBe(0);
+    });
+
+    it("renders select dataset widget if key is present", () => {
+        const rendered = shallowMount(ADRIntegration, {store: createStore("123")});
+        expect(rendered.findAll(SelectDataset).length).toBe(1);
+    });
+
+})

--- a/src/app/static/src/tests/components/adr/ADRKey.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRKey.test.ts
@@ -10,13 +10,9 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {RootActions} from "../../../app/store/root/actions";
 import {RootState} from "../../../app/root";
 import ErrorAlert from "../../../app/components/ErrorAlert.vue";
-import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
-
-declare let currentUser: string;
 
 describe("ADR Key", function () {
 
-    const fetchStub = jest.fn();
     const saveStub = jest.fn();
     const deleteStub = jest.fn();
 
@@ -25,7 +21,6 @@ describe("ADR Key", function () {
             state: mockRootState({adrKey: key, adrKeyError: error}),
             mutations: mutations,
             actions: {
-                fetchADRKey: fetchStub,
                 saveADRKey: saveStub,
                 deleteADRKey: deleteStub
             } as Partial<RootActions> & ActionTree<RootState, RootState>
@@ -35,35 +30,7 @@ describe("ADR Key", function () {
     }
 
     beforeEach(() => {
-        currentUser = "some.user@example.com"
         jest.resetAllMocks();
-    })
-
-    it("does not render if not logged in", () => {
-        currentUser = "guest";
-        const rendered = shallowMount(ADRKey, {store: createStore()});
-        expect(rendered.findAll("div").length).toBe(0);
-    });
-
-    it("does not render select dataset widget if key is not present", () => {
-        const rendered = shallowMount(ADRKey, {store: createStore()});
-        expect(rendered.findAll(SelectDataset).length).toBe(0);
-    });
-
-    it("renders select dataset widget if key is present", () => {
-        const rendered = shallowMount(ADRKey, {store: createStore("123")});
-        expect(rendered.findAll(SelectDataset).length).toBe(1);
-    });
-
-    it("fetches ADR key if logged in", () => {
-        shallowMount(ADRKey, {store: createStore()});
-        expect(fetchStub.mock.calls.length).toBe(1);
-    });
-
-    it("does not fetch ADR key if not logged in", () => {
-        currentUser = "guest";
-        shallowMount(ADRKey, {store: createStore()});
-        expect(fetchStub.mock.calls.length).toBe(0);
     });
 
     it("shows title", () => {

--- a/src/app/static/src/tests/components/adr/ADRKey.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRKey.test.ts
@@ -10,6 +10,7 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {RootActions} from "../../../app/store/root/actions";
 import {RootState} from "../../../app/root";
 import ErrorAlert from "../../../app/components/ErrorAlert.vue";
+import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
 
 declare let currentUser: string;
 
@@ -42,6 +43,16 @@ describe("ADR Key", function () {
         currentUser = "guest";
         const rendered = shallowMount(ADRKey, {store: createStore()});
         expect(rendered.findAll("div").length).toBe(0);
+    });
+
+    it("does not render select dataset widget if key is not present", () => {
+        const rendered = shallowMount(ADRKey, {store: createStore()});
+        expect(rendered.findAll(SelectDataset).length).toBe(0);
+    });
+
+    it("renders select dataset widget if key is present", () => {
+        const rendered = shallowMount(ADRKey, {store: createStore("123")});
+        expect(rendered.findAll(SelectDataset).length).toBe(1);
     });
 
     it("fetches ADR key if logged in", () => {
@@ -89,7 +100,8 @@ describe("ADR Key", function () {
         const rendered = mount(ADRKey,
             {
                 store: createStore("123-abc"),
-                attachToDocument: true
+                attachToDocument: true,
+                stubs: ["tree-select"]
             });
         expect(rendered.findAll(".input-group").length).toBe(0);
         const links = rendered.findAll("a")

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -1,8 +1,6 @@
 import Vuex, {ActionTree} from "vuex";
 import {mount, shallowMount} from "@vue/test-utils";
-import {RootState} from "../../../app/root";
 import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
-import {RootActions} from "../../../app/store/root/actions";
 import Modal from "../../../app/components/Modal.vue";
 import TreeSelect from '@riophae/vue-treeselect'
 import {mockRootState} from "../../mocks";
@@ -18,10 +16,7 @@ describe("select dataset", () => {
     const store = new Vuex.Store({
         state: mockRootState({
             adrDatasets: fakeDatasets
-        }),
-        actions: {
-            getADRDatasets: jest.fn()
-        } as Partial<RootActions> & ActionTree<RootState, RootState>
+        })
     });
 
     it("renders button", () => {

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -1,0 +1,66 @@
+import Vuex, {ActionTree} from "vuex";
+import {mount, shallowMount} from "@vue/test-utils";
+import {RootState} from "../../../app/root";
+import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
+import {RootActions} from "../../../app/store/root/actions";
+import Modal from "../../../app/components/Modal.vue";
+import TreeSelect from '@riophae/vue-treeselect'
+import {mockRootState} from "../../mocks";
+
+describe("select dataset", () => {
+
+    const fakeDatasets = [{
+        id: "id1",
+        title: "Some data",
+        organization: {title: "org"},
+        name: "some-data"
+    }]
+    const store = new Vuex.Store({
+        state: mockRootState({
+            adrDatasets: fakeDatasets
+        }),
+        actions: {
+            getADRDatasets: jest.fn()
+        } as Partial<RootActions> & ActionTree<RootState, RootState>
+    });
+
+    it("renders button", () => {
+        const rendered = shallowMount(SelectDataset, {store});
+        expect(rendered.find("button").text()).toBe("Select ADR dataset");
+    });
+
+    it("can open modal", () => {
+        const rendered = shallowMount(SelectDataset, {store});
+        expect(rendered.find(Modal).props("open")).toBe(false);
+        rendered.find("button").trigger("click");
+        expect(rendered.find(Modal).props("open")).toBe(true);
+    });
+
+    it("can close modal", () => {
+        const rendered = mount(SelectDataset, {store, stubs: ["tree-select"]});
+        rendered.find("button").trigger("click");
+        expect(rendered.find(Modal).props("open")).toBe(true);
+        rendered.find(Modal).findAll("button").at(1).trigger("click");
+        expect(rendered.find(Modal).props("open")).toBe(false);
+    });
+
+    it("renders select", async () => {
+        const rendered = shallowMount(SelectDataset, {store});
+        rendered.find("button").trigger("click");
+        const select = rendered.find(TreeSelect);
+        expect(select.props("multiple")).toBe(false);
+        expect(select.props("searchable")).toBe(true);
+
+        const expectedOptions = [{
+            id: "id1",
+            label: "Some data",
+            customLabel: `Some data
+                    <div class="text-muted small" style="margin-top:-5px; line-height: 0.8rem">
+                        (some-data)<br/>
+                        <span class="font-weight-bold">org</span>
+                    </div>`
+        }]
+        expect(select.props("options")).toStrictEqual(expectedOptions);
+    });
+
+});

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -529,9 +529,9 @@ describe("Stepper component", () => {
         expect(wrapper.findAll(ADRKey).length).toBe(1);
     });
 
-    it("show ADR key if on step 2", () => {
+    it("does not show ADR key on step 2", () => {
         const wrapper = getStepperOnStep(2);
-        expect(wrapper.findAll(ADRKey).length).toBe(1);
+        expect(wrapper.findAll(ADRKey).length).toBe(0);
     });
 
     it("does not show ADR key on step 3", () => {

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -1,4 +1,4 @@
-import {createLocalVue, mount, shallowMount, Wrapper} from '@vue/test-utils';
+import {createLocalVue, shallowMount, Wrapper} from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, {Store} from 'vuex';
 import {baselineGetters, BaselineState} from "../../app/store/baseline/baseline";
@@ -24,7 +24,7 @@ import {mutations as modelRunMutations} from '../../app/store/modelRun/mutations
 import {mutations as stepperMutations} from '../../app/store/stepper/mutations';
 import {mutations as loadMutations} from '../../app/store/load/mutations';
 import {modelRunGetters, ModelRunState} from "../../app/store/modelRun/modelRun";
-import ADRKey from "../../app/components/adr/ADRKey.vue";
+import ADRIntegration from "../../app/components/adr/ADRIntegration.vue";
 import Stepper from "../../app/components/Stepper.vue";
 import Step from "../../app/components/Step.vue";
 import LoadingSpinner from "../../app/components/LoadingSpinner.vue";
@@ -524,37 +524,34 @@ describe("Stepper component", () => {
         expect(mockRouterPush.mock.calls.length).toBe(0);
     });
 
-    it("show ADR key if on step 1", () => {
+    it("show ADR integration if on step 1", () => {
         const wrapper = getStepperOnStep(1);
-        expect(wrapper.findAll(ADRKey).length).toBe(1);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(1);
     });
 
-    it("does not show ADR key on step 2", () => {
+    it("does not show ADR integration on step 2", () => {
         const wrapper = getStepperOnStep(2);
-        expect(wrapper.findAll(ADRKey).length).toBe(0);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(0);
     });
 
-    it("does not show ADR key on step 3", () => {
+    it("does not show ADR integration on step 3", () => {
         const wrapper = getStepperOnStep(3);
-        expect(wrapper.findAll(ADRKey).length).toBe(0);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(0);
     });
 
-
-    it("does not show ADR key on step 4", () => {
+    it("does not show ADR keintegrationy on step 4", () => {
         const wrapper = getStepperOnStep(4);
-        expect(wrapper.findAll(ADRKey).length).toBe(0);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(0);
     });
 
-
-    it("does not show ADR key on step 5", () => {
+    it("does not show ADR integration on step 5", () => {
         const wrapper = getStepperOnStep(5);
-        expect(wrapper.findAll(ADRKey).length).toBe(0);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(0);
     });
 
-
-    it("does not show ADR key on step 6", () => {
+    it("does not show ADR integration on step 6", () => {
         const wrapper = getStepperOnStep(6);
-        expect(wrapper.findAll(ADRKey).length).toBe(0);
+        expect(wrapper.findAll(ADRIntegration).length).toBe(0);
     });
 
     const getStepperOnStep = (step: number) => {

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -37,7 +37,7 @@ describe("Root actions", () => {
         await actions.saveADRKey({commit, rootState} as any, "1234");
         await actions.getADRDatasets({commit, rootState} as any);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.SetADRDatasets);
-        expect(commit.mock.calls[1][0]["payload"]).toEqual([]);
+        expect(commit.mock.calls[2][0]["type"]).toBe(RootMutation.SetADRDatasets);
+        expect(commit.mock.calls[2][0]["payload"]).toEqual([]);
     });
 });

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -34,6 +34,7 @@ describe("Root actions", () => {
 
     it("can fetch ADR datasets", async () => {
         const commit = jest.fn();
+        await actions.saveADRKey({commit, rootState} as any, "1234");
         await actions.getADRDatasets({commit, rootState} as any);
 
         expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.SetADRDatasets);

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -31,4 +31,12 @@ describe("Root actions", () => {
         expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.UpdateADRKey);
         expect(commit.mock.calls[1][0]["payload"]).toBe(null);
     });
+
+    it("can fetch ADR datasets", async () => {
+        const commit = jest.fn();
+        await actions.getADRDatasets({commit, rootState} as any);
+
+        expect(commit.mock.calls[1][0]["type"]).toBe(RootMutation.SetADRDatasets);
+        expect(commit.mock.calls[1][0]["payload"]).toEqual([]);
+    });
 });

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -246,5 +246,20 @@ describe("root actions", () => {
             });
     });
 
+    it("fetches ADR datasets", async () => {
+        mockAxios.onGet(`/adr/datasets/`)
+            .reply(200, mockSuccess([1]));
+
+        const commit = jest.fn();
+
+        await actions.getADRDatasets({commit, rootState} as any);
+
+        expect(commit.mock.calls[0][0])
+            .toStrictEqual({
+                type: RootMutation.SetADRDatasets,
+                payload: [1]
+            });
+    });
+
 
 });

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -247,4 +247,10 @@ describe("Root mutations", () => {
         mutations[RootMutation.SetADRKeyError](state, {payload: null});
         expect(state.adrKeyError).toBe(null);
     });
+
+    it("can set ADR datasets", () => {
+        const state = mockRootState();
+        mutations[RootMutation.SetADRDatasets](state, {payload: [1,2,3]});
+        expect(state.adrDatasets).toEqual([1,2,3]);
+    });
 });


### PR DESCRIPTION
This PR adds the component for selecting a dataset, but does not yet do anything with that selection. Partly to keep PR small, partly to run by you a couple of architecture choices - see comments.

This also adds a parent component that wraps both this new component and the API key widget.