### PR TITLE
mrc-1636_backend Endpoint to get snapshot details needed to load the snapshot

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/VersionsController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/VersionsController.kt
@@ -51,6 +51,15 @@ class VersionsController(private val session: Session,
         return EmptySuccessResponse.asResponseEntity()
     }
 
+    @GetMapping("version/{versionId}/snapshot/{snapshotId}")
+    @ResponseBody
+    fun getSnapshot(@PathVariable("versionId") versionId: Int,
+                    @PathVariable("snapshotId") snapshotId: String): ResponseEntity<String>
+    {
+        val snapshotDetails = snapshotRepository.getSnapshotDetails(snapshotId, versionId, userId())
+        return SuccessResponse(snapshotDetails).asResponseEntity();
+    }
+
     @GetMapping("/versions/")
     @ResponseBody
     fun getVersions(): ResponseEntity<String>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/VersionsController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/VersionsController.kt
@@ -53,7 +53,7 @@ class VersionsController(private val session: Session,
 
     @GetMapping("version/{versionId}/snapshot/{snapshotId}")
     @ResponseBody
-    fun getSnapshot(@PathVariable("versionId") versionId: Int,
+    fun getSnapshotDetails(@PathVariable("versionId") versionId: Int,
                     @PathVariable("snapshotId") snapshotId: String): ResponseEntity<String>
     {
         val snapshotDetails = snapshotRepository.getSnapshotDetails(snapshotId, versionId, userId())

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/SnapshotDetails.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/SnapshotDetails.kt
@@ -1,0 +1,3 @@
+package org.imperial.mrc.hint.models
+
+data class SnapshotDetails(val state: String, val files: Map<String, SnapshotFile>)


### PR DESCRIPTION
This endpoint will get back snapshot details in the same format they are saved when we save out to local file (with 'state' and 'files' properties) so we should be able to re-use the same code in the front end to load. 