### PR TITLE
mrc-1931 Show remove file link when there is an error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.0.1
+
+* Fix bug to allow removal of files with errors
+
 # hint 1.0.0
 
 * ADR integration

--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -69,19 +69,19 @@
                     valid: !!state.country,
                     error: state.pjnzError,
                     fromADR: !!state.pjnz?.fromADR,
-                    existingFileName: state.pjnz && state.pjnz.filename
+                    existingFileName: (state.pjnz && state.pjnz.filename) || state.pjnzErroredFile
                 } as PartialFileUploadProps),
                 shape: state => ({
                     valid: state.shape != null,
                     error: state.shapeError,
                     fromADR: !!state.shape?.fromADR,
-                    existingFileName: state.shape && state.shape.filename
+                    existingFileName: (state.shape && state.shape.filename) || state.shapeErroredFile
                 } as PartialFileUploadProps),
                 population: state => ({
                     valid: state.population != null,
                     error: state.populationError,
                     fromADR: !!state.population?.fromADR,
-                    existingFileName: state.population && state.population.filename
+                    existingFileName: (state.population && state.population.filename) || state.populationErroredFile
                 } as PartialFileUploadProps),
                 hasBaselineError: state => !!state.baselineError,
                 baselineError: state => state.baselineError,

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -6,7 +6,7 @@
         <loading-spinner v-if="uploading" size="xs"></loading-spinner>
         <br/>
         <slot></slot>
-        <label v-if="existingFileName" class="file-name">
+        <label v-if="existingFileName || error" class="file-name">
             <span>
                 <strong v-translate="'file'"></strong>: {{ existingFileName }}
             </span>

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -7,7 +7,7 @@
         <br/>
         <slot></slot>
         <label v-if="existingFileName || error" class="file-name">
-            <span>
+            <span v-if="existingFileName">
                 <strong v-translate="'file'"></strong>: {{ existingFileName }}
             </span>
             <a class="small float-right"

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -134,7 +134,7 @@
                     valid: !!surveyAndProgram.anc,
                     fromADR: !!surveyAndProgram.anc?.fromADR,
                     error: surveyAndProgram.ancError,
-                    existingFileName: surveyAndProgram.anc && surveyAndProgram.anc.filename,
+                    existingFileName: (surveyAndProgram.anc && surveyAndProgram.anc.filename)|| surveyAndProgram.ancErroredFile,
                     tabClass: {
                         "disabled": !surveyAndProgram.anc,
                         "active": surveyAndProgram.selectedDataType == DataType.ANC
@@ -144,7 +144,7 @@
                     valid: surveyAndProgram.program != null,
                     fromADR: !!surveyAndProgram.program?.fromADR,
                     error: surveyAndProgram.programError,
-                    existingFileName: surveyAndProgram.program && surveyAndProgram.program.filename,
+                    existingFileName: (surveyAndProgram.program && surveyAndProgram.program.filename) || surveyAndProgram.programErroredFile,
                     tabClass: {
                         "disabled": !surveyAndProgram.program,
                         "active": surveyAndProgram.selectedDataType == DataType.Program
@@ -154,7 +154,7 @@
                     valid: surveyAndProgram.survey != null,
                     fromADR: !!surveyAndProgram.survey?.fromADR,
                     error: surveyAndProgram.surveyError,
-                    existingFileName: surveyAndProgram.survey && surveyAndProgram.survey.filename,
+                    existingFileName: (surveyAndProgram.survey && surveyAndProgram.survey.filename) || surveyAndProgram.surveyErroredFile,
                     tabClass: {
                         "disabled": !surveyAndProgram.survey,
                         "active": surveyAndProgram.selectedDataType == DataType.Survey

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.0.0";
+export const currentHintVersion = "1.0.1";

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -9,6 +9,7 @@ import {localStorageManager} from "../../localStorageManager";
 export interface BaselineState extends ReadyState {
     selectedDataset: Dataset | null
     pjnzError: Error | null
+    pjnzErroredFile: string | null
     country: string
     iso3: string
     pjnz: PjnzResponse | null
@@ -16,8 +17,10 @@ export interface BaselineState extends ReadyState {
     regionFilters: NestedFilterOption[]
     flattenedRegionFilters: Dict<NestedFilterOption>
     shapeError: Error | null
+    shapeErroredFile: string | null
     population: PopulationResponse | null,
     populationError: Error | null,
+    populationErroredFile: string | null,
     validating: boolean,
     validatedConsistent: boolean,
     baselineError: Error | null
@@ -29,13 +32,16 @@ export const initialBaselineState = (): BaselineState => {
         country: "",
         iso3: "",
         pjnzError: null,
+        pjnzErroredFile: null,
         pjnz: null,
         shape: null,
         regionFilters: [],
         flattenedRegionFilters: {},
         shapeError: null,
+        shapeErroredFile: null,
         population: null,
         populationError: null,
+        populationErroredFile: null,
         ready: false,
         validating: false,
         validatedConsistent: false,

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -15,10 +15,13 @@ import {ReadyState} from "../../root";
 export enum BaselineMutation {
     PJNZUpdated = "PJNZUpdated",
     PJNZUploadError = "PJNZUploadError",
+    PJNZErroredFile = "PJNZErroredFile",
     ShapeUpdated = "ShapeUpdated",
     ShapeUploadError = "ShapeUploadError",
+    ShapeErroredFile = "ShapeErroredFile",
     PopulationUpdated = "PopulationUpdated",
     PopulationUploadError = "PopulationUploadError",
+    PopulationErroredFile = "PopulationErroredFile",
     Ready = "Ready",
     Validating = "Validating",
     Validated = "Validated",
@@ -89,6 +92,11 @@ export const mutations: MutationTree<BaselineState> = {
             state.pjnz = null;
         }
         state.pjnzError = null;
+        state.pjnzErroredFile = null;
+    },
+
+    [BaselineMutation.PJNZErroredFile](state: BaselineState, action: PayloadWithType<string>) {
+        state.pjnzErroredFile = action.payload;
     },
 
     [BaselineMutation.ShapeUpdated](state: BaselineState, action: PayloadWithType<ShapeResponse>) {
@@ -98,19 +106,29 @@ export const mutations: MutationTree<BaselineState> = {
             state.flattenedRegionFilters = Object.freeze(flattenOptions(state.regionFilters));
         }
         state.shapeError = null;
+        state.shapeErroredFile = null;
     },
 
     [BaselineMutation.ShapeUploadError](state: BaselineState, action: PayloadWithType<Error>) {
         state.shapeError = action.payload;
     },
 
+    [BaselineMutation.ShapeErroredFile](state: BaselineState, action: PayloadWithType<string>) {
+        state.shapeErroredFile = action.payload;
+    },
+
     [BaselineMutation.PopulationUpdated](state: BaselineState, action: PayloadWithType<PopulationResponse>) {
         state.population = action.payload;
         state.populationError = null;
+        state.populationErroredFile = null;
     },
 
     [BaselineMutation.PopulationUploadError](state: BaselineState, action: PayloadWithType<Error>) {
         state.populationError = action.payload;
+    },
+
+    [BaselineMutation.PopulationErroredFile](state: BaselineState, action: PayloadWithType<string>) {
+        state.populationErroredFile = action.payload;
     },
 
     [BaselineMutation.Validating](state: BaselineState) {

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -5,6 +5,7 @@ import {api} from "../../apiService";
 import {AncResponse, ProgrammeResponse, SurveyResponse} from "../../generated";
 import {SurveyAndProgramMutation} from "./mutations";
 import qs from 'qs';
+import {getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
 
 export interface SurveyAndProgramActions {
     importSurvey: (store: ActionContext<SurveyAndProgramState, RootState>, url: string) => void,
@@ -31,7 +32,8 @@ interface UploadImportOptions {
     payload: FormData | string
 }
 
-async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions) {
+async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+                                 filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
 
@@ -43,11 +45,14 @@ async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, R
         .then((response) => {
             if (response) {
                 commitSelectedDataTypeUpdated(commit, DataType.ANC);
+            } else {
+                commit({type: SurveyAndProgramMutation.ANCErroredFile, payload: filename});
             }
         });
 }
 
-async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions) {
+async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+                                     filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
 
@@ -59,11 +64,14 @@ async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramStat
         .then((response) => {
             if (response) {
                 commitSelectedDataTypeUpdated(commit, DataType.Program);
+            } else {
+                commit({type: SurveyAndProgramMutation.ProgramErroredFile, payload: filename});
             }
         });
 }
 
-async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions) {
+async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+                                    filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
 
@@ -75,6 +83,8 @@ async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState
         .then((response) => {
             if (response) {
                 commitSelectedDataTypeUpdated(commit, DataType.Survey);
+            } else {
+                commit({type: SurveyAndProgramMutation.SurveyErroredFile, payload: filename});
             }
         });
 }
@@ -87,27 +97,33 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
     },
 
     async importSurvey(context, url) {
-        await uploadOrImportSurvey(context, {url: "/adr/survey/", payload: qs.stringify({url})});
+        await uploadOrImportSurvey(context, {url: "/adr/survey/", payload: qs.stringify({url})},
+            getFilenameFromImportUrl(url));
     },
 
     async importProgram(context, url) {
-        await uploadOrImportProgram(context, {url: "/adr/programme/", payload: qs.stringify({url})})
+        await uploadOrImportProgram(context, {url: "/adr/programme/", payload: qs.stringify({url})},
+            getFilenameFromImportUrl(url));
     },
 
     async importANC(context, url) {
-        await uploadOrImportANC(context, {url: "/adr/anc/", payload: qs.stringify({url})})
+        await uploadOrImportANC(context, {url: "/adr/anc/", payload: qs.stringify({url})},
+            getFilenameFromImportUrl(url))
     },
 
     async uploadSurvey(context, formData) {
-        await uploadOrImportSurvey(context, {url: "/disease/survey/", payload: formData})
+        await uploadOrImportSurvey(context, {url: "/disease/survey/", payload: formData},
+            getFilenameFromUploadFormData(formData))
     },
 
     async uploadProgram(context, formData) {
-        await uploadOrImportProgram(context, {url: "/disease/programme/", payload: formData})
+        await uploadOrImportProgram(context, {url: "/disease/programme/", payload: formData},
+            getFilenameFromUploadFormData(formData));
     },
 
     async uploadANC(context, formData) {
-        await uploadOrImportANC(context, {url: "/disease/anc/", payload: formData})
+        await uploadOrImportANC(context, {url: "/disease/anc/", payload: formData},
+            getFilenameFromUploadFormData(formData))
     },
 
     async deleteSurvey(context) {

--- a/src/app/static/src/app/store/surveyAndProgram/mutations.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/mutations.ts
@@ -8,10 +8,13 @@ export enum SurveyAndProgramMutation {
     SelectedDataTypeUpdated = "SelectedDataTypeUpdated",
     SurveyUpdated = "SurveyUpdated",
     SurveyError = "SurveyError",
+    SurveyErroredFile = "SurveyErroredFile",
     ProgramUpdated = "ProgramUpdated",
     ProgramError = "ProgramError",
+    ProgramErroredFile = "ProgramErroredFile",
     ANCUpdated = "ANCUpdated",
     ANCError = "ANCError",
+    ANCErroredFile = "ANCErroredFile",
     Ready = "Ready"
 }
 
@@ -29,28 +32,43 @@ export const mutations: MutationTree<SurveyAndProgramState> = {
     [SurveyAndProgramMutation.SurveyUpdated](state: SurveyAndProgramState, action: PayloadWithType<SurveyResponse>) {
         state.survey = action.payload;
         state.surveyError = null;
+        state.surveyErroredFile = null;
     },
 
     [SurveyAndProgramMutation.SurveyError](state: SurveyAndProgramState, action: PayloadWithType<Error>) {
         state.surveyError = action.payload;
     },
 
+    [SurveyAndProgramMutation.SurveyErroredFile](state: SurveyAndProgramState, action: PayloadWithType<string>) {
+        state.surveyErroredFile = action.payload;
+    },
+
     [SurveyAndProgramMutation.ProgramUpdated](state: SurveyAndProgramState, action: PayloadWithType<ProgrammeResponse>) {
         state.program = action.payload;
         state.programError = null;
+        state.programErroredFile = null;
     },
 
     [SurveyAndProgramMutation.ProgramError](state: SurveyAndProgramState, action: PayloadWithType<Error>) {
         state.programError = action.payload;
     },
 
+    [SurveyAndProgramMutation.ProgramErroredFile](state: SurveyAndProgramState, action: PayloadWithType<string>) {
+        state.programErroredFile = action.payload;
+    },
+
     [SurveyAndProgramMutation.ANCUpdated](state: SurveyAndProgramState, action: PayloadWithType<AncResponse>) {
         state.anc = action.payload;
         state.ancError = null;
+        state.ancErroredFile = null;
     },
 
     [SurveyAndProgramMutation.ANCError](state: SurveyAndProgramState, action: PayloadWithType<Error>) {
         state.ancError = action.payload;
+    },
+
+    [SurveyAndProgramMutation.ANCErroredFile](state: SurveyAndProgramState, action: PayloadWithType<string>) {
+        state.ancErroredFile = action.payload;
     },
 
     [SurveyAndProgramMutation.Ready](state: ReadyState) {

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -12,10 +12,13 @@ export interface SurveyAndProgramState extends ReadyState {
     selectedDataType: DataType | null
     survey: SurveyResponse | null
     surveyError: Error | null
+    surveyErroredFile: string | null
     program: ProgrammeResponse | null
     programError: Error | null
+    programErroredFile: string | null
     anc: AncResponse | null
     ancError: Error | null
+    ancErroredFile: string | null
 }
 
 export const initialSurveyAndProgramState = (): SurveyAndProgramState => {
@@ -23,10 +26,13 @@ export const initialSurveyAndProgramState = (): SurveyAndProgramState => {
         selectedDataType: null,
         survey: null,
         surveyError: null,
+        surveyErroredFile: null,
         program: null,
         programError: null,
+        programErroredFile: null,
         anc: null,
         ancError: null,
+        ancErroredFile: null,
         ready: false
     }
 };

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -224,3 +224,13 @@ function updateGroup(oldGroup: DynamicControlGroup, newGroup: DynamicControlGrou
     return newGroup
 }
 
+export function getFilenameFromImportUrl(url: string) {
+    const parts = url.split("/");
+    return parts[parts.length - 1];
+}
+
+export function getFilenameFromUploadFormData(formdata: FormData) {
+    const file = formdata.get("file");
+    return (file as File).name;
+}
+

--- a/src/app/static/src/tests/baseline/mutations.test.ts
+++ b/src/app/static/src/tests/baseline/mutations.test.ts
@@ -31,6 +31,7 @@ describe("Baseline mutations", () => {
         expect(testState.iso3).toBe("MWI");
         expect(testState.pjnz!!.filename).toBe("file.pjnz");
         expect(testState.pjnzError).toBe(null);
+        expect(testState.pjnzErroredFile).toBe(null);
     });
 
     it("state becomes complete once all files are Updated and validatedConsistent are true", () => {
@@ -78,15 +79,23 @@ describe("Baseline mutations", () => {
         expect(testState.pjnzError).toBe("Some error");
     });
 
+    it("sets error on PJNZErroredFile", () => {
+
+        const testState = mockBaselineState();
+        mutations[BaselineMutation.PJNZErroredFile](testState, {payload: "error.txt"});
+        expect(testState.pjnzErroredFile).toBe("error.txt");
+    });
+
     it("sets country and filename and clears error if present on PJNZUpdated", () => {
 
-        const testState = mockBaselineState({pjnzError: mockError("test")});
+        const testState = mockBaselineState({pjnzError: mockError("test"), pjnzErroredFile: "error.txt"});
         mutations[BaselineMutation.PJNZUpdated](testState, {
             payload: mockPJNZResponse({filename: "file.pjnz", data: {country: "Malawi", iso3: "MWI"}})
         });
         expect(testState.pjnz!!.filename).toBe("file.pjnz");
         expect(testState.country).toBe("Malawi");
         expect(testState.pjnzError).toBe(null);
+        expect(testState.pjnzErroredFile).toBe(null);
     });
 
     it("clears country and filename on PJNZUpdated if no data present", () => {
@@ -103,12 +112,13 @@ describe("Baseline mutations", () => {
     it("sets shape and clears error on ShapeUpdated", () => {
 
         const mockShape = mockShapeResponse();
-        const testState = mockBaselineState({shapeError: null});
+        const testState = mockBaselineState({shapeError: mockError("test error"), shapeErroredFile: "error.txt"});
         mutations[BaselineMutation.ShapeUpdated](testState, {
             payload: mockShape
         });
         expect(testState.shape).toBe(mockShape);
         expect(testState.shapeError).toBe(null);
+        expect(testState.shapeErroredFile).toBe(null);
     });
 
     it("sets region filters and flattened region filters on ShapeUpdated", () => {
@@ -145,21 +155,36 @@ describe("Baseline mutations", () => {
         expect(testState.shapeError).toBe("Some error");
     });
 
+    it("sets error on ShapeErroredFile", () => {
+
+        const testState = mockBaselineState();
+        mutations[BaselineMutation.ShapeErroredFile](testState, {payload: "error.txt"});
+        expect(testState.shapeErroredFile).toBe("error.txt");
+    });
+
     it("sets response and clears error on PopulationUpdated", () => {
 
         const mockPop = mockPopulationResponse();
-        const testState = mockBaselineState({populationError: mockError("test")});
+        const testState = mockBaselineState({populationError: mockError("test"), populationErroredFile: "error.txt"});
         mutations[BaselineMutation.PopulationUpdated](testState, {
             payload: mockPop
         });
         expect(testState.population).toBe(mockPop);
         expect(testState.populationError).toBe(null);
+        expect(testState.populationErroredFile).toBe(null);
     });
 
     it("sets error on PopulationUploadError", () => {
         const testState = mockBaselineState();
         mutations[BaselineMutation.PopulationUploadError](testState, {payload: "Some error"});
         expect(testState.populationError).toBe("Some error");
+    });
+
+    it("sets error on PopulationErroredFile", () => {
+
+        const testState = mockBaselineState();
+        mutations[BaselineMutation.PopulationErroredFile](testState, {payload: "error.txt"});
+        expect(testState.populationErroredFile).toBe("error.txt");
     });
 
     it("sets ready state", () => {

--- a/src/app/static/src/tests/components/baseline/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline/baseline.test.ts
@@ -170,6 +170,42 @@ describe("Baseline upload component", () => {
         expect(wrapper.findAll(ManageFile).at(2).props().accept).toBe("csv,.csv");
     });
 
+    it("passes pjnz response existing file name to manage file", () => {
+        const store = createSut({pjnz: {filename: "existing file"} as any});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(0).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes pjnz errored file to manage file", () => {
+        const store = createSut({pjnzErroredFile: "errored file"});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(0).props("existingFileName")).toBe("errored file");
+    });
+
+    it("passes shape response existing file name to manage file", () => {
+        const store = createSut({shape: {filename: "existing file"} as any});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(1).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes shape errored file to manage file", () => {
+        const store = createSut({shapeErroredFile: "errored file"});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(1).props("existingFileName")).toBe("errored file");
+    });
+
+    it("passes population response existing file name to manage file", () => {
+        const store = createSut({population: {filename: "existing file"} as any});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(2).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes population errored file to manage file", () => {
+        const store = createSut({populationErroredFile: "errored file"});
+        const wrapper = shallowMount(Baseline, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(2).props("existingFileName")).toBe("errored file");
+    });
+
     it("upload pjnz dispatches baseline/uploadPJNZ", (done) => {
         expectUploadToDispatchAction(0, () => actions.uploadPJNZ, done);
     });

--- a/src/app/static/src/tests/components/files/manageFile.test.ts
+++ b/src/app/static/src/tests/components/files/manageFile.test.ts
@@ -106,9 +106,10 @@ describe("Manage file component", () => {
         expect(wrapper.findAll(Tick).length).toBe(1);
     });
 
-    it("does not render remove link if filename is not present", () => {
+    it("does not render remove link if filename is not present and error is not present", () => {
         const wrapper = createSut({
-            existingFileName: null
+            existingFileName: null,
+            error: null
         });
         expect(wrapper.findAll("a").length).toBe(0);
     });
@@ -117,6 +118,21 @@ describe("Manage file component", () => {
         const removeHandler = jest.fn();
         const wrapper = createSut({
             existingFileName: "File.csv",
+            deleteFile: removeHandler
+        });
+        const removeLink = wrapper.find("a");
+        expect(removeLink.text()).toBe("remove");
+
+        removeLink.trigger("click");
+
+        expect(removeHandler.mock.calls.length).toBe(1);
+    });
+
+    it("renders remove link if error is present", () => {
+        const removeHandler = jest.fn();
+        const wrapper = createSut({
+            existingFileName: null,
+            error: mockError("test error"),
             deleteFile: removeHandler
         });
         const removeLink = wrapper.find("a");

--- a/src/app/static/src/tests/components/files/manageFile.test.ts
+++ b/src/app/static/src/tests/components/files/manageFile.test.ts
@@ -138,6 +138,9 @@ describe("Manage file component", () => {
         const removeLink = wrapper.find("a");
         expect(removeLink.text()).toBe("remove");
 
+        //should not render File label if no existing filename
+        expectTranslated(wrapper.find(".file-name"), "remove", "supprimer", wrapper.vm.$store);
+
         removeLink.trigger("click");
 
         expect(removeHandler.mock.calls.length).toBe(1);

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -301,6 +301,42 @@ describe("Survey and programme component", () => {
         );
     });
 
+    it("passes survey response existing file name to manage file", () => {
+        const store = createStore({survey: {filename: "existing file"} as any});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(0).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes survey errored file to manage file", () => {
+        const store = createStore({surveyErroredFile: "errored file"});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(0).props("existingFileName")).toBe("errored file");
+    });
+
+    it("passes program response existing file name to manage file", () => {
+        const store = createStore({program: {filename: "existing file"} as any});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(1).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes program errored file to manage file", () => {
+        const store = createStore({programErroredFile: "errored file"});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(1).props("existingFileName")).toBe("errored file");
+    });
+
+    it("passes anc response existing file name to manage file", () => {
+        const store = createStore({anc: {filename: "existing file"} as any});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(2).props("existingFileName")).toBe("existing file");
+    });
+
+    it("passes anc errored file to manage file", () => {
+        const store = createStore({ancErroredFile: "errored file"});
+        const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
+        expect(wrapper.findAll(ManageFile).at(2).props("existingFileName")).toBe("errored file");
+    });
+
     it("can return true when fromADR", async () => { 
         const store = createStore({
             survey: {

--- a/src/app/static/src/tests/integration/helpers.ts
+++ b/src/app/static/src/tests/integration/helpers.ts
@@ -5,5 +5,6 @@ export function getFormData(fileName: string): FormData {
     const file = fs.createReadStream(`../testdata/${fileName}`);
     const formData = new FormData();
     formData.append('file', file);
+    formData.get = (name: string) => { return name == 'file' ? File : null };
     return formData
 }

--- a/src/app/static/src/tests/integration/load.itest.ts
+++ b/src/app/static/src/tests/integration/load.itest.ts
@@ -10,6 +10,7 @@ import Vuex from "vuex";
 import {emptyState} from "../../app/root";
 import {localStorageManager} from "../../app/localStorageManager";
 import {currentHintVersion} from "../../app/hintVersion";
+import {getFormData} from "./helpers";
 
 const fs = require("fs");
 const FormData = require("form-data");
@@ -20,9 +21,8 @@ describe("load actions", () => {
     beforeAll(async () => {
         await login();
         const commit = jest.fn();
-        const file = fs.createReadStream("../testdata/malawi.geojson");
-        const formData = new FormData();
-        formData.append('file', file);
+        const formData = getFormData("../testdata/malawi.geojson");
+
         await baselineActions.uploadShape({commit, dispatch: jest.fn(), rootState} as any, formData);
         shape = (commit.mock.calls[1][0]["payload"] as ShapeResponse);
     });

--- a/src/app/static/src/tests/integration/modelOptions.itest.ts
+++ b/src/app/static/src/tests/integration/modelOptions.itest.ts
@@ -5,6 +5,7 @@ import {actions as surveyActions} from "../../app/store/surveyAndProgram/actions
 import {isDynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import { ModelOptionsMutation } from "../../app/store/modelOptions/mutations";
 import { Language } from "../../app/store/translations/locales";
+import {getFormData} from "./helpers";
 
 const fs = require("fs");
 const FormData = require("form-data");
@@ -16,15 +17,12 @@ describe("model options actions integration", () => {
 
         const commit = jest.fn();
         const dispatch = jest.fn();
-        let file = fs.createReadStream("../testdata/malawi.geojson");
-        let formData = new FormData();
-        formData.append('file', file);
+
+        let formData = getFormData("../testdata/malawi.geojson") ;
 
         await baselineActions.uploadShape({commit, dispatch, rootState} as any, formData);
 
-        file = fs.createReadStream("../testdata/survey.csv");
-        formData = new FormData();
-        formData.append('file', file);
+        formData = getFormData("../testdata/survey.csv") ;
 
         await surveyActions.uploadSurvey({commit, dispatch, rootState} as any, formData);
     });

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -15,6 +15,7 @@ import {
 import {localStorageManager, serialiseState} from "../app/localStorageManager";
 import {RootState} from "../app/root";
 import {DataType} from "../app/store/surveyAndProgram/surveyAndProgram";
+import {currentHintVersion} from "../app/hintVersion";
 
 declare const currentUser: string; // set in jest config, or on the index page when run for real
 
@@ -110,7 +111,7 @@ describe("LocalStorageManager", () => {
         const testState = {baseline: mockBaselineState()};
         localStorageManager.savePartialState(testState);
 
-        expect(spy.mock.calls[0][0]).toBe("hintAppState_v1.0.0");
+        expect(spy.mock.calls[0][0]).toBe(`hintAppState_v${currentHintVersion}`);
         expect(spy.mock.calls[0][1]).toBe(JSON.stringify(testState));
     });
 });

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -16,6 +16,9 @@ import Mock = jest.Mock;
 
 const FormData = require("form-data");
 const rootState = mockRootState();
+const mockFormData = {
+    get: (key: string) => { return key == "file" ? {name: "file.txt"} : null; }
+};
 
 describe("Survey and programme actions", () => {
 
@@ -35,7 +38,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess({data: "SOME DATA"}));
 
         const commit = jest.fn();
-        await actions.uploadSurvey({commit, rootState} as any, new FormData());
+        await actions.uploadSurvey({commit, rootState} as any, mockFormData as any);
 
         checkSurveyImportUpload(commit);
     });
@@ -73,7 +76,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadSurvey({commit, rootState} as any, new FormData());
+        await actions.uploadSurvey({commit, rootState} as any, mockFormData as FormData);
 
         checkFailedSurveyImportUpload(commit);
     });
@@ -84,12 +87,13 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.importSurvey({commit, rootState} as any, "some-url");
+        await actions.importSurvey({commit, rootState} as any, "some-url/file.txt");
 
         checkFailedSurveyImportUpload(commit);
     });
 
     const checkFailedSurveyImportUpload = (commit: Mock) => {
+        expect(commit.mock.calls.length).toBe(3);
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.SurveyUpdated,
             payload: null
@@ -99,8 +103,10 @@ describe("Survey and programme actions", () => {
             payload: mockError("error message")
         });
 
-        //Should not have set selectedDataType
-        expect(commit.mock.calls.length).toEqual(2);
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: SurveyAndProgramMutation.SurveyErroredFile,
+            payload: "file.txt"
+        });
     }
 
     it("sets data after programme file upload", async () => {
@@ -109,7 +115,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess("TEST"));
 
         const commit = jest.fn();
-        await actions.uploadProgram({commit, rootState} as any, new FormData());
+        await actions.uploadProgram({commit, rootState} as any, mockFormData as any);
 
         checkProgrammeImportUpload(commit)
     });
@@ -147,7 +153,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadProgram({commit, rootState} as any, new FormData());
+        await actions.uploadProgram({commit, rootState} as any, mockFormData as FormData);
 
         checkFailedProgramImportUpload(commit);
     });
@@ -158,12 +164,13 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.importProgram({commit, rootState} as any, "some-url");
+        await actions.importProgram({commit, rootState} as any, "some-url/file.txt");
 
         checkFailedProgramImportUpload(commit);
     });
 
     const checkFailedProgramImportUpload = (commit: Mock) => {
+        expect(commit.mock.calls.length).toEqual(3);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramUpdated,
@@ -175,8 +182,10 @@ describe("Survey and programme actions", () => {
             payload: mockError("error message")
         });
 
-        //Should not have set selectedDataType
-        expect(commit.mock.calls.length).toEqual(2);
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: SurveyAndProgramMutation.ProgramErroredFile,
+            payload: "file.txt"
+        });
     }
 
     it("sets data after anc file upload", async () => {
@@ -185,7 +194,7 @@ describe("Survey and programme actions", () => {
             .reply(200, mockSuccess("TEST"));
 
         const commit = jest.fn();
-        await actions.uploadANC({commit, rootState} as any, new FormData());
+        await actions.uploadANC({commit, rootState} as any, mockFormData as any);
 
         checkANCImportUpload(commit);
     });
@@ -223,7 +232,7 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.uploadANC({commit, rootState} as any, new FormData());
+        await actions.uploadANC({commit, rootState} as any, mockFormData as any);
 
         checkFailedANCImportUpload(commit);
     });
@@ -234,12 +243,14 @@ describe("Survey and programme actions", () => {
             .reply(500, mockFailure("error message"));
 
         const commit = jest.fn();
-        await actions.importANC({commit, rootState} as any, "some-url");
+        await actions.importANC({commit, rootState} as any, "some-url/file.txt");
 
         checkFailedANCImportUpload(commit);
     });
 
     const checkFailedANCImportUpload = (commit: Mock) => {
+        expect(commit.mock.calls.length).toEqual(3);
+
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCUpdated,
             payload: null
@@ -250,8 +261,10 @@ describe("Survey and programme actions", () => {
             payload: mockError("error message")
         });
 
-        //Should not have set selectedDataType
-        expect(commit.mock.calls.length).toEqual(2);
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: SurveyAndProgramMutation.ANCErroredFile,
+            payload: "file.txt"
+        });
     }
 
     it("gets data, commits it and marks state ready", async () => {

--- a/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
@@ -28,11 +28,12 @@ describe("Survey and programme mutations", () => {
     });
 
     it("sets surveys data and filename and clears error on SurveyUpdated", () => {
-        const testState = mockSurveyAndProgramState({surveyError: mockError("test")});
+        const testState = mockSurveyAndProgramState({surveyError: mockError("test"), surveyErroredFile: "error.txt"});
         mutations[SurveyAndProgramMutation.SurveyUpdated](testState, testPayload);
         expect(testState.survey!!.data).toStrictEqual(testData);
         expect(testState.survey!!.filename).toBe("somefile.csv");
         expect(testState.surveyError).toBe(null);
+        expect(testState.surveyErroredFile).toBe(null);
     });
 
     it("sets error on SurveyError", () => {
@@ -41,13 +42,20 @@ describe("Survey and programme mutations", () => {
         expect(testState.surveyError).toBe("Some error");
     });
 
+    it("sets errored file on SurveyErroredFile", () => {
+        const testState = mockSurveyAndProgramState();
+        mutations[SurveyAndProgramMutation.SurveyErroredFile](testState, {payload: "error.txt"});
+        expect(testState.surveyErroredFile).toBe("error.txt");
+    });
+
     it("sets programme data and filename and clears error on ProgramUpdated", () => {
-        const testState = mockSurveyAndProgramState({programError: mockError("test")});
+        const testState = mockSurveyAndProgramState({programError: mockError("test"), programErroredFile: "error.txt"});
         mutations[SurveyAndProgramMutation.ProgramUpdated](testState, testPayload);
 
         expect(testState.program!!.data).toStrictEqual(testData);
         expect(testState.program!!.filename).toBe("somefile.csv");
         expect(testState.programError).toBe(null);
+        expect(testState.programErroredFile).toBe(null);
     });
 
     it("sets error on ProgramError", () => {
@@ -57,18 +65,31 @@ describe("Survey and programme mutations", () => {
         expect(testState.programError).toBe("Some error");
     });
 
+    it("sets errored file on SurveyErroredFile", () => {
+        const testState = mockSurveyAndProgramState();
+        mutations[SurveyAndProgramMutation.ProgramErroredFile](testState, {payload: "error.txt"});
+        expect(testState.programErroredFile).toBe("error.txt");
+    });
+
     it("sets anc data and filename and clears error on ANCUpdated", () => {
-        const testState = mockSurveyAndProgramState({ancError: mockError("test")});
+        const testState = mockSurveyAndProgramState({ancError: mockError("test"), ancErroredFile: "error.txt"});
         mutations[SurveyAndProgramMutation.ANCUpdated](testState, testPayload);
         expect(testState.anc!!.data).toStrictEqual(testData);
         expect(testState.anc!!.filename).toBe("somefile.csv");
         expect(testState.ancError).toBe(null);
+        expect(testState.ancErroredFile).toBe(null);
     });
 
     it("sets error on ANCError", () => {
         const testState = mockSurveyAndProgramState();
         mutations[SurveyAndProgramMutation.ANCError](testState, {payload: "Some error"});
         expect(testState.ancError).toBe("Some error");
+    });
+
+    it("sets errored file on ANCErroredFile", () => {
+        const testState = mockSurveyAndProgramState();
+        mutations[SurveyAndProgramMutation.ANCErroredFile](testState, {payload: "error.txt"});
+        expect(testState.ancErroredFile).toBe("error.txt");
     });
 
     it("is complete once survey file is present", () => {

--- a/src/app/static/src/tests/testHelpers.ts
+++ b/src/app/static/src/tests/testHelpers.ts
@@ -14,6 +14,9 @@ export function expectEqualsFrozen(args: PayloadWithType<any>, expected: Payload
 export function testUploadErrorCommitted(url: string,
                                          expectedErrorType: string,
                                          expectedSuccessType: string,
+                                         expectedErroredFileType: string,
+                                         expectedErroredFilename: string,
+                                         formData: any,
                                          action: (store: ActionContext<any, any>, formData: FormData) => void) {
 
     it(`commits error message when ${url} fails`, async () => {
@@ -25,7 +28,7 @@ export function testUploadErrorCommitted(url: string,
         const state = mockBaselineState();
         const dispatch = jest.fn();
         const rootState = mockRootState();
-        await action({commit, state, dispatch, rootState} as any, new FormData());
+        await action({commit, state, dispatch, rootState} as any, formData);
 
         // first call to clear the data
         expect(commit.mock.calls[0][0]).toStrictEqual({
@@ -37,6 +40,11 @@ export function testUploadErrorCommitted(url: string,
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: expectedErrorType,
             payload: mockError("Something went wrong")
+        });
+
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: expectedErroredFileType,
+            payload: expectedErroredFilename
         });
     });
 }


### PR DESCRIPTION
I *think* this change is all we need to do to address the issue of not being able to remove files with errors - it allows the delete request to be sent to the backend when there was any error with the upload. 

I believe this works in all cases, both when file save fails (I had to temporarily sabotage the controller method to test this) and when the subsequent validate fails. In both cases the delete request triggered by the 'remove' click returns a 200 so there are no further errors, the existing error is cleared and subsequent step is enabled 

It does look a little bit odd because you have the 'remove' link as you do when you have a (successful) file name, but no file name (I've hidden the File label in this case, but the control still expands to add the remove link). So it does look like you're being invited to remove something that isn't there - we don't actually get the filename back from the server if there's an error. An alternative might be to use a 'clear error' link next to the error instead.