### PR TITLE
mrc-1567 Make "fit to filtered data" default colour scale

### DIFF
--- a/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
+++ b/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
@@ -80,7 +80,7 @@ export const initialChorplethSelections = (): ChoroplethSelections => {
 
 export const initialColourScaleSettings = (): ColourScaleSettings => {
     return {
-        type: ColourScaleType.Default,
+        type: ColourScaleType.DynamicFiltered,
         customMin: 0,
         customMax: 0
     }

--- a/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
@@ -424,7 +424,7 @@ describe("Choropleth component", () => {
         expect(wrapper.emitted("update-colour-scales")[0][0]).toStrictEqual({
             ...propsData.colourScales,
             plhiv: {
-                type: ColourScaleType.Default,
+                type: ColourScaleType.DynamicFiltered,
                 customMin: 1,
                 customMax: 100
             }

--- a/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
@@ -17,7 +17,7 @@ describe("Choropleth utils", () => {
         };
 
         const result = initialiseColourScaleFromMetadata(meta);
-        expect(result.type).toBe(ColourScaleType.Default);
+        expect(result.type).toBe(ColourScaleType.DynamicFiltered);
         expect(result.customMin).toBe(1.5);
         expect(result.customMax).toBe(2.5);
     });


### PR DESCRIPTION
Make “Fit to filtered data” default colour scale or make “fit to entire dataset” the default value for min/max boxes

Does this mean the static defaults are kind of useless?