### PR TITLE
Disable Calibrate button while calibration in progress

### DIFF
--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -4,12 +4,19 @@
             <loading-spinner size="lg"></loading-spinner>
             <h2 id="loading-message" v-translate="'loadingOptions'"></h2>
         </div>
-        <dynamic-form v-if="!loading"
+        <dynamic-form ref="form"
+                      v-if="!loading"
                       v-model="calibrateOptions"
-                      :submit-text="submitText"
                       @submit="calibrate"
                       :required-text="requiredText"
-                      :select-text="selectText"></dynamic-form>
+                      :select-text="selectText"
+                      :include-submit-button="false"></dynamic-form>
+        <button class="btn"
+                :class="calibrating ? 'btn-secondary' : 'btn-submit'"
+                :disabled="calibrating"
+                @click="submitForm">
+            {{submitText}}
+        </button>
         <div v-if="calibrating" id="calibrating" class="mt-3">
             <loading-spinner size="xs"></loading-spinner>
             <span v-translate="'calibrating'"></span>
@@ -42,6 +49,7 @@
         fetchOptions: () => void
         calibrate: (data: DynamicFormData) => void
         update: (data: DynamicFormMeta) => void
+        submitForm: (e: Event) => void
     }
 
     interface Computed {
@@ -106,7 +114,10 @@
         methods: {
             update: mapMutationByName(namespace, ModelCalibrateMutation.Update),
             calibrate: mapActionByName(namespace,"calibrate"),
-            fetchOptions: mapActionByName(namespace, "fetchModelCalibrateOptions")
+            fetchOptions: mapActionByName(namespace, "fetchModelCalibrateOptions"),
+            submitForm() {
+                (this.$refs.form as any).submit()
+            }
         },
         components: {
             DynamicForm,

--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -11,7 +11,8 @@
                       :required-text="requiredText"
                       :select-text="selectText"
                       :include-submit-button="false"></dynamic-form>
-        <button class="btn"
+        <button v-if="!loading"
+                class="btn"
                 :class="calibrating ? 'btn-secondary' : 'btn-submit'"
                 :disabled="calibrating"
                 @click="submitForm">

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -66,6 +66,7 @@ describe("Model calibrate component", () => {
         expect(wrapper.find("#calibration-complete").exists()).toBe(false);
         expect(wrapper.find(ErrorAlert).exists()).toBe(false);
         expect(wrapper.find("#calibrating").exists()).toBe(false);
+        expect(wrapper.find("button").exists()).toBe(false);
     });
 
     it("invokes fetch options action on mount", () => {
@@ -84,10 +85,14 @@ describe("Model calibrate component", () => {
         const form = wrapper.find(DynamicForm);
         expect(form.attributes("required-text")).toBe("required");
         expect(form.attributes("select-text")).toBe("Select...");
-        expectTranslated(form.find("button"), "Calibrate", "Calibrer", store);
+        expect(form.props("includeSubmitButton")).toBe(false);
         expect(form.find("h3").text()).toBe("Test Section");
         expect(form.find(".text-muted").text()).toBe("Just a test section");
         expect((form.find("input").element as HTMLInputElement).value).toBe("5");
+        expectTranslated(wrapper.find("button"), "Calibrate", "Calibrer", store);
+        expect(wrapper.find("button").classes()).toContain("btn-submit");
+        expect(wrapper.find("button").classes()).not.toContain("btn-secondary");
+        expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.find("#calibration-complete").exists()).toBe(false);
     });
 
@@ -106,12 +111,15 @@ describe("Model calibrate component", () => {
         expect(wrapper.find(ErrorAlert).props("error")).toBe(error);
     });
 
-    it("renders calibrating message", () => {
+    it("renders as expected while calibrating", () => {
         const store = getStore({calibrating: true});
         const wrapper = getWrapper(store);
         expect(wrapper.find("#calibrating").find(LoadingSpinner).exists()).toBe(true);
         expectTranslated(wrapper.find("#calibrating"), "Calibrating...",
             "Calibrage en cours...", store);
+        expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+        expect(wrapper.find("button").classes()).toContain("btn-secondary");
+        expect(wrapper.find("button").classes()).not.toContain("btn-submit");
     });
 
     it("setting options value commits update mutation", () => {
@@ -129,7 +137,7 @@ describe("Model calibrate component", () => {
         const mockCalibrate = jest.fn();
         const store = getStore({optionsFormMeta: mockOptionsFormMeta}, jest.fn(), mockCalibrate);
         const wrapper = mount(ModelCalibrate, {store});
-        wrapper.find(DynamicForm).find("button").trigger("click");
+        wrapper.find("button").trigger("click");
         expect(mockCalibrate.mock.calls.length).toBe(1);
 
     });


### PR DESCRIPTION
Hide the form's button and provide a separate button in the component while is disabled while calibrating is true