### PR TITLE
mrc-1724 add border separator between Versions | File

### DIFF
--- a/src/app/static/src/app/components/header/FileMenu.vue
+++ b/src/app/static/src/app/components/header/FileMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div style="flex:auto" class="ml-2 border-left">
+    <div style="flex:auto">
         <drop-down text="file">
             <a class="dropdown-item" v-on:mousedown="save">
                 <span v-translate="'save'"></span>

--- a/src/app/static/src/app/components/header/FileMenu.vue
+++ b/src/app/static/src/app/components/header/FileMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div style="flex:auto">
+    <div style="flex:auto" class="ml-2 border-left">
         <drop-down text="file">
             <a class="dropdown-item" v-on:mousedown="save">
                 <span v-translate="'save'"></span>

--- a/src/app/static/src/app/components/header/UserHeader.vue
+++ b/src/app/static/src/app/components/header/UserHeader.vue
@@ -5,7 +5,7 @@
                 <div class="navbar-header">
                     {{title}}
                 </div>
-                <router-link v-if="!isGuest" to="/versions" class="ml-2" v-translate="'versions'"
+                <router-link v-if="!isGuest" to="/versions" class="ml-2 pr-2 border-right" v-translate="'versions'"
                              style="flex:none"></router-link>
                 <file-menu :title="title"></file-menu>
                 <span v-if="!isGuest" class="pr-2 mr-2 border-right text-light">


### PR DESCRIPTION
The top menu should have a visual separator between the "Versions" and "File" options.