### PR TITLE
Fixes weird race condition when running all tests at once

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ADRTests.kt
@@ -1,8 +1,6 @@
 package org.imperial.mrc.hint.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.nhaarman.mockito_kotlin.isA
-import jdk.nashorn.internal.ir.annotations.Ignore
 import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.db.Tables.ADR_KEY
 import org.junit.jupiter.api.Test

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/CleanDatabaseTests.kt
@@ -1,25 +1,35 @@
 package org.imperial.mrc.hint.integration
 
-import org.jooq.Table
-import org.imperial.mrc.hint.logic.DbProfileServiceUserLogic
 import org.imperial.mrc.hint.db.Tables
 import org.imperial.mrc.hint.helpers.tmpUploadDirectory
+import org.imperial.mrc.hint.logic.DbProfileServiceUserLogic
 import org.jooq.DSLContext
+import org.jooq.Table
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.core.env.Environment
 import org.springframework.test.context.ActiveProfiles
 import java.io.File
 
+
 @ActiveProfiles(profiles = ["dev"])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-abstract class CleanDatabaseTests
-{
+abstract class CleanDatabaseTests {
+
     @Autowired
     protected lateinit var dsl: DSLContext
 
     @Autowired
     protected lateinit var userRepo: DbProfileServiceUserLogic
+
+    @Autowired
+    lateinit var env: Environment
+
+    @Autowired
+    lateinit var restTemplateBuilder: RestTemplateBuilder
 
     @AfterEach
     fun tearDown() {
@@ -27,7 +37,7 @@ abstract class CleanDatabaseTests
 
         val tableFields = Tables::class.java.fields
 
-        for (tableField in tableFields){
+        for (tableField in tableFields) {
             val table = tableField.get(null) as Table<*>
             dsl.truncate(table)
                     .cascade()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/IntegrationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/IntegrationTests.kt
@@ -10,16 +10,23 @@ import org.imperial.mrc.hint.helpers.getTestEntity
 import org.imperial.mrc.hint.models.ModelRunOptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.boot.test.web.client.postForEntity
 import org.springframework.http.*
+import javax.annotation.PostConstruct
 
 abstract class SecureIntegrationTests : CleanDatabaseTests() {
 
-    @Autowired
-    lateinit var testRestTemplate: TestRestTemplate
+    protected lateinit var testRestTemplate: TestRestTemplate
+
+    @PostConstruct
+    fun getTemplate() {
+        val builder = restTemplateBuilder
+                .rootUri("http://localhost:" + env.getProperty("local.server.port"))
+
+        this.testRestTemplate = TestRestTemplate(builder)
+    }
 
     @BeforeEach
     fun beforeEach(info: TestInfo) {


### PR DESCRIPTION
Seems that the autowired `TestRestTemplate`, which is shared between all integration tests, is causing problems. See https://github.com/mrc-ide/hint/pull/344 for discussion. This PR changes the logic of the base integration test class to build a fresh `TestRestTemplate` for each class.

Although we weren't seeing test failures on master on Travis, this branch has been merged into https://github.com/mrc-ide/hint/pull/344, which fixed the Travis test failures there. 