### PR TITLE
mrc-1642 backend for cloning project to a new user

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ProjectsController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ProjectsController.kt
@@ -1,25 +1,25 @@
 package org.imperial.mrc.hint.controllers
 
-import org.imperial.mrc.hint.db.VersionRepository
 import org.imperial.mrc.hint.db.ProjectRepository
-import org.imperial.mrc.hint.models.*
-import org.imperial.mrc.hint.models.SuccessResponse
+import org.imperial.mrc.hint.db.VersionRepository
+import org.imperial.mrc.hint.exceptions.UserException
+import org.imperial.mrc.hint.logic.UserLogic
+import org.imperial.mrc.hint.models.EmptySuccessResponse
 import org.imperial.mrc.hint.models.Project
+import org.imperial.mrc.hint.models.SuccessResponse
 import org.imperial.mrc.hint.models.asResponseEntity
 import org.imperial.mrc.hint.security.Session
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.bind.annotation.PostMapping
 
 @RestController
 class ProjectsController(private val session: Session,
                          private val versionRepository: VersionRepository,
-                         private val projectRepository: ProjectRepository)
-{
+                         private val projectRepository: ProjectRepository,
+                         private val userLogic: UserLogic) {
     @PostMapping("/project/")
     @ResponseBody
-    fun newProject(@RequestParam("name") name: String): ResponseEntity<String>
-    {
+    fun newProject(@RequestParam("name") name: String): ResponseEntity<String> {
         val projectId = projectRepository.saveNewProject(userId(), name)
 
         //Generate new version id and set it as the session variable, and save new version to db
@@ -31,12 +31,25 @@ class ProjectsController(private val session: Session,
         return SuccessResponse(project).asResponseEntity()
     }
 
+    @PostMapping("/user/{email}/project/")
+    @ResponseBody
+    fun cloneProjectToUser(@RequestParam("parentProjectId") parentProjectId: Int,
+                           @PathVariable("email") email: String): ResponseEntity<String> {
+
+        val userId = userLogic.getUser(email)?.id ?: throw UserException("userDoesNotExist")
+        val currentProject = projectRepository.getProject(parentProjectId)
+        val newProjectId = projectRepository.saveNewProject(userId, currentProject.name)
+        currentProject.versions.forEach {
+            versionRepository.cloneVersion(it.id, session.generateNewVersionId(), newProjectId)
+        }
+        return SuccessResponse(null).asResponseEntity()
+    }
+
     @PostMapping("/project/{projectId}/version/")
     fun newVersion(@PathVariable("projectId") projectId: Int,
-                   @RequestParam("parent") parentVersionId: String): ResponseEntity<String>
-    {
+                   @RequestParam("parent") parentVersionId: String): ResponseEntity<String> {
         val newVersionId = session.generateNewVersionId()
-        versionRepository.copyVersion(parentVersionId, newVersionId,projectId, userId())
+        versionRepository.copyVersion(parentVersionId, newVersionId, projectId, userId())
         val newVersion = versionRepository.getVersion(newVersionId)
         return SuccessResponse(newVersion).asResponseEntity();
     }
@@ -45,8 +58,7 @@ class ProjectsController(private val session: Session,
     @ResponseBody
     fun uploadState(@PathVariable("projectId") projectId: Int,
                     @PathVariable("versionId") versionId: String,
-                    @RequestBody state: String): ResponseEntity<String>
-    {
+                    @RequestBody state: String): ResponseEntity<String> {
         versionRepository.saveVersionState(versionId, projectId, userId(), state)
         return EmptySuccessResponse.asResponseEntity()
     }
@@ -54,8 +66,7 @@ class ProjectsController(private val session: Session,
     @GetMapping("project/{projectId}/version/{versionId}")
     @ResponseBody
     fun loadVersionDetails(@PathVariable("projectId") projectId: Int,
-                           @PathVariable("versionId") versionId: String): ResponseEntity<String>
-    {
+                           @PathVariable("versionId") versionId: String): ResponseEntity<String> {
         val versionDetails = versionRepository.getVersionDetails(versionId, projectId, userId())
         session.setVersionId(versionId)
         return SuccessResponse(versionDetails).asResponseEntity();
@@ -63,8 +74,7 @@ class ProjectsController(private val session: Session,
 
     @GetMapping("/projects/")
     @ResponseBody
-    fun getProjects(): ResponseEntity<String>
-    {
+    fun getProjects(): ResponseEntity<String> {
         val projects =
                 if (session.userIsGuest()) {
                     listOf<Project>()
@@ -77,22 +87,19 @@ class ProjectsController(private val session: Session,
     @DeleteMapping("/project/{projectId}/version/{versionId}")
     @ResponseBody
     fun deleteVersion(@PathVariable("projectId") projectId: Int,
-                      @PathVariable("versionId") versionId: String): ResponseEntity<String>
-    {
+                      @PathVariable("versionId") versionId: String): ResponseEntity<String> {
         versionRepository.deleteVersion(versionId, projectId, userId())
         return EmptySuccessResponse.asResponseEntity()
     }
 
     @DeleteMapping("/project/{projectId}")
     @ResponseBody
-    fun deleteProject(@PathVariable("projectId") projectId: Int): ResponseEntity<String>
-    {
+    fun deleteProject(@PathVariable("projectId") projectId: Int): ResponseEntity<String> {
         projectRepository.deleteProject(projectId, userId())
         return EmptySuccessResponse.asResponseEntity()
     }
 
-    private fun userId(): String
-    {
+    private fun userId(): String {
         return session.getUserProfile().id
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ProjectsController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ProjectsController.kt
@@ -37,7 +37,7 @@ class ProjectsController(private val session: Session,
                            @PathVariable("email") email: String): ResponseEntity<String> {
 
         val userId = userLogic.getUser(email)?.id ?: throw UserException("userDoesNotExist")
-        val currentProject = projectRepository.getProject(parentProjectId)
+        val currentProject = projectRepository.getProject(parentProjectId, userId())
         val newProjectId = projectRepository.saveNewProject(userId, currentProject.name)
         currentProject.versions.forEach {
             versionRepository.cloneVersion(it.id, session.generateNewVersionId(), newProjectId)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
@@ -30,7 +30,12 @@ class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
                 .from(PROJECT)
                 .join(PROJECT_VERSION)
                 .on(PROJECT.ID.eq(PROJECT_VERSION.PROJECT_ID))
-                .where(PROJECT.ID.eq(projectId)).fetch() ?: throw ProjectException("projectDoesNotExist")
+                .where(PROJECT.ID.eq(projectId)).fetch()
+
+        if (!projectRecord.any()) {
+            throw ProjectException("projectDoesNotExist")
+        }
+
         return mapProject(projectRecord)
     }
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
@@ -13,13 +13,13 @@ interface ProjectRepository {
     fun saveNewProject(userId: String, projectName: String): Int
     fun getProjects(userId: String): List<Project>
     fun deleteProject(projectId: Int, userId: String)
-    fun getProject(projectId: Int): Project
+    fun getProject(projectId: Int, userId: String): Project
 }
 
 @Component
 class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
 
-    override fun getProject(projectId: Int): Project {
+    override fun getProject(projectId: Int, userId: String): Project {
         val projectRecord = dsl.select(
                 PROJECT.ID,
                 PROJECT.NAME,
@@ -30,7 +30,9 @@ class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
                 .from(PROJECT)
                 .join(PROJECT_VERSION)
                 .on(PROJECT.ID.eq(PROJECT_VERSION.PROJECT_ID))
-                .where(PROJECT.ID.eq(projectId)).fetch()
+                .where(PROJECT.ID.eq(projectId)
+                        .and(PROJECT.USER_ID.eq(userId))
+                ).fetch()
 
         if (!projectRecord.any()) {
             throw ProjectException("projectDoesNotExist")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/ProjectRepository.kt
@@ -1,28 +1,44 @@
 package org.imperial.mrc.hint.db
 
-import org.jooq.DSLContext
 import org.imperial.mrc.hint.db.Tables.PROJECT
 import org.imperial.mrc.hint.db.Tables.PROJECT_VERSION
 import org.imperial.mrc.hint.exceptions.ProjectException
-import org.imperial.mrc.hint.models.Version
 import org.imperial.mrc.hint.models.Project
+import org.imperial.mrc.hint.models.Version
+import org.jooq.DSLContext
+import org.jooq.Record
 import org.springframework.stereotype.Component
 
-interface ProjectRepository
-{
+interface ProjectRepository {
     fun saveNewProject(userId: String, projectName: String): Int
     fun getProjects(userId: String): List<Project>
     fun deleteProject(projectId: Int, userId: String)
+    fun getProject(projectId: Int): Project
 }
 
 @Component
 class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
-    override fun saveNewProject(userId: String, projectName: String): Int
-    {
+
+    override fun getProject(projectId: Int): Project {
+        val projectRecord = dsl.select(
+                PROJECT.ID,
+                PROJECT.NAME,
+                PROJECT_VERSION.ID,
+                PROJECT_VERSION.CREATED,
+                PROJECT_VERSION.UPDATED,
+                PROJECT_VERSION.VERSION_NUMBER)
+                .from(PROJECT)
+                .join(PROJECT_VERSION)
+                .on(PROJECT.ID.eq(PROJECT_VERSION.PROJECT_ID))
+                .where(PROJECT.ID.eq(projectId)).fetch() ?: throw ProjectException("projectDoesNotExist")
+        return mapProject(projectRecord)
+    }
+
+    override fun saveNewProject(userId: String, projectName: String): Int {
         val result = dsl.insertInto(PROJECT, PROJECT.USER_ID, PROJECT.NAME)
                 .values(userId, projectName)
                 .returning(PROJECT.ID)
-                .fetchOne();
+                .fetchOne()
 
         return result[PROJECT.ID]
     }
@@ -45,18 +61,12 @@ class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
                         .fetch()
 
         return result.groupBy { it[PROJECT.ID] }
-                .map { v ->
-                    Project(v.key, v.value[0][PROJECT.NAME],
-                            v.value.map { s ->
-                                Version(s[PROJECT_VERSION.ID], s[PROJECT_VERSION.CREATED],
-                                        s[PROJECT_VERSION.UPDATED], s[PROJECT_VERSION.VERSION_NUMBER])
-                            })
-                }
+                .values
+                .map(::mapProject)
                 .sortedByDescending { it.versions[0].updated }
     }
 
-    override fun deleteProject(projectId: Int, userId: String)
-    {
+    override fun deleteProject(projectId: Int, userId: String) {
         checkProjectExists(projectId, userId)
         dsl.update(PROJECT_VERSION)
                 .set(PROJECT_VERSION.DELETED, true)
@@ -64,12 +74,23 @@ class JooqProjectRepository(private val dsl: DSLContext) : ProjectRepository {
                 .execute()
     }
 
-    private fun checkProjectExists(projectId: Int, userId: String)
-    {
+    private fun checkProjectExists(projectId: Int, userId: String) {
         dsl.select(PROJECT.ID)
                 .from(PROJECT)
                 .where(PROJECT.ID.eq(projectId))
                 .and(PROJECT.USER_ID.eq(userId))
                 .fetchAny() ?: throw ProjectException("projectDoesNotExist")
     }
+
+    private fun mapProject(versions: List<Record>): Project {
+        return Project(versions[0][PROJECT.ID], versions[0][PROJECT.NAME], mapVersion(versions))
+    }
+
+    private fun mapVersion(records: List<Record>): List<Version> {
+        return records.map { v ->
+            Version(v[PROJECT_VERSION.ID], v[PROJECT_VERSION.CREATED],
+                    v[PROJECT_VERSION.UPDATED], v[PROJECT_VERSION.VERSION_NUMBER])
+        }
+    }
+
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
@@ -1,15 +1,14 @@
 package org.imperial.mrc.hint.database
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForClassTypes
 import org.imperial.mrc.hint.db.ProjectRepository
 import org.imperial.mrc.hint.db.VersionRepository
 import org.imperial.mrc.hint.db.tables.Project.PROJECT
-import org.imperial.mrc.hint.db.tables.ProjectVersion
 import org.imperial.mrc.hint.db.tables.ProjectVersion.PROJECT_VERSION
 import org.imperial.mrc.hint.exceptions.ProjectException
 import org.imperial.mrc.hint.logic.UserLogic
-import org.imperial.mrc.hint.models.Version
 import org.jooq.DSLContext
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -59,8 +58,16 @@ class ProjectRepositoryTests {
     }
 
     @Test
-    fun `can save new project`()
-    {
+    fun `getProject throws project exception if project id does not exist`() {
+
+        assertThatThrownBy {
+            sut.getProject(1234)
+        }.isInstanceOf(ProjectException::class.java)
+                .hasMessageContaining("projectDoesNotExist")
+    }
+
+    @Test
+    fun `can save new project`() {
         val uid = setupUser()
 
         val projectId = sut.saveNewProject(uid, "testProjectRepo")
@@ -74,8 +81,7 @@ class ProjectRepositoryTests {
     }
 
     @Test
-    fun `delete project throws error if project does not exist`()
-    {
+    fun `delete project throws error if project does not exist`() {
         val uid = setupUser()
         AssertionsForClassTypes.assertThatThrownBy { sut.deleteProject(9999, uid) }
                 .isInstanceOf(ProjectException::class.java)
@@ -83,13 +89,12 @@ class ProjectRepositoryTests {
     }
 
     @Test
-    fun `can delete project`()
-    {
+    fun `can delete project`() {
         val uid = setupUser()
 
         val projectId = sut.saveNewProject(uid, "testProjectRepo")
         val versionId1 = "testVersion"
-        val versionId2= "testVersion2"
+        val versionId2 = "testVersion2"
         versionRepo.saveVersion(versionId1, projectId)
         versionRepo.saveVersion(versionId2, projectId)
 
@@ -111,8 +116,7 @@ class ProjectRepositoryTests {
     }
 
     @Test
-    fun `can get projects for user`()
-    {
+    fun `can get projects for user`() {
         val userId = setupUser()
 
         userRepo.addUser("another.user@example.com", "pw")
@@ -162,20 +166,17 @@ class ProjectRepositoryTests {
         assertThat(p1.versions[1].versionNumber).isEqualTo(1)
     }
 
-    private fun setupUser(email: String = testEmail): String
-    {
+    private fun setupUser(email: String = testEmail): String {
         userRepo.addUser(email, "pw")
-       return userRepo.getUser(email)!!.id
+        return userRepo.getUser(email)!!.id
     }
 
-    private fun format(time: Instant): String
-    {
+    private fun format(time: Instant): String {
         val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
         return formatter.format(LocalDateTime.ofInstant(time, ZoneId.systemDefault()))
     }
 
-    private fun insertProject(name: String, userId: String): Int
-    {
+    private fun insertProject(name: String, userId: String): Int {
         val saved = dsl.insertInto(PROJECT, PROJECT.USER_ID, PROJECT.NAME)
                 .values(userId, name)
                 .returning(PROJECT.ID)
@@ -185,8 +186,7 @@ class ProjectRepositoryTests {
     }
 
     private fun insertVersion(versionId: String, projectId: Int, created: Instant, updated: Instant, deleted: Boolean,
-                              versionNumber: Int)
-    {
+                              versionNumber: Int) {
         dsl.insertInto(PROJECT_VERSION,
                 PROJECT_VERSION.ID,
                 PROJECT_VERSION.PROJECT_ID,

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
@@ -47,7 +47,7 @@ class ProjectRepositoryTests {
 
         val projectId = sut.saveNewProject(uid, "testProjectRepo")
         versionRepo.saveVersion("v1", projectId)
-        val project = sut.getProject(projectId)
+        val project = sut.getProject(projectId, uid)
         assertThat(project.name).isEqualTo("testProjectRepo")
         assertThat(project.id).isEqualTo(projectId)
         assertThat(project.versions.count()).isEqualTo(1)
@@ -61,7 +61,18 @@ class ProjectRepositoryTests {
     fun `getProject throws project exception if project id does not exist`() {
 
         assertThatThrownBy {
-            sut.getProject(1234)
+            sut.getProject(1234, "uid")
+        }.isInstanceOf(ProjectException::class.java)
+                .hasMessageContaining("projectDoesNotExist")
+    }
+
+    @Test
+    fun `getProject throws project exception if project id does not belong to user`() {
+
+        val uid = setupUser()
+        val projectId = sut.saveNewProject(uid, "testProjectRepo")
+        assertThatThrownBy {
+            sut.getProject(projectId, "testProjectRepo")
         }.isInstanceOf(ProjectException::class.java)
                 .hasMessageContaining("projectDoesNotExist")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
@@ -5,9 +5,11 @@ import org.assertj.core.api.AssertionsForClassTypes
 import org.imperial.mrc.hint.db.ProjectRepository
 import org.imperial.mrc.hint.db.VersionRepository
 import org.imperial.mrc.hint.db.tables.Project.PROJECT
+import org.imperial.mrc.hint.db.tables.ProjectVersion
 import org.imperial.mrc.hint.db.tables.ProjectVersion.PROJECT_VERSION
 import org.imperial.mrc.hint.exceptions.ProjectException
 import org.imperial.mrc.hint.logic.UserLogic
+import org.imperial.mrc.hint.models.Version
 import org.jooq.DSLContext
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,6 +41,22 @@ class ProjectRepositoryTests {
     private lateinit var dsl: DSLContext
 
     private val testEmail = "test@test.com"
+
+    @Test
+    fun `can get project`() {
+        val uid = setupUser()
+
+        val projectId = sut.saveNewProject(uid, "testProjectRepo")
+        versionRepo.saveVersion("v1", projectId)
+        val project = sut.getProject(projectId)
+        assertThat(project.name).isEqualTo("testProjectRepo")
+        assertThat(project.id).isEqualTo(projectId)
+        assertThat(project.versions.count()).isEqualTo(1)
+        assertThat(project.versions[0].versionNumber).isEqualTo(1)
+        assertThat(project.versions[0].id).isEqualTo("v1")
+        assertThat(project.versions[0].created).isNotNull()
+        assertThat(project.versions[0].updated).isNotNull()
+    }
 
     @Test
     fun `can save new project`()
@@ -144,10 +162,10 @@ class ProjectRepositoryTests {
         assertThat(p1.versions[1].versionNumber).isEqualTo(1)
     }
 
-    private fun setupUser(): String
+    private fun setupUser(email: String = testEmail): String
     {
-        userRepo.addUser(testEmail, "pw")
-       return userRepo.getUser(testEmail)!!.id
+        userRepo.addUser(email, "pw")
+       return userRepo.getUser(email)!!.id
     }
 
     private fun format(time: Instant): String

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/VersionRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/VersionRepositoryTests.kt
@@ -3,13 +3,13 @@ package org.imperial.mrc.hint.database
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
 import org.imperial.mrc.hint.FileType
-import org.imperial.mrc.hint.db.VersionRepository
-import org.imperial.mrc.hint.logic.UserLogic
-import org.imperial.mrc.hint.db.Tables.VERSION_FILE
-import org.imperial.mrc.hint.db.Tables.PROJECT_VERSION
 import org.imperial.mrc.hint.db.ProjectRepository
+import org.imperial.mrc.hint.db.Tables.PROJECT_VERSION
+import org.imperial.mrc.hint.db.Tables.VERSION_FILE
+import org.imperial.mrc.hint.db.VersionRepository
 import org.imperial.mrc.hint.exceptions.VersionException
 import org.imperial.mrc.hint.helpers.TranslationAssert
+import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.models.VersionFile
 import org.jooq.DSLContext
 import org.junit.jupiter.api.Test
@@ -55,8 +55,7 @@ class VersionRepositoryTests {
     }
 
     @Test
-    fun `can save version with project id`()
-    {
+    fun `can save version with project id`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
         sut.saveVersion(versionId, projectId)
@@ -107,31 +106,28 @@ class VersionRepositoryTests {
     }
 
     @Test
-    fun `save version state throws error if version does not exist`()
-    {
+    fun `save version state throws error if version does not exist`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.saveVersionState("nonexistentVersion", projectId, uid, "testState") }
+        assertThatThrownBy { sut.saveVersionState("nonexistentVersion", projectId, uid, "testState") }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `save version state throws error if version belongs to another project`()
-    {
+    fun `save version state throws error if version belongs to another project`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.saveVersionState(versionId, projectId+1, uid, "testState") }
+        assertThatThrownBy { sut.saveVersionState(versionId, projectId + 1, uid, "testState") }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `save version state throws error if version belongs to another user`()
-    {
+    fun `save version state throws error if version belongs to another user`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.saveVersionState(versionId, projectId, "not$uid", "testState") }
+        assertThatThrownBy { sut.saveVersionState(versionId, projectId, "not$uid", "testState") }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
@@ -160,9 +156,9 @@ class VersionRepositoryTests {
 
         val newVersionRecord =
                 dsl.select(PROJECT_VERSION.STATE, PROJECT_VERSION.PROJECT_ID, PROJECT_VERSION.VERSION_NUMBER)
-                .from(PROJECT_VERSION)
-                .where(PROJECT_VERSION.ID.eq("newVersionId"))
-                .fetchOne()
+                        .from(PROJECT_VERSION)
+                        .where(PROJECT_VERSION.ID.eq("newVersionId"))
+                        .fetchOne()
 
         assertThat(newVersionRecord[PROJECT_VERSION.STATE]).isEqualTo("TEST STATE")
         assertThat(newVersionRecord[PROJECT_VERSION.PROJECT_ID]).isEqualTo(projectId)
@@ -177,38 +173,54 @@ class VersionRepositoryTests {
     }
 
     @Test
-    fun `copy version throws error if version does not exist`()
-    {
+    fun `copy version throws error if version does not exist`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.copyVersion("nonexistentVersion", "newVersion", projectId, uid) }
+        assertThatThrownBy { sut.copyVersion("nonexistentVersion", "newVersion", projectId, uid) }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `copy version throws error if version belongs to another project`()
-    {
+    fun `copy version throws error if version belongs to another project`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.copyVersion(versionId, "newVersion", projectId+1, uid) }
+        assertThatThrownBy { sut.copyVersion(versionId, "newVersion", projectId + 1, uid) }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `copy version throws error if version belongs to another user`()
-    {
+    fun `copy version throws error if version belongs to another user`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.copyVersion(versionId, "newVersion", projectId, "not$uid") }
+        assertThatThrownBy { sut.copyVersion(versionId, "newVersion", projectId, "not$uid") }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `can get version`()
-    {
+    fun `can clone version to new project`() {
+        val uid = setupUser()
+        val uid2 = setupUser("another.user@email.com")
+
+        val originalProject = projectRepo.saveNewProject(uid, "p1")
+        val originalVersionId = "v1"
+        sut.saveVersion(originalVersionId, originalProject)
+        sut.saveVersionState(originalVersionId, originalProject, uid, "{'something': 1}")
+        setUpHashAndVersionFile("survey_hash", "survey_file", originalVersionId, "survey", false)
+
+        val clonedProject = projectRepo.saveNewProject(uid2, "p1")
+        val clonedVersionId = "v2"
+        sut.cloneVersion(originalVersionId, clonedVersionId, clonedProject)
+
+        val originalVersionDetails = sut.getVersionDetails(originalVersionId, originalProject, uid)
+        val clonedVersionDetails = sut.getVersionDetails(clonedVersionId, clonedProject, uid2)
+        assertThat(originalVersionDetails).isEqualToComparingFieldByFieldRecursively(clonedVersionDetails)
+    }
+
+    @Test
+    fun `can get version`() {
         val now = LocalDateTime.now(ZoneOffset.UTC)
         val soon = now.plusSeconds(5)
         setUpVersion()
@@ -434,18 +446,16 @@ class VersionRepositoryTests {
     }
 
     @Test
-    fun `get version details throws error if version does not exist`()
-    {
+    fun `get version details throws error if version does not exist`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.getVersionDetails("nonexistentVersion", projectId, uid) }
+        assertThatThrownBy { sut.getVersionDetails("nonexistentVersion", projectId, uid) }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `can delete version`()
-    {
+    fun `can delete version`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
         sut.saveVersion(versionId, projectId)
@@ -459,7 +469,7 @@ class VersionRepositoryTests {
                 .fetchOne()[PROJECT_VERSION.DELETED]
         assertThat(deleted).isTrue()
 
-        val notDeleted =  dsl.select(PROJECT_VERSION.DELETED)
+        val notDeleted = dsl.select(PROJECT_VERSION.DELETED)
                 .from(PROJECT_VERSION)
                 .where(PROJECT_VERSION.ID.eq("another version"))
                 .fetchOne()[PROJECT_VERSION.DELETED]
@@ -467,18 +477,16 @@ class VersionRepositoryTests {
     }
 
     @Test
-    fun `delete version throws error if version does not exist`()
-    {
+    fun `delete version throws error if version does not exist`() {
         val uid = setupUser()
         val projectId = setupProject(uid)
-        assertThatThrownBy{ sut.deleteVersion("nonexistentVersion", projectId, uid) }
+        assertThatThrownBy { sut.deleteVersion("nonexistentVersion", projectId, uid) }
                 .isInstanceOf(VersionException::class.java)
                 .hasMessageContaining("versionDoesNotExist")
     }
 
     @Test
-    fun `copy version after delete version assigns unused version number to new version`()
-    {
+    fun `copy version after delete version assigns unused version number to new version`() {
         //deleted version still exists, with deleted flag set, its version number should not be reused
         val uid = setupUser()
         val projectId = setupProject(uid);
@@ -498,15 +506,13 @@ class VersionRepositoryTests {
         assertThat(records.count()).isEqualTo(1)
     }
 
-    private fun setupUser(): String
-    {
-        userRepo.addUser(testEmail, "pw")
-        return userRepo.getUser(testEmail)!!.id
+    private fun setupUser(email: String = testEmail): String {
+        userRepo.addUser(email, "pw")
+        return userRepo.getUser(email)!!.id
     }
 
-    private fun setupProject(userId: String): Int
-    {
-       return projectRepo.saveNewProject(userId, "testProject")
+    private fun setupProject(userId: String): Int {
+        return projectRepo.saveNewProject(userId, "testProject")
     }
 
     private fun setUpVersionAndHash() {
@@ -515,7 +521,7 @@ class VersionRepositoryTests {
     }
 
     private fun setUpVersion() {
-        sut.saveVersion(versionId,null)
+        sut.saveVersion(versionId, null)
     }
 
     private fun setUpHashAndVersionFile(hash: String, filename: String, versionId: String, type: String, setUpVersion: Boolean = true) {
@@ -525,7 +531,6 @@ class VersionRepositoryTests {
         }
         dsl.insertInto(VERSION_FILE)
                 .set(VERSION_FILE.FILENAME, filename)
-
                 .set(VERSION_FILE.HASH, hash)
                 .set(VERSION_FILE.VERSION, versionId)
                 .set(VERSION_FILE.TYPE, type)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
@@ -19,7 +19,7 @@ abstract class CleanDatabaseTests
     protected lateinit var dsl: DSLContext
 
     @Autowired
-    private lateinit var userRepo: DbProfileServiceUserLogic
+    protected lateinit var userRepo: DbProfileServiceUserLogic
 
     @AfterEach
     fun tearDown() {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
@@ -3,19 +3,22 @@ package org.imperial.mrc.hint.unit.controllers
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
-import org.imperial.mrc.hint.controllers.ProjectsController
-import org.imperial.mrc.hint.security.Session
-import org.junit.jupiter.api.Test
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.imperial.mrc.hint.db.VersionRepository
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.imperial.mrc.hint.controllers.ProjectsController
 import org.imperial.mrc.hint.db.ProjectRepository
+import org.imperial.mrc.hint.db.VersionRepository
+import org.imperial.mrc.hint.logic.UserLogic
+import org.imperial.mrc.hint.models.Project
 import org.imperial.mrc.hint.models.Version
 import org.imperial.mrc.hint.models.VersionDetails
 import org.imperial.mrc.hint.models.VersionFile
-import org.imperial.mrc.hint.models.Project
+import org.imperial.mrc.hint.security.Session
+import org.junit.jupiter.api.Test
+import org.omg.CORBA.UserException
 import org.pac4j.core.profile.CommonProfile
 import org.springframework.http.HttpStatus
 
@@ -35,8 +38,7 @@ class ProjectsControllerTests {
     private val parser = ObjectMapper()
 
     @Test
-    fun `creates new project`()
-    {
+    fun `creates new project`() {
         val mockVersionRepo = mock<VersionRepository> {
             on { getVersion("testVersion") } doReturn mockVersion
         }
@@ -45,7 +47,7 @@ class ProjectsControllerTests {
             on { saveNewProject("testUser", "testProject") } doReturn 99
         }
 
-        val sut = ProjectsController(mockSession, mockVersionRepo, mockProjectRepo)
+        val sut = ProjectsController(mockSession, mockVersionRepo, mockProjectRepo, mock())
 
         val result = sut.newProject("testProject")
 
@@ -61,30 +63,28 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `copies version`()
-    {
+    fun `copies version`() {
         val mockVersionRepo = mock<VersionRepository> {
             on { getVersion("testVersion") } doReturn mockVersion
         }
-        val sut = ProjectsController(mockSession, mockVersionRepo, mock())
+        val sut = ProjectsController(mockSession, mockVersionRepo, mock(), mock())
         val result = sut.newVersion(99, "parentVersion")
 
-        verify(mockVersionRepo).copyVersion("parentVersion", "testVersion",99, "testUser" )
+        verify(mockVersionRepo).copyVersion("parentVersion", "testVersion", 99, "testUser")
 
         val resultJson = parser.readTree(result.body)["data"]
         assertExpectedVersion(resultJson)
     }
 
     @Test
-    fun `gets Projects`()
-    {
+    fun `gets Projects`() {
         val mockVersions = listOf(Version("testVersion", "createdTime", "updatedTime", 1))
         val mockProjects = listOf(Project(99, "testProject", mockVersions))
-        val mockProjectRepo = mock<ProjectRepository>{
+        val mockProjectRepo = mock<ProjectRepository> {
             on { getProjects("testUser") } doReturn mockProjects
         }
 
-        val sut = ProjectsController(mockSession, mock(), mockProjectRepo)
+        val sut = ProjectsController(mockSession, mock(), mockProjectRepo, mock())
         val result = sut.getProjects()
 
         val resultJson = parser.readTree(result.body)["data"]
@@ -98,12 +98,11 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `gets empty projects list if user is guest`()
-    {
+    fun `gets empty projects list if user is guest`() {
         val guestSession = mock<Session> {
             on { userIsGuest() } doReturn true
         }
-        val sut = ProjectsController(guestSession, mock(), mock())
+        val sut = ProjectsController(guestSession, mock(), mock(), mock())
         val result = sut.getProjects()
 
         val resultJson = parser.readTree(result.body)["data"]
@@ -112,10 +111,9 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `can upload state`()
-    {
+    fun `can upload state`() {
         val mockRepo = mock<VersionRepository>();
-        val sut = ProjectsController(mockSession, mockRepo, mock())
+        val sut = ProjectsController(mockSession, mockRepo, mock(), mock())
 
         val result = sut.uploadState(99, "testVersion", "testState")
 
@@ -125,14 +123,13 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `can get version details`()
-    {
+    fun `can get version details`() {
         val mockDetails = VersionDetails("TEST STATE", mapOf("pjnz" to VersionFile("hash1", "filename1")))
         val mockRepo = mock<VersionRepository> {
-          on { getVersionDetails("testVersion", 99, "testUser") }  doReturn mockDetails
+            on { getVersionDetails("testVersion", 99, "testUser") } doReturn mockDetails
         };
 
-        val sut = ProjectsController(mockSession, mockRepo, mock())
+        val sut = ProjectsController(mockSession, mockRepo, mock(), mock())
         val result = sut.loadVersionDetails(99, "testVersion")
         assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
         val resultJson = parser.readTree(result.body)["data"]
@@ -145,10 +142,37 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `can delete version`()
-    {
+    fun `can clone project to user`() {
+        val mockVersionRepo = mock<VersionRepository>()
+        val mockProjectRepo = mock<ProjectRepository> {
+            on { getProject(1) } doReturn Project(1, "p1", listOf(Version("v1", "createdTime", "updatedTime", 1),
+                    Version("v2", "createdTime", "updatedTime", 1)))
+            on { saveNewProject("uid", "p1") } doReturn 2
+        }
+        val mockLogic = mock<UserLogic> {
+            on { getUser("new.user@email.com") } doReturn CommonProfile().apply { id = "uid" }
+        }
+        val sut = ProjectsController(mockSession, mockVersionRepo, mockProjectRepo, mockLogic)
+        sut.cloneProjectToUser(1, "new.user@email.com")
+        verify(mockVersionRepo).cloneVersion("v1", "testVersion", 2)
+        verify(mockVersionRepo).cloneVersion("v2", "testVersion", 2)
+    }
+
+    @Test
+    fun `clone project to user throws if user does not exist`() {
+        val mockLogic = mock<UserLogic> {
+            on { getUser("new.user@email.com") } doReturn null as CommonProfile?
+        }
+        val sut = ProjectsController(mockSession, mock(), mock(), mockLogic)
+        assertThatThrownBy {  sut.cloneProjectToUser(1, "new.user@email.com") }
+                .isInstanceOf(UserException::class.java)
+                .hasMessageContaining("userDoesNotExist")
+    }
+
+    @Test
+    fun `can delete version`() {
         val mockRepo = mock<VersionRepository>()
-        val sut = ProjectsController(mockSession, mockRepo, mock())
+        val sut = ProjectsController(mockSession, mockRepo, mock(), mock())
         val result = sut.deleteVersion(1, "testVersion")
 
         verify(mockRepo).deleteVersion("testVersion", 1, "testUser")
@@ -156,18 +180,16 @@ class ProjectsControllerTests {
     }
 
     @Test
-    fun `can delete project`()
-    {
+    fun `can delete project`() {
         val mockRepo = mock<ProjectRepository>()
-        val sut = ProjectsController(mockSession, mock(), mockRepo)
+        val sut = ProjectsController(mockSession, mock(), mockRepo, mock())
         val result = sut.deleteProject(1)
 
         verify(mockRepo).deleteProject(1, "testUser")
         assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
     }
 
-    private fun assertExpectedVersion(node: JsonNode)
-    {
+    private fun assertExpectedVersion(node: JsonNode) {
         assertThat(node["id"].asText()).isEqualTo("testVersion")
         assertThat(node["created"].asText()).isEqualTo("createdTime")
         assertThat(node["updated"].asText()).isEqualTo("updatedTime")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
@@ -145,7 +145,7 @@ class ProjectsControllerTests {
     fun `can clone project to user`() {
         val mockVersionRepo = mock<VersionRepository>()
         val mockProjectRepo = mock<ProjectRepository> {
-            on { getProject(1, "testuser") } doReturn Project(1, "p1", listOf(Version("v1", "createdTime", "updatedTime", 1),
+            on { getProject(1, "testUser") } doReturn Project(1, "p1", listOf(Version("v1", "createdTime", "updatedTime", 1),
                     Version("v2", "createdTime", "updatedTime", 1)))
             on { saveNewProject("uid", "p1") } doReturn 2
         }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.imperial.mrc.hint.controllers.ProjectsController
 import org.imperial.mrc.hint.db.ProjectRepository
 import org.imperial.mrc.hint.db.VersionRepository
+import org.imperial.mrc.hint.exceptions.UserException
 import org.imperial.mrc.hint.logic.UserLogic
 import org.imperial.mrc.hint.models.Project
 import org.imperial.mrc.hint.models.Version
@@ -18,7 +19,6 @@ import org.imperial.mrc.hint.models.VersionDetails
 import org.imperial.mrc.hint.models.VersionFile
 import org.imperial.mrc.hint.security.Session
 import org.junit.jupiter.api.Test
-import org.omg.CORBA.UserException
 import org.pac4j.core.profile.CommonProfile
 import org.springframework.http.HttpStatus
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ProjectsControllerTests.kt
@@ -145,7 +145,7 @@ class ProjectsControllerTests {
     fun `can clone project to user`() {
         val mockVersionRepo = mock<VersionRepository>()
         val mockProjectRepo = mock<ProjectRepository> {
-            on { getProject(1) } doReturn Project(1, "p1", listOf(Version("v1", "createdTime", "updatedTime", 1),
+            on { getProject(1, "testuser") } doReturn Project(1, "p1", listOf(Version("v1", "createdTime", "updatedTime", 1),
                     Version("v2", "createdTime", "updatedTime", 1)))
             on { saveNewProject("uid", "p1") } doReturn 2
         }


### PR DESCRIPTION
I've noticed that every Kotlin file I've auto-formatted that was previously only coded by @EmmaLRussell has changed code style from the more spaced out:


```
fun someFunction() 
{
 // something here
}
```


to the default Kotlin convention:

```
fun someFunction() {
// something here
}
```

Suggests we have different code style rules in our IDEs! 

We actually use the former, the more spaced out convention in both orderly-web and montagu-api, but looking at this codebase almost every file is formatted with the latter convention (and we haven't committed the code style settings to the repo.) I'll raise a ticket to make this consistent and commit the code style settings so we don't get out of sync again. I'm minded to use the same settings as orderly-web and montagu-api and make that our standard code style convention for all Kotlin code.