### PR TITLE
Fix forever loading when create version

### DIFF
--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -85,6 +85,9 @@ export const mutations: MutationTree<RootState> = {
         const resetState: RootState = {
             ...emptyState(),
             language: state.language,
+            adrDatasets: state.adrDatasets,
+            adrSchemas: state.adrSchemas,
+            adrKey: state.adrKey,
             versions: {
                 ...initialVersionsState(),
                 currentVersion: action.payload,

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -207,6 +207,9 @@ describe("Root mutations", () => {
     it("can reset for new version", () => {
         const state = populatedState();
         state.language = Language.fr;
+        state.adrDatasets = ["TEST DATASETA"];
+        state.adrSchemas = ["TEST SCHEMAS"] as any;
+        state.adrKey = "TEST KEY";
 
         const mockRouterPush = jest.fn();
         router.push = mockRouterPush;
@@ -221,6 +224,9 @@ describe("Root mutations", () => {
         expect(state.versions.currentSnapshot).toBe(version.snapshots[0]);
 
         expect(state.language).toBe(Language.fr);
+        expect(state.adrDatasets).toStrictEqual(["TEST DATASETA"]);
+        expect(state.adrSchemas).toStrictEqual(["TEST SCHEMAS"]);
+        expect(state.adrKey).toBe("TEST KEY");
 
         expect(state.baseline.ready).toBe(true);
         expect(state.surveyAndProgram.ready).toBe(true);


### PR DESCRIPTION
This fixes a bug which had crept into master, which meant that the stepper was never ready on create version. This was becaue it was waiting for adr schemas, which had not been set in the state for the new version. Have added that into the SetVersion schema, and also copied over adr dataset and key.