### PR TITLE
mrc-1884 Pass format function to barchart component

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -1863,9 +1863,9 @@
       }
     },
     "@reside-ic/vue-charts": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@reside-ic/vue-charts/-/vue-charts-0.0.4.tgz",
-      "integrity": "sha512-4dCAT9w5aqA5XVsYpUWvna1DL9Hk6Yw2/d5yOkieCZg+mNJwShiVyb19qV1MuEbnNy8CFjRO3kgIPG2DoQK1Og==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@reside-ic/vue-charts/-/vue-charts-0.0.5.tgz",
+      "integrity": "sha512-bzy4YEqim++Bj7sQ/yOkkrAoPqk9bD7JAGRJqlIKWRX08GKH3mjXmoJtL6oREm95RvfV4V4HJ1qPVe7xNT0MHg==",
       "dev": true
     },
     "@reside-ic/vue-dynamic-form": {
@@ -6128,8 +6128,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6150,14 +6149,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6172,20 +6169,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6302,8 +6296,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6315,7 +6308,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6330,7 +6322,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6338,8 +6329,7 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
@@ -6452,8 +6442,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6465,7 +6454,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6587,7 +6575,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6607,7 +6594,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6651,8 +6637,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -18,7 +18,7 @@
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.3",
     "@babel/register": "^7.6.2",
-    "@reside-ic/vue-charts": "0.0.4",
+    "@reside-ic/vue-charts": "0.0.5",
     "@riophae/vue-treeselect": "^0.3.0",
     "@types/crypto-js": "^3.1.43",
     "@types/d3-scale-chromatic": "^1.3.1",

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -47,6 +47,7 @@
                     :filter-config="filterConfig"
                     :indicators="barchartIndicators"
                     :selections="barchartSelections"
+                    :formatFunction="formatBarchartValue"
                     @update="updateBarchartSelections({payload: $event})"></bar-chart-with-filters>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
@@ -116,6 +117,7 @@
     import {LevelLabel} from "../../types";
     import {mapState} from "vuex";
     import {ChoroplethIndicatorMetadata} from "../../generated";
+    import {formatOutput} from "../plots/utils";
 
     const namespace = 'filteredData';
 
@@ -128,6 +130,7 @@
         updateBarchartSelections: (data: BarchartSelections) => void
         updateBubblePlotSelections: (data: BubblePlotSelections) => void
         updateOutputColourScales: (colourScales: ColourScaleSelections) => void
+        formatBarchartValue: (value: string | number, indicator: BarchartIndicator) => string
     }
 
     interface Computed {
@@ -223,7 +226,10 @@
             ...mapMutationsByNames<keyof Methods>("plottingSelections",
                 ["updateBarchartSelections", "updateBubblePlotSelections", "updateOutputChoroplethSelections",
                     "updateOutputColourScales"]),
-            tabSelected: mapMutationByName<keyof Methods>("modelOutput", ModelOutputMutation.TabSelected)
+            tabSelected: mapMutationByName<keyof Methods>("modelOutput", ModelOutputMutation.TabSelected),
+            formatBarchartValue: (value: string | number, indicator: BarchartIndicator) => {
+                return formatOutput(value, indicator.format, indicator.scale, indicator.accuracy).toString();
+            }
         },
         components: {
             BarChartWithFilters,

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -45,7 +45,10 @@ export interface BarchartIndicator {
     indicator_value: string,
     name: string,
     error_low_column: string,
-    error_high_column: string
+    error_high_column: string,
+    format: string,
+    scale: number,
+    accuracy: number | null
 }
 
 export interface Filter {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -16,6 +16,7 @@ import {ModelOutputState} from "../../../app/store/modelOutput/modelOutput";
 import Choropleth from "../../../app/components/plots/choropleth/Choropleth.vue";
 import BubblePlot from "../../../app/components/plots/bubble/BubblePlot.vue";
 import {expectTranslated} from "../../testHelpers";
+import {BarchartIndicator} from "../../../app/types";
 
 const localVue = createLocalVue();
 
@@ -118,6 +119,19 @@ describe("ModelOutput component", () => {
         expect(bubble.props().selections).toStrictEqual({test: "TEST BUBBLE SELECTIONS"});
         expect(bubble.props().indicators).toStrictEqual(["TEST BUBBLE INDICATORS"]);
         expect(bubble.props().colourScales).toStrictEqual({test: "TEST OUTPUT COLOUR SCALES"});
+    });
+
+    it("renders barchart", () => {
+        const store = getStore({selectedTab: "bar"});
+        const wrapper = shallowMount(ModelOutput, {localVue, store});
+        const vm = wrapper.vm as any;
+
+        const barchart = wrapper.find(BarChartWithFilters);
+        expect(barchart.props().chartData).toStrictEqual(["TEST DATA"]);
+        expect(barchart.props().filterConfig).toBe(vm.filterConfig);
+        expect(barchart.props().indicators).toStrictEqual(["TEST BARCHART INDICATORS"]);
+        expect(barchart.props().selections).toBe(vm.barchartSelections);
+        expect(barchart.props().formatFunction).toBe(vm.formatBarchartValue);
     });
 
     it("if no selected tab in state, defaults to select Map tab", () => {
@@ -396,5 +410,29 @@ describe("ModelOutput component", () => {
                 {"indicator": "art_coverage", "indicator_value": "4"}
             ]
         );
+    });
+
+    it("formatBarchartValue formats value", () => {
+        const store = getStore();
+        const wrapper = shallowMount(ModelOutput, {store, localVue});
+
+        const indicator: BarchartIndicator = {
+            indicator: "testIndicator",
+            value_column: "val_col",
+            indicator_column: "ind_col",
+            indicator_value: "",
+            name: "Test Indicator",
+            error_low_column: "err_lo",
+            error_high_column: "err_hi",
+            format: "0.00%",
+            scale: 1,
+            accuracy: null
+        };
+        expect((wrapper.vm as any).formatBarchartValue(0.29, indicator)).toBe("29.00%");
+
+        indicator.format = "0";
+        indicator.scale = 10;
+        indicator.accuracy = 100;
+        expect((wrapper.vm as any).formatBarchartValue(4231, indicator)).toBe("42300");
     });
 });


### PR DESCRIPTION
I have published the changes from https://github.com/reside-ic/vue-charts/pull/6 to npm so that the formatFunction feature was available to HINT. You'll need to `npm install` to install this new version.

This branch uses the existing formatOutput method to tell the barchart how to format values of a given indicator. 

One thing that might need looking at in future at is the y-axis - it's currently showing percentage indicators to 2 decimal places, as we use the same indicator format for both axis ticks and value tooltips.  So you get a lot of ticks like 10.00% which seems a little verbose. But to fix that we would need separate formats for axes and values in the metadata.