### PR TITLE
mrc-1916 add loading spinner to model option validating

### DIFF
--- a/src/app/static/src/app/components/modelOptions/ModelOptions.vue
+++ b/src/app/static/src/app/components/modelOptions/ModelOptions.vue
@@ -11,6 +11,11 @@
                       @submit="validate"
                       :required-text="requiredText"
                       :select-text="selectText"></dynamic-form>
+
+        <div v-if="validating" id="validating" class="mt-3">
+            <loading-spinner size="xs"></loading-spinner>
+            <span v-translate="'validating'"></span>
+        </div>
         <h4 v-if="valid" class="mt-3">
             <span v-translate="'optionsValid'"></span>
             <tick color="#e31837" width="20px"></tick>
@@ -79,6 +84,7 @@
             ...mapStateProps<ModelOptionsState, keyof Computed>(namespace, {
                 loading: state => state.fetching,
                 valid: state => state.valid,
+                validating: state => state.validating,
                 validateError: state => state.validateError,
                 hasValidateError: state => !!state.validateError
             }),

--- a/src/app/static/src/app/store/modelOptions/actions.ts
+++ b/src/app/static/src/app/store/modelOptions/actions.ts
@@ -32,13 +32,12 @@ export const actions: ActionTree<ModelOptionsState, RootState> & ModelOptionsAct
         commit(ModelOptionsMutation.LoadUpdatedOptions, payload);
         const options = rootState.modelOptions.options;
         const version = rootState.modelOptions.version;
-        const response = await api<ModelOptionsMutation, ModelOptionsMutation>(context)
+        await api<ModelOptionsMutation, ModelOptionsMutation>(context)
             .withSuccess(ModelOptionsMutation.Validate)
             .withError(ModelOptionsMutation.HasValidationError)
             .postAndReturn<ModelOptionsValidate>("/model/validate/options/", {options, version})
-
-        if(response) {
-            commit(ModelOptionsMutation.Validated);
-        }  
+            
+        commit(ModelOptionsMutation.Validated);
+        
     }
 };

--- a/src/app/static/src/app/store/modelOptions/actions.ts
+++ b/src/app/static/src/app/store/modelOptions/actions.ts
@@ -28,13 +28,17 @@ export const actions: ActionTree<ModelOptionsState, RootState> & ModelOptionsAct
 
     async validateModelOptions(context, payload) {
         const {commit, rootState} = context;
+        commit(ModelOptionsMutation.Validating);
         commit(ModelOptionsMutation.LoadUpdatedOptions, payload);
         const options = rootState.modelOptions.options;
         const version = rootState.modelOptions.version;
-        await api<ModelOptionsMutation, ModelOptionsMutation>(context)
+        const response = await api<ModelOptionsMutation, ModelOptionsMutation>(context)
             .withSuccess(ModelOptionsMutation.Validate)
             .withError(ModelOptionsMutation.HasValidationError)
             .postAndReturn<ModelOptionsValidate>("/model/validate/options/", {options, version})
 
+        if(response) {
+            commit(ModelOptionsMutation.Validated);
+        }  
     }
 };

--- a/src/app/static/src/app/store/modelOptions/modelOptions.ts
+++ b/src/app/static/src/app/store/modelOptions/modelOptions.ts
@@ -10,6 +10,7 @@ export interface ModelOptionsState {
     optionsFormMeta: DynamicFormMeta
     options: DynamicFormData
     valid: boolean
+    validating: boolean
     fetching: boolean
     version: VersionInfo
     validateError: Error | null
@@ -20,6 +21,7 @@ export const initialModelOptionsState = (): ModelOptionsState => {
         optionsFormMeta: {controlSections: []},
         options: {},
         valid: false,
+        validating: false,
         fetching: false,
         version: {hintr: "unknown", naomi: "unknown", rrq: "unknown"},
         validateError: null

--- a/src/app/static/src/app/store/modelOptions/mutations.ts
+++ b/src/app/static/src/app/store/modelOptions/mutations.ts
@@ -9,6 +9,8 @@ import {VersionInfo, Error} from "../../generated";
 export enum ModelOptionsMutation {
     UnValidate = "UnValidate",
     Validate = "Validate",
+    Validating = "Validating",
+    Validated = "Validated",
     Update = "Update",
     FetchingModelOptions = "FetchingModelOptions",
     ModelOptionsFetched = "ModelOptionsFetched",
@@ -26,6 +28,14 @@ export const mutations: MutationTree<ModelOptionsState> = {
 
     [ModelOptionsMutation.Validate](state: ModelOptionsState) {
         state.valid = true;
+    },
+
+    [ModelOptionsMutation.Validating](state: ModelOptionsState) {
+        state.validating = true;
+    },
+
+    [ModelOptionsMutation.Validated](state: ModelOptionsState) {
+        state.validating = false;
     },
 
     [ModelOptionsMutation.LoadUpdatedOptions](state: ModelOptionsState, payload: DynamicFormData) {

--- a/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
+++ b/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
@@ -26,7 +26,8 @@ describe("Model options component", () => {
         [ModelOptionsMutation.Update]: jest.fn(),
         [ModelOptionsMutation.Validate]: jest.fn(),
         [ModelOptionsMutation.ModelOptionsFetched]: jest.fn(),
-        [ModelOptionsMutation.FetchingModelOptions]: jest.fn()
+        [ModelOptionsMutation.FetchingModelOptions]: jest.fn(),
+        [ModelOptionsMutation.Validating]: jest.fn()
     };
 
     const mockGetters = {
@@ -68,6 +69,7 @@ describe("Model options component", () => {
         const rendered = shallowMount(ModelOptions, {store});
         expect(rendered.findAll(DynamicForm).length).toBe(1);
         expect(rendered.findAll(LoadingSpinner).length).toBe(0);
+        expect(rendered.find("#validating").exists()).toBe(false);
     });
 
     it("displays loading spinner while fetching is true", () => {
@@ -79,12 +81,21 @@ describe("Model options component", () => {
             "Chargement de vos options.", store);
     });
 
+    it("renders as expected while validating", () => {
+        const store = createStore({validating: true});
+        const rendered = shallowMount(ModelOptions, {store});
+        expect(rendered.find("#validating").find(LoadingSpinner).exists()).toBe(true);
+        expectTranslated(rendered.find("#validating"), "Validating...",
+            "Validation en cours...", store);
+    });
+
     it("displays tick and message if valid is true", () => {
         const store = createStore({valid: true});
         const rendered = shallowMount(ModelOptions, {store});
         expectTranslated(rendered.find("h4"), "Options are valid",
             "Les options sont valides", store);
         expect(rendered.findAll(Tick).length).toBe(1);
+        expect(rendered.find("#validating").exists()).toBe(false);
     });
 
 

--- a/src/app/static/src/tests/integration/modelOptions.itest.ts
+++ b/src/app/static/src/tests/integration/modelOptions.itest.ts
@@ -55,9 +55,9 @@ describe("model options actions integration", () => {
         }
         //passed mock params which will return validation error
         await actions.validateModelOptions({commit, rootState: mockState} as any, {options,version} as any);
-        expect(commit.mock.calls[0][0]).toBe(ModelOptionsMutation.LoadUpdatedOptions);
-        expect(commit.mock.calls[1][0]["type"]).toBe(ModelOptionsMutation.HasValidationError);
-        expect(commit.mock.calls[1][0]["payload"]["error"]).toBe("INVALID_INPUT")
-
+        expect(commit.mock.calls[0][0]).toBe(ModelOptionsMutation.Validating);
+        expect(commit.mock.calls[1][0]).toBe(ModelOptionsMutation.LoadUpdatedOptions);
+        expect(commit.mock.calls[2][0]["type"]).toBe(ModelOptionsMutation.HasValidationError);
+        expect(commit.mock.calls[2][0]["payload"]["error"]).toBe("INVALID_INPUT")
     });
 });

--- a/src/app/static/src/tests/modelOptions/actions.test.ts
+++ b/src/app/static/src/tests/modelOptions/actions.test.ts
@@ -39,11 +39,13 @@ describe("model run options actions", () => {
         const payload = jest.fn();
         await actions.validateModelOptions({commit, rootState} as any, payload as any);
 
-        expect(commit.mock.calls[0][0]).toStrictEqual(ModelOptionsMutation.LoadUpdatedOptions);
+        expect(commit.mock.calls[0][0]).toStrictEqual(ModelOptionsMutation.Validating);
+        expect(commit.mock.calls[1][0]).toStrictEqual(ModelOptionsMutation.LoadUpdatedOptions);
 
-        expect(commit.mock.calls[1][0]).toStrictEqual({
+        expect(commit.mock.calls[2][0]).toStrictEqual({
             type: ModelOptionsMutation.Validate,
             payload: "TEST"
         });
+        expect(commit.mock.calls[3][0]).toStrictEqual(ModelOptionsMutation.Validated);
     });
 });

--- a/src/app/static/src/tests/modelOptions/mutations.test.ts
+++ b/src/app/static/src/tests/modelOptions/mutations.test.ts
@@ -33,6 +33,18 @@ describe("Model run options mutations", () => {
         expect(state.valid).toBe(false);
     });
 
+    it("can assert validating model option start", () => {
+        const state = mockModelOptionsState();
+        mutations[ModelOptionsMutation.Validating](state);
+        expect(state.validating).toBe(true);
+    });
+
+    it("can assert validating model option complete", () => {
+        const state = mockModelOptionsState();
+        mutations[ModelOptionsMutation.Validated](state);
+        expect(state.validating).toBe(false);
+    });
+
     it("saves version", () => {
         const state = mockModelOptionsState();
         const mockVersion: VersionInfo = {
@@ -104,6 +116,17 @@ describe("Model run options mutations", () => {
         mutations.ModelOptionsFetched(state, {payload: newForm});
         expect(state.optionsFormMeta).toStrictEqual(expected);
         expect(state.fetching).toBe(false);
+    });
+
+    it("does not set validating to true if model asserts valid", () => {
+
+        const state = mockModelOptionsState({
+            valid: true,
+            optionsFormMeta: testForm
+        });
+
+        mutations.ModelOptionsFetched(state, {payload: testForm});
+        expect(state.validating).toBe(false);
     });
 
     it("sets valid to false if updated form differs from existing", () => {

--- a/src/app/static/src/tests/modelOptions/mutations.test.ts
+++ b/src/app/static/src/tests/modelOptions/mutations.test.ts
@@ -40,7 +40,7 @@ describe("Model run options mutations", () => {
     });
 
     it("can assert validating model option complete", () => {
-        const state = mockModelOptionsState();
+        const state = mockModelOptionsState({validating:true});
         mutations[ModelOptionsMutation.Validated](state);
         expect(state.validating).toBe(false);
     });
@@ -116,17 +116,6 @@ describe("Model run options mutations", () => {
         mutations.ModelOptionsFetched(state, {payload: newForm});
         expect(state.optionsFormMeta).toStrictEqual(expected);
         expect(state.fetching).toBe(false);
-    });
-
-    it("does not set validating to true if model asserts valid", () => {
-
-        const state = mockModelOptionsState({
-            valid: true,
-            optionsFormMeta: testForm
-        });
-
-        mutations.ModelOptionsFetched(state, {payload: testForm});
-        expect(state.validating).toBe(false);
     });
 
     it("sets valid to false if updated form differs from existing", () => {


### PR DESCRIPTION
PR to add loading spinner to the 'Validate' button on the model options page which takes a bit of time now before the check mark appears. 