### PR TITLE
mrc-1871 set loading status to true while loading current project

### DIFF
--- a/src/app/static/src/app/store/projects/actions.ts
+++ b/src/app/static/src/app/store/projects/actions.ts
@@ -70,12 +70,14 @@ export const actions: ActionTree<ProjectsState, RootState> & ProjectsActions = {
     },
 
     async getCurrentProject(context) {
-        const {rootGetters} = context;
+        const {rootGetters, commit} = context;
         if (!rootGetters.isGuest) {
+            commit({type: ProjectsMutations.SetLoading, payload: true});
             await api<ProjectsMutations, ProjectsMutations>(context)
                 .withSuccess(ProjectsMutations.SetCurrentProject)
                 .withError(ProjectsMutations.ProjectError)
                 .get<CurrentProject>("/project/current");
+            commit({type: ProjectsMutations.SetLoading, payload: false});
         }
     },
 

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -124,7 +124,9 @@ describe("Projects actions", () => {
         actions.getCurrentProject({commit, state, rootState, rootGetters} as any);
 
         setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetCurrentProject, payload: testProjects});
+            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+            expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetCurrentProject, payload: testProjects});
+            expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
             done();
         });
     });
@@ -183,11 +185,13 @@ describe("Projects actions", () => {
         actions.getCurrentProject({commit, state, rootState, rootGetters} as any);
 
         setTimeout(() => {
+            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
             const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
+            expect(commit.mock.calls[1][0]).toStrictEqual({
                 type: ProjectsMutations.ProjectError,
                 payload: expectedError
             });
+            expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
             done();
         });
     });


### PR DESCRIPTION
Project loading is broken because it relies on a page refresh, but on page refresh the `Stepper.vue` component is too eager to redirect the user back to `/projects` while the back-end is still loading the current project. Since the stepper respects the `loading` property, we just need to set this before and after loading the current project.