### PR TITLE
mrc-1945 Add hint version to version menu

### DIFF
--- a/src/app/static/src/app/components/header/HintrVersionMenu.vue
+++ b/src/app/static/src/app/components/header/HintrVersionMenu.vue
@@ -4,19 +4,21 @@
         <span class="dropdown-item" style="cursor: default;"> hintr    : v{{ hintrVersions.hintr }} </span>
         <span class="dropdown-item" style="cursor: default;"> rrq      : v{{ hintrVersions.rrq }} </span>
         <span class="dropdown-item" style="cursor: default;"> traduire : v{{ hintrVersions.traduire }}</span>
+        <span class="dropdown-item" style="cursor: default;"> hint : v{{ hintVersion }}</span>
     </drop-down>
 </template>
 
 <script lang="ts">
     import Vue from "vue";
-    import {ActionMethod, mapActions} from "vuex";
     import {HintrVersionResponse} from "../../generated";
     import {RootState} from "../../root";
     import {mapActionByName, mapStateProp} from "../../utils";
     import DropDown from "./DropDown.vue";
+    import {currentHintVersion} from "../../hintVersion";
 
     interface Computed {
         hintrVersions: HintrVersionResponse;
+        hintVersion: string
     }
 
     interface Methods {
@@ -31,6 +33,7 @@
                 null,
                 (state: RootState) => state.hintrVersion.hintrVersion
             ),
+            hintVersion: () => currentHintVersion
         },
 
         methods: {

--- a/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
+++ b/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
@@ -4,6 +4,7 @@ import HintrVersionMenu from "../../../app/components/header/HintrVersionMenu.vu
 import DropDown from "../../../app/components/header/DropDown.vue";
 import { mockHintrVersionState } from "../../mocks";
 import { emptyState } from "../../../app/root";
+import {currentHintVersion} from "../../../app/hintVersion";
 
 describe("Hintr Menu Version", () => {
 
@@ -24,13 +25,22 @@ describe("Hintr Menu Version", () => {
         return store;
     }
 
-    it("hintr version menu displays link for (4) items", async() => {
+    it("hintr version menu displays span for (5) items", async() => {
         const store = createStore();
         const wrapper = shallowMount(HintrVersionMenu, {
             store
         });
 
-        expect(wrapper.findAll("span").length).toBe(4);
+        expect(wrapper.findAll("span").length).toBe(5);
+    });
+
+    it("hintr version menu displays current hint version", async() => {
+        const store = createStore();
+        const wrapper = shallowMount(HintrVersionMenu, {
+            store
+        });
+
+        expect(wrapper.findAll("span").at(4).text()).toBe(`hint : v${currentHintVersion}`);
     });
 
     it("hintr version menu gets initial version placeholder before getter ", async() => {


### PR DESCRIPTION
Arguably HintrVersionMenu is no longer a great name for this component, but it was showing more than hintr's version anyway! ('PackageVersionMenu'?)