### PR TITLE
add v-translate lowercase modifier

### DIFF
--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -52,7 +52,7 @@
                     <a href="#"
                        v-if="editing"
                        @click="cancel"
-                       v-translate="'cancel'"></a>
+                       v-translate.lowercase="'cancel'"></a>
                 </div>
             </div>
             <error-alert v-if="error" :error="error"></error-alert>

--- a/src/app/static/src/app/directives/translate.ts
+++ b/src/app/static/src/app/directives/translate.ts
@@ -17,10 +17,14 @@ export default <S extends TranslatableState>(store: Store<S>): DirectiveOptions 
 
     function _translateText(lng: Language, el: HTMLElement, binding: DirectiveBinding) {
         const attribute = binding.arg;
+        let translatedText = i18next.t(binding.value, {lng});
+        if (binding.modifiers.lowercase){
+            translatedText = translatedText.toLowerCase()
+        }
         if (attribute) {
-            el.setAttribute(attribute, i18next.t(binding.value, {lng}));
+            el.setAttribute(attribute, translatedText);
         } else {
-            el.innerHTML = i18next.t(binding.value, {lng});
+            el.innerHTML = translatedText;
         }
     }
 

--- a/src/app/static/src/tests/directives/translate.test.ts
+++ b/src/app/static/src/tests/directives/translate.test.ts
@@ -17,6 +17,10 @@ describe("translate directive", () => {
         template: '<input v-translate:value="\'validate\'" />'
     };
 
+    const TranslateLowercaseAttributeTest = {
+        template: '<input v-translate:value.lowercase="\'validate\'" />'
+    };
+
     const TranslateInnerTextTestStatic = {
         template: '<h4 v-translate="\'validate\'"></h4>'
     };
@@ -46,6 +50,12 @@ describe("translate directive", () => {
         const store = createStore();
         const rendered = shallowMount(TranslateAttributeTest, {store});
         expect((rendered.find("input").element as HTMLInputElement).value).toBe("Validate");
+    });
+
+    it("makes translated text lowercase if modifier specified", () => {
+        const store = createStore();
+        const rendered = shallowMount(TranslateLowercaseAttributeTest, {store});
+        expect((rendered.find("input").element as HTMLInputElement).value).toBe("validate");
     });
 
     it("translates the attribute when the store language changes", () => {


### PR DESCRIPTION
Makes the `v-translate` directive more flexible by allowing a `.lowercase` modifier to make the translated text all lowercase