### PR TITLE
fixed bug preventing tables for barcharts rendering

### DIFF
--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -104,6 +104,8 @@ export default Vue.extend<{}, {}, Computed, Props>({
             const areaArray = Array.from(selectedAreaIdSet);
             if (this.selections.detail === 0){
                 return [areaArray[0]]
+            } else if (!this.selections.detail){
+              return this.selections.selectedFilterOptions.area.map(row => row.id)
             } else return areaArray.filter(val => parseInt(val[4]) === this.selections.detail);
         },
         selectedAreaFilterOptions() {

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -226,6 +226,51 @@ describe('Table from testdata', () => {
       expect(wrapper.findAll('td').at(3).text()).toBe('0.5');
       expect(wrapper.findAll('tr').length).toBe(2);
   });
+  it('renders correct markup when detail set to null', () => {
+    const wrapper = getWrapper({ 
+      selections: {
+        ...propsData.selections,
+        detail: null,
+        selectedFilterOptions: {
+          ...propsData.selections.selectedFilterOptions,
+          area: [
+            { id: "MWI", label: "Malawi", children: [
+              {"id": "MWI_3_1", "label": "3.1", "children": [ { "id": "MWI_4_1", "label": "4.1", "children": [] }]},
+              { "id": "MWI_3_2", "label": "3.2", "children": [ { "id": "MWI_4_2", "label": "4.2", "children": [] }] }
+            ] }
+          ]
+        }
+    },
+    tabledata: [
+      ...propsData.tabledata,
+      {
+        area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
+      }
+    ],
+      filters: [
+          {
+              ...propsData.filters[0],
+              options: [
+                  { id: "MWI", label: "Malawi", children: [
+                    {"id": "MWI_3_1", "label": "3.1", "children": [ { "id": "MWI_4_1", "label": "4.1", "children": [] }]},
+                    { "id": "MWI_3_2", "label": "3.2", "children": [ { "id": "MWI_4_2", "label": "4.2", "children": [] }] }
+                  ] },
+              ]
+          },
+          {...propsData.filters[1]},
+          {...propsData.filters[2]}
+      ]
+  });
+    expect(wrapper.find('th').text()).toBe('Area');
+    expect(wrapper.find('td').text()).toBe('Malawi');
+    expect(wrapper.findAll('th').at(1).text()).toBe('Age');
+    expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
+    expect(wrapper.findAll('th').at(2).text()).toBe('Sex');
+    expect(wrapper.findAll('td').at(2).text()).toBe('Female');
+    expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence');
+    expect(wrapper.findAll('td').at(3).text()).toBe('0.5');
+    expect(wrapper.findAll('tr').length).toBe(2);
+});
   it('renders correct markup when detail set to 0 but 3.2 is selected', () => {
     const wrapper = getWrapper({ 
       selections: {


### PR DESCRIPTION
Added an extra conditional to the selectedAreaIds function for the barcharts, which have a detail value of null. Produces array area ids directly from the selectionFilterOptions rather than from the areaArray. Barchart now produces correct table even if disaggregated by area.