### PR TITLE
mrc-1949 Add action to make tagged release on merge to master

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ env.RELEASE_VERSION }}
+          tag_name: ${{ env.RELEASE_VERSION }}
           release_name: Release hint ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: false

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set env
         run: |
-          if ["${{steps.checkTag.outputs.exists}}" == "false"];
+          if [ "${{steps.checkTag.outputs.exists}}" == "false" ];
           then
             echo "CREATE_RELEASE=true" >> GITHUB_ENV
           else

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
+      - name: Test tags
         run: |
           echo ${{steps.checkTag.outputs.exists}}
           echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -28,10 +28,10 @@ jobs:
       - name: Test
         run: |
           echo ${{steps.checkTag.outputs.exists}}
-          echo $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
+          echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
-        if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
+        if: [ "${{steps.checkTag.outputs.exists}}" == "false" ]
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -31,7 +31,7 @@ jobs:
           echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
-        if: [ "${{steps.checkTag.outputs.exists}}" == "false" ]
+        if: ${{ "${{steps.checkTag.outputs.exists}}" == "false" }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Test
         run: |
-        echo tag=${{ env.RELEASE_VERSION }}
-        echo tagExists=${{ steps.checkTag.outputs.exists }}
+          echo tag=${{ env.RELEASE_VERSION }}
+          echo tagExists=${{ steps.checkTag.outputs.exists }}
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -33,6 +33,9 @@ jobs:
           else
             echo "CREATE_RELEASE=false" >> GITHUB_ENV
           fi
+      - name: Test
+        run: echo ${{env.CREATE_RELEASE}}
+
       - name: Create release
         if: env.CREATE_RELEASE
         run: echo "creating release..."

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -27,10 +27,11 @@ jobs:
 
       - name: Set env
         run: |
-          doRelease = "false"
-          if ["${{steps.checkTag.outputs.exists}}" == "false] doRelease = true fi
-          echo "CREATE_RELEASE=$doRelease" >> GITHUB_ENV
-
+          if ["${{steps.checkTag.outputs.exists}}" == "false"]
+            echo "CREATE_RELEASE='true'" >> GITHUB_ENV
+          else
+             echo "CREATE_RELEASE='false'" >> GITHUB_ENV
+          fi
       - name: Create release
         if: env.CREATE_RELEASE
         run: echo "creating release..."

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -37,6 +37,6 @@ jobs:
         run: echo ${{env.CREATE_RELEASE}}
 
       - name: Create release
-        if: [ "${{steps.checkTag.outputs.exists}}" == "false" ];
+        if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -30,7 +30,7 @@ jobs:
           doRelease = "false"
           if ["${{steps.checkTag.outputs.exists}}" == "false] doRelease = true fi
           echo "CREATE_RELEASE=$doRelease" >> GITHUB_ENV
-          echo "doRelease is $doRelease"
+          echo doRelease is $doRelease
 
       - name: Create release
         if: env.CREATE_RELEASE

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "RELEASE_VERSION=$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+          echo "::set-env name=RELEASE_VERSION::$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)"
 
       - name: Test
-        run: echo ${ env.RELEASE_VERSION }
+        run: echo ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -29,9 +29,9 @@ jobs:
         run: |
           if [ "${{steps.checkTag.outputs.exists}}" == "false" ];
           then
-            echo "CREATE_RELEASE=true" >> GITHUB_ENV
+            echo "CREATE_RELEASE=true" >> $GITHUB_ENV
           else
-            echo "CREATE_RELEASE=false" >> GITHUB_ENV
+            echo "CREATE_RELEASE=false" >> $GITHUB_ENV
           fi
       - name: Test
         run: echo ${{env.CREATE_RELEASE}}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - master
+      - mrc-1949
+
+name: make-release
+
+jobs:
+  create-release:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version
+        run: |
+          echo "RELEASE_VERSION=$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+
+      - name: Test
+        run: echo ${ env.RELEASE_VERSION }

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - mrc-1949
 
 name: make-release
 
@@ -15,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Extract version from NEWS.md
-        run: echo "RELEASE_VERSION=test-action-$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=v$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Check if release tag exists
         uses: mukunku/tag-exists-action@v1.0.0
@@ -24,11 +23,6 @@ jobs:
           tag: ${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Test tags
-        run: |
-          echo ${{steps.checkTag.outputs.exists}}
-          echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
         if: ${{ steps.checkTag.outputs.exists == 'false' }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -26,9 +26,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
-        - run: |
-            echo ${{steps.checkTag.outputs.exists}}
-            echo $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
+        run: |
+          echo ${{steps.checkTag.outputs.exists}}
+          echo $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
         if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,18 +25,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set CREATE_RELEASE
-        run: |
-          if [ "${{steps.checkTag.outputs.exists}}" == "false" ];
-          then
-            echo "CREATE_RELEASE=true" >> $GITHUB_ENV
-          else
-            echo "CREATE_RELEASE=false" >> $GITHUB_ENV
-          fi
-      - name: Test
-        run: echo ${{env.CREATE_RELEASE}}
-
       - name: Create release
         if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
-        run: echo "creating release..."
+        uses: actions/create-release@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: v${{ env.RELEASE_VERSION }}
+            release_name: Release hint ${{ env.RELEASE_VERSION }}
+            draft: false
+            prerelease: false
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -31,7 +31,7 @@ jobs:
           echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
-        if: ${{ steps.checkTag.outputs.exists == "false" }}
+        if: ${{ steps.checkTag.outputs.exists == 'false' }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -29,9 +29,9 @@ jobs:
         run: |
           if ["${{steps.checkTag.outputs.exists}}" == "false"]
           then
-            echo "CREATE_RELEASE='true'" >> GITHUB_ENV
+            echo "CREATE_RELEASE=true" >> GITHUB_ENV
           else
-            echo "CREATE_RELEASE='false'" >> GITHUB_ENV
+            echo "CREATE_RELEASE=false" >> GITHUB_ENV
           fi
       - name: Create release
         if: env.CREATE_RELEASE

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Extract version from NEWS.md
-        run: echo "RELEASE_VERSION=v$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=test-action-$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Check if release tag exists
         uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Extract version
+      - name: Extract version from NEWS.md
         run: echo "RELEASE_VERSION=v$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Check if release tag exists

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set env
+      - name: Set CREATE_RELEASE
         run: |
           if [ "${{steps.checkTag.outputs.exists}}" == "false" ];
           then
@@ -37,6 +37,6 @@ jobs:
         run: echo ${{env.CREATE_RELEASE}}
 
       - name: Create release
-        if: env.CREATE_RELEASE
+        if: [ "${{steps.checkTag.outputs.exists}}" == "false" ];
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -28,5 +28,9 @@ jobs:
       - name: Test
         run: |
           echo tag=${{ env.RELEASE_VERSION }}
-          echo tagExists=${{ steps.checkTag.outputs.exists }}
+          echo tagNotExists=${{ !steps.checkTag.outputs.exists }}
+
+      - name: Create release
+        if: ${{ !steps.checkTag.outputs.exists }}
+        run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "::set-env name=RELEASE_VERSION::$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)"
+          echo "RELEASE_VERSION::$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Test
         run: echo ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -31,7 +31,7 @@ jobs:
           echo [ "${{steps.checkTag.outputs.exists}}" == "false" ]
 
       - name: Create release if tag does not exist
-        if: ${{ "${{steps.checkTag.outputs.exists}}" == "false" }}
+        if: ${{ steps.checkTag.outputs.exists == "false" }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -14,8 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version
-        run: |
-          echo "RELEASE_VERSION=$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=v$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Test
         run: echo ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -26,6 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        if: [steps.checkTag.outputs.exists != "true"]
+        if: steps.checkTag.outputs.exists != "true"
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -28,9 +28,9 @@ jobs:
       - name: Test
         run: |
           echo tag=${{ env.RELEASE_VERSION }}
-          echo tagNotExists=${{ !steps.checkTag.outputs.exists }}
+          echo tagNotExists=${{ ! steps.checkTag.outputs.exists }}
 
       - name: Create release
-        if: ${{ !steps.checkTag.outputs.exists }}
+        if: ${{ ! steps.checkTag.outputs.exists }}
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,12 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        run: |
-          echo tag=${{ env.RELEASE_VERSION }}
-          echo tagNotExists=${{ ! steps.checkTag.outputs.exists }}
-
       - name: Create release
-        if: ${{ ! steps.checkTag.outputs.exists }}
+        if: [steps.checkTag.outputs.exists != "true"]
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -30,7 +30,6 @@ jobs:
           doRelease = "false"
           if ["${{steps.checkTag.outputs.exists}}" == "false] doRelease = true fi
           echo "CREATE_RELEASE=$doRelease" >> GITHUB_ENV
-          echo doRelease is ${{doRelease}}
 
       - name: Create release
         if: env.CREATE_RELEASE

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -11,10 +11,22 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Extract version
         run: echo "RELEASE_VERSION=v$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
+      - name: Check if release tag exists
+        uses: mukunku/tag-exists-action@v1.0.0
+        id: checkTag
+        with:
+          tag: ${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test
-        run: echo ${{ env.RELEASE_VERSION }}
+        run: |
+        echo tag=${{ env.RELEASE_VERSION }}
+        echo tagExists=${{ steps.checkTag.outputs.exists }}
+

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,14 +25,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create release
+      - name: Create release if tag does not exist
         if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
         uses: actions/create-release@v1
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            tag_name: v${{ env.RELEASE_VERSION }}
-            release_name: Release hint ${{ env.RELEASE_VERSION }}
-            draft: false
-            prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.RELEASE_VERSION }}
+          release_name: Release hint ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,6 +25,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test
+        - run: |
+            echo ${{steps.checkTag.outputs.exists}}
+            echo $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
+
       - name: Create release if tag does not exist
         if: $[ "${{steps.checkTag.outputs.exists}}" == "false" ]
         uses: actions/create-release@v1

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set env
         run: |
-          if ["${{steps.checkTag.outputs.exists}}" == "false"]
+          if ["${{steps.checkTag.outputs.exists}}" == "false"];
           then
             echo "CREATE_RELEASE=true" >> GITHUB_ENV
           else

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "RELEASE_VERSION::$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(awk '($1 == "#") && ($2 == "hint"){print $3; exit;}' NEWS.md)" >> $GITHUB_ENV
 
       - name: Test
         run: echo ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,7 +25,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set env
+        run: |
+          doRelease = "false"
+          if ["${{steps.checkTag.outputs.exists}}" == "false] doRelease = true fi
+          echo "CREATE_RELEASE=$doRelease" >> GITHUB_ENV
+          echo "doRelease is $doRelease"
+
       - name: Create release
-        if: steps.checkTag.outputs.exists != "true"
+        if: env.CREATE_RELEASE
         run: echo "creating release..."
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -28,9 +28,10 @@ jobs:
       - name: Set env
         run: |
           if ["${{steps.checkTag.outputs.exists}}" == "false"]
+          then
             echo "CREATE_RELEASE='true'" >> GITHUB_ENV
           else
-             echo "CREATE_RELEASE='false'" >> GITHUB_ENV
+            echo "CREATE_RELEASE='false'" >> GITHUB_ENV
           fi
       - name: Create release
         if: env.CREATE_RELEASE

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -30,7 +30,7 @@ jobs:
           doRelease = "false"
           if ["${{steps.checkTag.outputs.exists}}" == "false] doRelease = true fi
           echo "CREATE_RELEASE=$doRelease" >> GITHUB_ENV
-          echo doRelease is $doRelease
+          echo doRelease is ${{doRelease}}
 
       - name: Create release
         if: env.CREATE_RELEASE


### PR DESCRIPTION
This action pulls out the latest version defined in NEWS.md and creates a release from it, if the tag does not already exist (not doing automatic version numbering at this point). This will only happen on push/master to master branch, though I previously had it running on this branch, and you'll see it has created a couple of releases, for a test tag and v1.0.0 (the current version). 

As you can see from the commit history, it's been quite a journey - this was mostly me being inept about how to define the conditional to run the release step only if tag didn't already exist. It eventually seemed to work when I RTFM - the last two commits but one created, then didn't attempt to create, the release as expected. 

The build is failing because of the ADR tests!