### PR TITLE
mrc-1762 backend for refreshing ADR datasets

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -76,6 +76,12 @@ class ADRController(private val encryption: Encryption,
         }
     }
 
+    @GetMapping("/datasets/{id}")
+    fun getDataset(@PathVariable id: String): ResponseEntity<String> {
+        val adr = adrClientBuilder.build()
+        return adr.get("package_show?id=${id}")
+    }
+
     @GetMapping("/schemas")
     fun getFileTypeMappings(): ResponseEntity<String> {
         return SuccessResponse(

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -91,6 +91,11 @@ class ADRTests : SecureIntegrationTests() {
 
         val result = testRestTemplate.getForEntity<String>("/adr/datasets/$id")
         assertSecureWithSuccess(isAuthorized, result, null)
+
+        if (isAuthorized == IsAuthorized.TRUE) {
+            val data = ObjectMapper().readTree(result.body!!)["data"]
+            assertThat(data["id"].textValue()).isEqualTo(id)
+        }
     }
 
     @ParameterizedTest

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -1,6 +1,7 @@
 package org.imperial.mrc.hint.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockito_kotlin.isA
 import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.db.Tables.ADR_KEY
 import org.junit.jupiter.api.Test
@@ -74,6 +75,22 @@ class ADRTests : SecureIntegrationTests() {
             // the test api key has access to exactly 1 dataset
             assertThat(data.count()).isEqualTo(1)
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
+    fun `can get individual ADR dataset`(isAuthorized: IsAuthorized) {
+        testRestTemplate.postForEntity<String>("/adr/key", getPostEntityWithKey())
+        val datasets = testRestTemplate.getForEntity<String>("/adr/datasets")
+
+        val id = if (isAuthorized == IsAuthorized.TRUE) {
+            val data = ObjectMapper().readTree(datasets.body!!)["data"]
+            data.first()["id"].textValue()
+        }
+        else "fake-id"
+
+        val result = testRestTemplate.getForEntity<String>("/adr/datasets/$id")
+        assertSecureWithSuccess(isAuthorized, result, null)
     }
 
     @ParameterizedTest

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -179,6 +179,31 @@ class ADRControllerTests : HintrControllerTests() {
     }
 
     @Test
+    fun `gets dataset by id`() {
+        val expectedUrl = "package_show?id=1234"
+        val mockClient = mock<ADRClient> {
+            on { get(expectedUrl) } doReturn ResponseEntity
+                    .ok()
+                    .body("whatever")
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties,
+                mock(),
+                mock(),
+                mockSession,
+                mock())
+        val result = sut.getDataset("1234")
+        assertThat(result.body!!).isEqualTo("whatever")
+    }
+
+    @Test
     fun `returns map of names to adr file schemas`() {
         val sut = ADRController(
                 mock(),


### PR DESCRIPTION
This PR adds an endpoint that fetches metadata for a single dataset, so that the app can compare this against stored metadata and tell the user if their imported data is out of date with the ADR.