### PR TITLE
mrc-1725 preliminary refactor

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -6,15 +6,11 @@ import com.github.kittinunf.fuel.httpPost
 import org.imperial.mrc.hint.asResponseEntity
 import org.springframework.http.ResponseEntity
 
-interface HttpClient {
-    fun get(url: String): ResponseEntity<String>
-}
-
-abstract class FuelClient(protected val baseUrl: String): HttpClient {
+abstract class FuelClient(protected val baseUrl: String) {
 
     abstract fun standardHeaders(): Map<String, Any>
 
-    override fun get(url: String): ResponseEntity<String> {
+    fun get(url: String): ResponseEntity<String> {
         return "$baseUrl/$url".httpGet()
                 .header(standardHeaders())
                 .addTimeouts()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -132,9 +132,9 @@ class ExceptionHandlerTests : SecureIntegrationTests() {
     }
 
     @Test
-    fun `does not include original message from psql exceptions`() {
+    fun `does not include original message from arbitrary exceptions`() {
         val sut = HintExceptionHandler(RandomErrorCodeGenerator(), ConfiguredAppProperties())
-        val result = sut.handlePSQLException(PSQLException("some message", mock()), mock())
+        val result = sut.handleArbitraryException(PSQLException("some message", mock()), mock())
         JSONValidator().validateError(result.body!!.toString(),
                 "OTHER_ERROR",
                 unexpectedErrorRegex)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -27,6 +27,7 @@ import org.springframework.http.converter.HttpMessageNotWritableException
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.context.request.WebRequest
 import java.io.File
+import java.lang.reflect.UndeclaredThrowableException
 
 class ExceptionHandlerTests : SecureIntegrationTests() {
 
@@ -139,6 +140,17 @@ class ExceptionHandlerTests : SecureIntegrationTests() {
                 "OTHER_ERROR",
                 unexpectedErrorRegex)
         assertThat(result.body!!.toString()).doesNotContain("trace")
+    }
+
+    @Test
+    fun `handles HintExceptions thrown inside UndeclaredThrowableException`() {
+        val sut = HintExceptionHandler(RandomErrorCodeGenerator(), ConfiguredAppProperties())
+        val fakeError = UndeclaredThrowableException(HintException("some message", HttpStatus.BAD_REQUEST))
+        val result = sut.handleArbitraryException(fakeError, mock())
+        JSONValidator().validateError(result.body!!.toString(),
+                "OTHER_ERROR",
+                "some message")
+        assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/ADRClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/ADRClientTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
-import org.imperial.mrc.hint.clients.ADRClient
+import org.imperial.mrc.hint.clients.ADRFuelClient
 import org.imperial.mrc.hint.ConfiguredAppProperties
 import org.junit.jupiter.api.Test
 
@@ -12,7 +12,7 @@ class ADRClientTests {
 
     @Test
     fun `can parse successful response from ADR`() {
-        val sut = ADRClient(ConfiguredAppProperties(), "fakekey")
+        val sut = ADRFuelClient(ConfiguredAppProperties(), "fakekey")
         val response = sut.get("/organization_list_for_user")
         assertThat(response.statusCodeValue).isEqualTo(200)
         val data = ObjectMapper().readValue<JsonNode>(response.body!!)["data"]
@@ -22,7 +22,7 @@ class ADRClientTests {
 
     @Test
     fun `can parse error response from ADR`() {
-        val sut = ADRClient(ConfiguredAppProperties(), "fakekey")
+        val sut = ADRFuelClient(ConfiguredAppProperties(), "fakekey")
         val response = sut.get("/member_list?id=nonsense")
         assertThat(response.statusCodeValue).isEqualTo(500)
         val errors = ObjectMapper().readValue<JsonNode>(response.body!!)["errors"]
@@ -34,7 +34,7 @@ class ADRClientTests {
 
     @Test
     fun `returns error if ADR response not correctly formatted`() {
-        val sut = ADRClient(ConfiguredAppProperties(), "fakekey")
+        val sut = ADRFuelClient(ConfiguredAppProperties(), "fakekey")
         val response = sut.get("/garbage")
         assertThat(response.statusCodeValue).isEqualTo(500)
         val errors = ObjectMapper().readValue<JsonNode>(response.body!!)["errors"]

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
@@ -5,7 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.clients.ADRClientBuilder
 import org.imperial.mrc.hint.ConfiguredAppProperties
-import org.imperial.mrc.hint.clients.ADRClient
+import org.imperial.mrc.hint.clients.ADRFuelClient
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.exceptions.UserException
 import org.imperial.mrc.hint.security.Encryption
@@ -39,7 +39,7 @@ class ADRClientBuilderTests {
     @Test
     fun `creates client with correct auth header`() {
         val sut = ADRClientBuilder(ConfiguredAppProperties(), encryption, mockSession, mockRepo)
-        val result = sut.build() as ADRClient
+        val result = sut.build() as ADRFuelClient
         val headers = result.standardHeaders()
         Assertions.assertThat(headers["Authorization"]).isEqualTo(TEST_KEY)
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -8,7 +8,7 @@ import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.clients.ADRClientBuilder
-import org.imperial.mrc.hint.clients.HttpClient
+import org.imperial.mrc.hint.clients.ADRClient
 import org.imperial.mrc.hint.controllers.ADRController
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.security.Encryption
@@ -65,7 +65,7 @@ class ADRControllerTests {
     @Test
     fun `gets datasets without inaccessible resources by default`() {
         val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
-        val mockClient = mock<HttpClient> {
+        val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -87,7 +87,7 @@ class ADRControllerTests {
     @Test
     fun `gets datasets including inaccessible resources if flag is passed`() {
         val expectedUrl = "package_search?q=type:adr-schema"
-        val mockClient = mock<HttpClient> {
+        val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -109,7 +109,7 @@ class ADRControllerTests {
     @Test
     fun `filters datasets to only those with resources`() {
         val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
-        val mockClient = mock<HttpClient> {
+        val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -133,7 +133,7 @@ class ADRControllerTests {
     fun `passes error responses along`() {
         val badResponse = ResponseEntity<String>(HttpStatus.BAD_REQUEST)
         val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
-        val mockClient = mock<HttpClient> {
+        val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn badResponse
         }
         val mockBuilder = mock<ADRClientBuilder> {


### PR DESCRIPTION
* removes the `HttpClient` interface and replaces with an `ADRClient` interface, as this will end up having other methods on it
* while testing I noticed that we were not handling arbitrary exceptions - unhandled exception types were not returning in our API format but in the SprintBoot default format, so I've added this in to the `ExceptionHandler`