### PR TITLE
mrc-1725 endpoint to GET ADR schema names

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -7,13 +7,13 @@ import java.net.URL
 import java.util.*
 
 interface AppProperties {
-    val adrANC: String
-    val adrART: String
-    val adrPJNZ: String
-    val adrPop: String
-    val adrShape: String
-    val adrSurvey: String
-    val adrSchema: String
+    val adrANCSchema: String
+    val adrARTSchema: String
+    val adrPJNZSchema: String
+    val adrPopSchema: String
+    val adrShapeSchema: String
+    val adrSurveySchema: String
+    val adrDatasetSchema: String
     val adrUrl: String
     val apiUrl: String
     val applicationTitle: String
@@ -37,13 +37,13 @@ class HintProperties : Properties()
 
 @Component
 class ConfiguredAppProperties(private val props: HintProperties = properties) : AppProperties {
-    override val adrANC = propString("adr_anc_schema")
-    override val adrART = propString("adr_art_schema")
-    override val adrPJNZ= propString("adr_pjnz_schema")
-    override val adrPop = propString("adr_pop_schema")
-    override val adrShape = propString("adr_shape_schema")
-    override val adrSurvey = propString("adr_survey_schema")
-    override val adrSchema = propString("adr_schema")
+    override val adrANCSchema = propString("adr_anc_schema")
+    override val adrARTSchema = propString("adr_art_schema")
+    override val adrPJNZSchema= propString("adr_pjnz_schema")
+    override val adrPopSchema = propString("adr_pop_schema")
+    override val adrShapeSchema = propString("adr_shape_schema")
+    override val adrSurveySchema = propString("adr_survey_schema")
+    override val adrDatasetSchema = propString("adr_schema")
     override val adrUrl = propString("adr_url")
     override val apiUrl = propString("hintr_url")
     override val applicationTitle = propString("application_title")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -7,6 +7,12 @@ import java.net.URL
 import java.util.*
 
 interface AppProperties {
+    val adrANC: String
+    val adrART: String
+    val adrPJNZ: String
+    val adrPop: String
+    val adrShape: String
+    val adrSurvey: String
     val adrSchema: String
     val adrUrl: String
     val apiUrl: String
@@ -27,10 +33,16 @@ interface AppProperties {
 }
 
 //prevent auto-wiring of default Properties
-class HintProperties: Properties()
+class HintProperties : Properties()
 
 @Component
-class ConfiguredAppProperties(private val props: HintProperties = properties): AppProperties {
+class ConfiguredAppProperties(private val props: HintProperties = properties) : AppProperties {
+    override val adrANC = propString("adr_anc_schema")
+    override val adrART = propString("adr_art_schema")
+    override val adrPJNZ= propString("adr_pjnz_schema")
+    override val adrPop = propString("adr_pop_schema")
+    override val adrShape = propString("adr_shape_schema")
+    override val adrSurvey = propString("adr_survey_schema")
     override val adrSchema = propString("adr_schema")
     override val adrUrl = propString("adr_url")
     override val apiUrl = propString("hintr_url")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -51,7 +51,7 @@ class ADRController(private val session: Session,
     @GetMapping("/datasets")
     fun getDatasets(@RequestParam showInaccessible: Boolean = false): ResponseEntity<String> {
         val adr = adrClientBuilder.build()
-        var url = "package_search?q=type:${appProperties.adrSchema}"
+        var url = "package_search?q=type:${appProperties.adrDatasetSchema}"
         url = if (showInaccessible) {
             // this flag is used for testing but will never
             // actually be passed by the front-end
@@ -71,11 +71,11 @@ class ADRController(private val session: Session,
     @GetMapping("/schemas")
     fun getFileTypeMappings(): ResponseEntity<String> {
         return SuccessResponse(
-                mapOf("anc" to appProperties.adrANC,
-                        "programme" to appProperties.adrART,
-                        "pjnz" to appProperties.adrPJNZ,
-                        "population" to appProperties.adrPop,
-                        "shape" to appProperties.adrShape,
-                        "survey" to appProperties.adrSurvey)).asResponseEntity()
+                mapOf("anc" to appProperties.adrANCSchema,
+                        "programme" to appProperties.adrARTSchema,
+                        "pjnz" to appProperties.adrPJNZSchema,
+                        "population" to appProperties.adrPopSchema,
+                        "shape" to appProperties.adrShapeSchema,
+                        "survey" to appProperties.adrSurveySchema)).asResponseEntity()
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -67,4 +67,15 @@ class ADRController(private val session: Session,
             SuccessResponse(data.filter { it["resources"].count() > 0 }).asResponseEntity()
         }
     }
+
+    @GetMapping("/schemas")
+    fun getFileTypeMappings(): ResponseEntity<String> {
+        return SuccessResponse(
+                mapOf("anc" to appProperties.adrANC,
+                        "programme" to appProperties.adrART,
+                        "pjnz" to appProperties.adrPJNZ,
+                        "population" to appProperties.adrPop,
+                        "shape" to appProperties.adrShape,
+                        "survey" to appProperties.adrSurvey)).asResponseEntity()
+    }
 }

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -1,3 +1,9 @@
+adr_anc_schema=inputs-unaids-anc
+adr_art_schema=inputs-unaids-art
+adr_pjnz_schema=inputs-unaids-spectrum-file
+adr_pop_schema=inputs-unaids-population
+adr_shape_schema=inputs-unaids-geographic
+adr_survey_schema=inputs-unaids-survey
 adr_schema=inputs-unaids-estimates
 adr_url=https://dev.adr.fjelltopp.org/api/3/action
 application_title=Naomi

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -81,6 +81,17 @@ class ADRTests : SecureIntegrationTests() {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
+    fun `can get ADR schema types`(isAuthorized: IsAuthorized) {
+        val result = testRestTemplate.getForEntity<String>("/adr/schemas")
+        assertSecureWithSuccess(isAuthorized, result, null)
+        if (isAuthorized == IsAuthorized.TRUE) {
+            val data = ObjectMapper().readTree(result.body!!)["data"]
+            assertThat(data["pjnz"].textValue()).isEqualTo("inputs-unaids-spectrum-file")
+        }
+    }
+
     private fun getPostEntity(): HttpEntity<LinkedMultiValueMap<String, String>> {
         val map = LinkedMultiValueMap<String, String>()
         map.add("key", "testkey")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -31,6 +31,12 @@ class ADRControllerTests {
 
     private val mockProperties = mock<AppProperties> {
         on { adrSchema } doReturn "adr-schema"
+        on { adrANC } doReturn "adr-anc"
+        on { adrART } doReturn "adr-art"
+        on { adrPJNZ } doReturn "adr-pjnz"
+        on { adrPop } doReturn "adr-pop"
+        on { adrShape } doReturn "adr-shape"
+        on { adrSurvey } doReturn "adr-survey"
     }
 
     private val objectMapper = ObjectMapper()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -150,6 +150,25 @@ class ADRControllerTests {
         assertThat(result).isEqualTo(badResponse)
     }
 
+    @Test
+    fun `returns map of names to adr file schemas`() {
+        val sut = ADRController(
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                objectMapper,
+                mockProperties)
+        val result = sut.getFileTypeMappings()
+        val data = objectMapper.readTree(result.body!!)["data"]
+        assertThat(data["pjnz"].textValue()).isEqualTo("adr-pjnz")
+        assertThat(data["population"].textValue()).isEqualTo("adr-pop")
+        assertThat(data["programme"].textValue()).isEqualTo("adr-art")
+        assertThat(data["anc"].textValue()).isEqualTo("adr-anc")
+        assertThat(data["shape"].textValue()).isEqualTo("adr-shape")
+        assertThat(data["survey"].textValue()).isEqualTo("adr-survey")
+    }
+
     private fun makeFakeSuccessResponse(): ResponseEntity<String> {
         val resultWithResources = mapOf("resources" to listOf(1, 2))
         val resultWithoutResources = mapOf("resources" to listOf<Any>())

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -30,13 +30,13 @@ class ADRControllerTests {
     }
 
     private val mockProperties = mock<AppProperties> {
-        on { adrSchema } doReturn "adr-schema"
-        on { adrANC } doReturn "adr-anc"
-        on { adrART } doReturn "adr-art"
-        on { adrPJNZ } doReturn "adr-pjnz"
-        on { adrPop } doReturn "adr-pop"
-        on { adrShape } doReturn "adr-shape"
-        on { adrSurvey } doReturn "adr-survey"
+        on { adrDatasetSchema } doReturn "adr-schema"
+        on { adrANCSchema } doReturn "adr-anc"
+        on { adrARTSchema } doReturn "adr-art"
+        on { adrPJNZSchema } doReturn "adr-pjnz"
+        on { adrPopSchema } doReturn "adr-pop"
+        on { adrShapeSchema } doReturn "adr-shape"
+        on { adrSurveySchema } doReturn "adr-survey"
     }
 
     private val objectMapper = ObjectMapper()


### PR DESCRIPTION
When the user selects a dataset, one of the dataset fields is an array resources that look something like:
`[{"name": "Spectrum File", "url": "https://dev.adr.fjelltopp.org/dataset/4ffa1536-5be5-4444-8f32-b1a183b0de1f/resource/26efad44-a2ed-475d-bd30-d76e394040aa/download/spectrum.pjnz", "resource_type": "inputs-unaids-spectrum-file", ...}... ]`

The `resource_type` field of each resource identifies which of the 6 input files it is. Once a dataset is selected, the front-end can just pick out each file and make a POST request to `/import/pjnz` or whatever, but it needs to know what the 6 schema names are so it can select the right resource. Rather than hard-code these in the front-end I thought it was best to make them configurable. So this PR adds an endpoint to return a dictionary of configured schema names that the front-end can use to work out which resources to import.