### PR TITLE
mrc-1952 User can choose to scale bubble size by filtered dataset or entire dataset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.1.0
+
+* Bubble plot size can be scaled by filtered dataset
+
 # hint 1.0.0
 
 * ADR integration

--- a/buildkite/test-adr-front-end-integration.sh
+++ b/buildkite/test-adr-front-end-integration.sh
@@ -13,7 +13,7 @@ trap cleardocker EXIT
 $HERE/run-dependencies-for-integration-tests.sh
 
 # Wait for HINT to become responsive
-sleep 5
+sleep 10
 
 # Create an image based on the shared build env that compiles and tests the front-end ADR integration
 docker build --tag hint-test-adr \

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -104,7 +104,7 @@
     import {
         BarchartSelections,
         BubblePlotSelections,
-        ChoroplethSelections, ColourScaleSelections,
+        ChoroplethSelections, ScaleSelections,
         PlottingSelectionsState
     } from "../../store/plottingSelections/plottingSelections";
     import {ModelOutputState} from "../../store/modelOutput/modelOutput";
@@ -129,7 +129,7 @@
         tabSelected: (tab: string) => void
         updateBarchartSelections: (data: BarchartSelections) => void
         updateBubblePlotSelections: (data: BubblePlotSelections) => void
-        updateOutputColourScales: (colourScales: ColourScaleSelections) => void
+        updateOutputColourScales: (colourScales: ScaleSelections) => void
         formatBarchartValue: (value: string | number, indicator: BarchartIndicator) => string
     }
 
@@ -148,7 +148,7 @@
         featureLevels: LevelLabel[]
         currentLanguage: Language,
         filterConfig: FilterConfig,
-        colourScales: ColourScaleSelections,
+        colourScales: ScaleSelections,
         choroplethIndicators: ChoroplethIndicatorMetadata[],
         bubblePlotIndicators: ChoroplethIndicatorMetadata[],
         filteredChoroplethIndicators: ChoroplethIndicatorMetadata[],

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -70,8 +70,10 @@
                              :selections="bubblePlotSelections"
                              area-filter-id="area"
                              :colour-scales="colourScales"
+                             :size-scales="bubbleSizeScales"
                              @update="updateBubblePlotSelections({payload: $event})"
-                             @update-colour-scales="updateOutputColourScales({payload: $event})"></bubble-plot>
+                             @update-colour-scales="updateOutputColourScales({payload: $event})"
+                             @update-size-scales="updateOutputBubbleSizeScales({payload: $event})"></bubble-plot>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <table-view class="col-md-9"
@@ -130,6 +132,7 @@
         updateBarchartSelections: (data: BarchartSelections) => void
         updateBubblePlotSelections: (data: BubblePlotSelections) => void
         updateOutputColourScales: (colourScales: ScaleSelections) => void
+        updateOutputBubbleSizeScales: (colourScales: ScaleSelections) => void
         formatBarchartValue: (value: string | number, indicator: BarchartIndicator) => string
     }
 
@@ -149,6 +152,7 @@
         currentLanguage: Language,
         filterConfig: FilterConfig,
         colourScales: ScaleSelections,
+        bubbleSizeScales: ScaleSelections,
         choroplethIndicators: ChoroplethIndicatorMetadata[],
         bubblePlotIndicators: ChoroplethIndicatorMetadata[],
         filteredChoroplethIndicators: ChoroplethIndicatorMetadata[],
@@ -184,7 +188,8 @@
                 barchartSelections: state => state.barchart,
                 bubblePlotSelections: state => state.bubble,
                 choroplethSelections: state => state.outputChoropleth,
-                colourScales: state => state.colourScales.output
+                colourScales: state => state.colourScales.output,
+                bubbleSizeScales: state => state.bubbleSizeScales.output
             }),
             ...mapStateProps<BaselineState, keyof Computed>("baseline", {
                     features: state => state.shape!.data.features as Feature[],
@@ -225,7 +230,7 @@
         methods: {
             ...mapMutationsByNames<keyof Methods>("plottingSelections",
                 ["updateBarchartSelections", "updateBubblePlotSelections", "updateOutputChoroplethSelections",
-                    "updateOutputColourScales"]),
+                    "updateOutputColourScales", "updateOutputBubbleSizeScales"]),
             tabSelected: mapMutationByName<keyof Methods>("modelOutput", ModelOutputMutation.TabSelected),
             formatBarchartValue: (value: string | number, indicator: BarchartIndicator) => {
                 return formatOutput(value, indicator.format, indicator.scale, indicator.accuracy).toString();

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -81,7 +81,7 @@ import {ScaleType} from "../../store/colourScales/colourScales";
 
     interface Props {
         show: boolean,
-        colourScale: ScaleSettings,
+        scale: ScaleSettings,
         step: number,
         metadata: any,
         hideStaticDefault: boolean,
@@ -95,7 +95,7 @@ import {ScaleType} from "../../store/colourScales/colourScales";
     }
 
     interface Data {
-        colourScaleToAdjust: ScaleSettings
+        scaleToAdjust: ScaleSettings
     }
 
     interface Methods {
@@ -106,7 +106,7 @@ import {ScaleType} from "../../store/colourScales/colourScales";
         name: "MapAdjustScale",
         props: {
             show: Boolean,
-            colourScale: Object,
+            scale: Object,
             step: Number,
             metadata: Object,
             hideStaticDefault: Boolean,
@@ -114,15 +114,15 @@ import {ScaleType} from "../../store/colourScales/colourScales";
         },
         data(): any {
             return {
-                colourScaleToAdjust: {...this.colourScale},
+                colourScaleToAdjust: {...this.scale},
                 ColourScaleType: ScaleType
             };
         },
         computed: {
             invalidMsg() {
                 let result = null;
-                if (this.colourScaleToAdjust.type == ScaleType.Custom) {
-                    if (this.colourScaleToAdjust.customMin >= this.colourScaleToAdjust.customMax) {
+                if (this.scaleToAdjust.type == ScaleType.Custom) {
+                    if (this.scaleToAdjust.customMin >= this.sScaleToAdjust.customMax) {
                         result = i18next.t("maxMustBeGreaterThanMin");
                     }
                 }
@@ -130,7 +130,7 @@ import {ScaleType} from "../../store/colourScales/colourScales";
                 return result;
             },
             disableCustom() {
-                return this.colourScaleToAdjust.type != ScaleType.Custom;
+                return this.scaleToAdjust.type != ScaleType.Custom;
             },
             scaleText(){
                 const { format, scale, accuracy} = this.metadata
@@ -142,13 +142,13 @@ import {ScaleType} from "../../store/colourScales/colourScales";
         methods: {
             update: function () {
                 if (this.invalidMsg == null) {
-                    this.$emit("update", this.colourScaleToAdjust)
+                    this.$emit("update", this.scaleToAdjust)
                 }
             }
         },
         watch: {
             colourScale: function () {
-                this.colourScaleToAdjust = {...this.colourScale};
+                this.scaleToAdjust = {...this.scale};
             }
         }
     });

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -1,4 +1,4 @@
-import {ScaleType} from "../../store/colourScales/colourScales";
+import {ScaleType} from "../../store/plottingSelections/plottingSelections";
 <template>
     <div v-if="show" class="pt-2 pl-3">
         <div v-if="!(hideStaticCustom && hideStaticDefault)" class="static-container">
@@ -7,16 +7,16 @@ import {ScaleType} from "../../store/colourScales/colourScales";
                 <div v-if="!hideStaticDefault" class="form-check static-default">
                     <label class="form-check-label">
                         <input id="type-input-default" class="form-check-input" type="radio" name="scaleType"
-                               :value="ColourScaleType.Default"
-                               v-model="colourScaleToAdjust.type" @change="update">
+                               :value="ScaleType.Default"
+                               v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'default'"></span>
                     </label>
                 </div>
                 <div v-if="!hideStaticCustom" class="form-check mt-1 static-custom">
                     <label class="form-check-label">
                         <input id="type-input-custom" class="form-check-input" type="radio" name="scaleType"
-                               :value="ColourScaleType.Custom"
-                               v-model="colourScaleToAdjust.type" @change="update">
+                               :value="ScaleType.Custom"
+                               v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'custom'"></span>
                     </label>
                 </div>
@@ -27,50 +27,51 @@ import {ScaleType} from "../../store/colourScales/colourScales";
                             <label for="custom-min-input" class="col col-form-label col-2"><span v-translate="'min'"></span></label>
                             <div class="col pt-1 pr-1">
                                 <input id="custom-min-input" type="number" :step="step"
-                                       v-model.number="colourScaleToAdjust.customMin"
-                                       :max="colourScaleToAdjust.customMax"
+                                       v-model.number="scaleToAdjust.customMin"
+                                       :max="scaleToAdjust.customMax"
                                        @change="update" @keyup="update" :disabled="disableCustom">
                             </div>
-                            <p v-if="colourScaleToAdjust.customMin" class="col col-form-label pl-0">{{ scaleText}}</p>
+                            <p v-if="scaleToAdjust.customMin" class="col col-form-label pl-0">{{ scaleText}}</p>
                         </div>
                         <div class="row">
                             <label class="col col-form-label col-2" for="custom-max-input"><span v-translate="'max'"></span></label>
                             <div class="col pt-1 pr-1">
                                 <input id="custom-max-input" type="number" :step="step"
-                                       v-model.number="colourScaleToAdjust.customMax"
-                                       :min="colourScaleToAdjust.customMin"
+                                       v-model.number="scaleToAdjust.customMax"
+                                       :min="scaleToAdjust.customMin"
                                        @change="update" @keyup="update" :disabled="disableCustom">
                             </div>
-                            <p v-if="colourScaleToAdjust.customMax" class="col col-form-label pl-0">{{ scaleText}}</p>
+                            <p v-if="scaleToAdjust.customMax" class="col col-form-label pl-0">{{ scaleText}}</p>
                         </div>
                     </form>
                 </div>
             </div>
         </div>
-
-        <div class="mt-1"><span v-translate="'fitToCurrentDataset'"></span></div>
-        <div class="ml-2">
-            <div class="form-check mt-1">
-                <label class="form-check-label">
-                    <input id="type-input-dynamic-full" class="form-check-input" type="radio" name="scaleType"
-                           :value="ColourScaleType.DynamicFull"
-                           v-model="colourScaleToAdjust.type" @change="update">
-                    <span v-translate="'entireDataset'"></span>
-                </label>
+        <div class="dynamic-container">
+            <div class="mt-1"><span v-translate="'fitToCurrentDataset'"></span></div>
+            <div class="ml-2">
+                <div class="form-check mt-1">
+                    <label class="form-check-label">
+                        <input id="type-input-dynamic-full" class="form-check-input" type="radio" name="scaleType"
+                               :value="ScaleType.DynamicFull"
+                               v-model="scaleToAdjust.type" @change="update">
+                        <span v-translate="'entireDataset'"></span>
+                    </label>
+                </div>
             </div>
-        </div>
-        <div class="ml-2">
-            <div class="form-check mt-1">
-                <label class="form-check-label">
-                    <input id="type-input-dynamic-filtered" class="form-check-input" type="radio" name="scaleType"
-                           :value="ColourScaleType.DynamicFiltered"
-                           v-model="colourScaleToAdjust.type" @change="update">
-                    <span v-translate="'filteredDataset'"></span>
-                </label>
+            <div class="ml-2">
+                <div class="form-check mt-1">
+                    <label class="form-check-label">
+                        <input id="type-input-dynamic-filtered" class="form-check-input" type="radio" name="scaleType"
+                               :value="ScaleType.DynamicFiltered"
+                               v-model="scaleToAdjust.type" @change="update">
+                        <span v-translate="'filteredDataset'"></span>
+                    </label>
+                </div>
             </div>
-        </div>
 
-        <div class="text-danger">{{ invalidMsg }}</div>
+            <div class="text-danger">{{ invalidMsg }}</div>
+        </div>
     </div>
 </template>
 
@@ -114,15 +115,15 @@ import {ScaleType} from "../../store/colourScales/colourScales";
         },
         data(): any {
             return {
-                colourScaleToAdjust: {...this.scale},
-                ColourScaleType: ScaleType
+                scaleToAdjust: {...this.scale},
+                ScaleType: ScaleType
             };
         },
         computed: {
             invalidMsg() {
                 let result = null;
                 if (this.scaleToAdjust.type == ScaleType.Custom) {
-                    if (this.scaleToAdjust.customMin >= this.sScaleToAdjust.customMax) {
+                    if (this.scaleToAdjust.customMin >= this.scaleToAdjust.customMax) {
                         result = i18next.t("maxMustBeGreaterThanMin");
                     }
                 }
@@ -147,7 +148,7 @@ import {ScaleType} from "../../store/colourScales/colourScales";
             }
         },
         watch: {
-            colourScale: function () {
+            scale: function () {
                 this.scaleToAdjust = {...this.scale};
             }
         }

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -1,4 +1,4 @@
-import {ColourScaleType} from "../../store/colourScales/colourScales";
+import {ScaleType} from "../../store/colourScales/colourScales";
 <template>
     <div v-if="show" class="pt-2 pl-3">
         <div v-if="!(hideStaticCustom && hideStaticDefault)" class="static-container">
@@ -76,12 +76,12 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
 
 <script lang="ts">
     import Vue from "vue";
-    import {ColourScaleSettings, ColourScaleType} from "../../store/plottingSelections/plottingSelections";
+    import {ScaleSettings, ScaleType} from "../../store/plottingSelections/plottingSelections";
     import i18next from "i18next";
 
     interface Props {
         show: boolean,
-        colourScale: ColourScaleSettings,
+        colourScale: ScaleSettings,
         step: number,
         metadata: any,
         hideStaticDefault: boolean,
@@ -95,7 +95,7 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
     }
 
     interface Data {
-        colourScaleToAdjust: ColourScaleSettings
+        colourScaleToAdjust: ScaleSettings
     }
 
     interface Methods {
@@ -115,13 +115,13 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
         data(): any {
             return {
                 colourScaleToAdjust: {...this.colourScale},
-                ColourScaleType
+                ColourScaleType: ScaleType
             };
         },
         computed: {
             invalidMsg() {
                 let result = null;
-                if (this.colourScaleToAdjust.type == ColourScaleType.Custom) {
+                if (this.colourScaleToAdjust.type == ScaleType.Custom) {
                     if (this.colourScaleToAdjust.customMin >= this.colourScaleToAdjust.customMax) {
                         result = i18next.t("maxMustBeGreaterThanMin");
                     }
@@ -130,7 +130,7 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
                 return result;
             },
             disableCustom() {
-                return this.colourScaleToAdjust.type != ColourScaleType.Custom;
+                return this.colourScaleToAdjust.type != ScaleType.Custom;
             },
             scaleText(){
                 const { format, scale, accuracy} = this.metadata

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -1,48 +1,50 @@
 import {ColourScaleType} from "../../store/colourScales/colourScales";
 <template>
     <div v-if="show" class="pt-2 pl-3">
-        <div><span v-translate="'static'"></span></div>
-        <div class="ml-2">
-            <div class="form-check">
-                <label class="form-check-label">
-                    <input id="type-input-default" class="form-check-input" type="radio" name="scaleType"
-                           :value="ColourScaleType.Default"
-                           v-model="colourScaleToAdjust.type" @change="update">
-                    <span v-translate="'default'"></span>
-                </label>
-            </div>
-            <div class="form-check mt-1">
-                <label class="form-check-label">
-                    <input id="type-input-custom" class="form-check-input" type="radio" name="scaleType"
-                           :value="ColourScaleType.Custom"
-                           v-model="colourScaleToAdjust.type" @change="update">
-                    <span v-translate="'custom'"></span>
-                </label>
-            </div>
+        <div v-if="!(hideStaticCustom && hideStaticDefault)" class="static-container">
+            <div><span v-translate="'static'"></span></div>
+            <div class="ml-2">
+                <div v-if="!hideStaticDefault" class="form-check static-default">
+                    <label class="form-check-label">
+                        <input id="type-input-default" class="form-check-input" type="radio" name="scaleType"
+                               :value="ColourScaleType.Default"
+                               v-model="colourScaleToAdjust.type" @change="update">
+                        <span v-translate="'default'"></span>
+                    </label>
+                </div>
+                <div v-if="!hideStaticCustom" class="form-check mt-1 static-custom">
+                    <label class="form-check-label">
+                        <input id="type-input-custom" class="form-check-input" type="radio" name="scaleType"
+                               :value="ColourScaleType.Custom"
+                               v-model="colourScaleToAdjust.type" @change="update">
+                        <span v-translate="'custom'"></span>
+                    </label>
+                </div>
 
-            <div class="mt-2 ml-2">
-                <form novalidate>
-                    <div class="row p-0 mb-2">
-                        <label for="custom-min-input" class="col col-form-label col-2"><span v-translate="'min'"></span></label>
-                        <div class="col pt-1 pr-1">
-                            <input id="custom-min-input" type="number" :step="step"
-                                   v-model.number="colourScaleToAdjust.customMin"
-                                   :max="colourScaleToAdjust.customMax"
-                                   @change="update" @keyup="update" :disabled="disableCustom">
+                <div v-if="!hideStaticCustom" class="mt-2 ml-2 static-custom-values">
+                    <form novalidate>
+                        <div class="row p-0 mb-2">
+                            <label for="custom-min-input" class="col col-form-label col-2"><span v-translate="'min'"></span></label>
+                            <div class="col pt-1 pr-1">
+                                <input id="custom-min-input" type="number" :step="step"
+                                       v-model.number="colourScaleToAdjust.customMin"
+                                       :max="colourScaleToAdjust.customMax"
+                                       @change="update" @keyup="update" :disabled="disableCustom">
+                            </div>
+                            <p v-if="colourScaleToAdjust.customMin" class="col col-form-label pl-0">{{ scaleText}}</p>
                         </div>
-                        <p v-if="colourScaleToAdjust.customMin" class="col col-form-label pl-0">{{ scaleText}}</p>
-                    </div>
-                    <div class="row">
-                        <label class="col col-form-label col-2" for="custom-max-input"><span v-translate="'max'"></span></label>
-                        <div class="col pt-1 pr-1">
-                            <input id="custom-max-input" type="number" :step="step"
-                                   v-model.number="colourScaleToAdjust.customMax"
-                                   :min="colourScaleToAdjust.customMin"
-                                   @change="update" @keyup="update" :disabled="disableCustom">
+                        <div class="row">
+                            <label class="col col-form-label col-2" for="custom-max-input"><span v-translate="'max'"></span></label>
+                            <div class="col pt-1 pr-1">
+                                <input id="custom-max-input" type="number" :step="step"
+                                       v-model.number="colourScaleToAdjust.customMax"
+                                       :min="colourScaleToAdjust.customMin"
+                                       @change="update" @keyup="update" :disabled="disableCustom">
+                            </div>
+                            <p v-if="colourScaleToAdjust.customMax" class="col col-form-label pl-0">{{ scaleText}}</p>
                         </div>
-                        <p v-if="colourScaleToAdjust.customMax" class="col col-form-label pl-0">{{ scaleText}}</p>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
 
@@ -81,7 +83,9 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
         show: boolean,
         colourScale: ColourScaleSettings,
         step: number,
-        metadata: any
+        metadata: any,
+        hideStaticDefault: boolean,
+        hideStaticCustom: boolean
     }
 
     interface Computed {
@@ -104,7 +108,9 @@ import {ColourScaleType} from "../../store/colourScales/colourScales";
             show: Boolean,
             colourScale: Object,
             step: Number,
-            metadata: Object
+            metadata: Object,
+            hideStaticDefault: Boolean,
+            hideStaticCustom: Boolean
         },
         data(): any {
             return {

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -6,7 +6,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
             <div class="ml-2">
                 <div v-if="!hideStaticDefault" class="form-check static-default">
                     <label class="form-check-label">
-                        <input id="type-input-default" class="form-check-input" type="radio" name="scaleType"
+                        <input id="type-input-default" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.Default"
                                v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'default'"></span>
@@ -14,7 +14,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
                 </div>
                 <div v-if="!hideStaticCustom" class="form-check mt-1 static-custom">
                     <label class="form-check-label">
-                        <input id="type-input-custom" class="form-check-input" type="radio" name="scaleType"
+                        <input id="type-input-custom" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.Custom"
                                v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'custom'"></span>
@@ -52,7 +52,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
             <div class="ml-2">
                 <div class="form-check mt-1">
                     <label class="form-check-label">
-                        <input id="type-input-dynamic-full" class="form-check-input" type="radio" name="scaleType"
+                        <input id="type-input-dynamic-full" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.DynamicFull"
                                v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'entireDataset'"></span>
@@ -62,14 +62,13 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
             <div class="ml-2">
                 <div class="form-check mt-1">
                     <label class="form-check-label">
-                        <input id="type-input-dynamic-filtered" class="form-check-input" type="radio" name="scaleType"
+                        <input id="type-input-dynamic-filtered" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.DynamicFiltered"
                                v-model="scaleToAdjust.type" @change="update">
                         <span v-translate="'filteredDataset'"></span>
                     </label>
                 </div>
             </div>
-
             <div class="text-danger">{{ invalidMsg }}</div>
         </div>
     </div>
@@ -81,6 +80,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
     import i18next from "i18next";
 
     interface Props {
+        name: string,
         show: boolean,
         scale: ScaleSettings,
         step: number,
@@ -92,7 +92,8 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
     interface Computed {
         disableCustom: boolean,
         invalidMsg: string | null,
-        scaleText: string
+        scaleText: string,
+        scaleTypeGroup: string
     }
 
     interface Data {
@@ -106,6 +107,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
     export default Vue.extend<Data, Methods, Computed, Props>({
         name: "MapAdjustScale",
         props: {
+            name: String,
             show: Boolean,
             scale: Object,
             step: Number,
@@ -138,7 +140,8 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
                 if (!format.includes('%') && scale !== 1){
                     return `x ${scale}`
                 } else return ''
-            }
+            },
+            scaleTypeGroup() { return `${this.name}-scaleType`; }
         },
         methods: {
             update: function () {

--- a/src/app/static/src/app/components/plots/MapLegend.vue
+++ b/src/app/static/src/app/components/plots/MapLegend.vue
@@ -1,7 +1,7 @@
 <template>
     <l-control position="bottomright">
         <div class="legend-container">
-            <map-adjust-scale class="legend-element legend-adjust map-control" :step="colourScaleStep"
+            <map-adjust-scale class="legend-element legend-adjust map-control" name="colour" :step="colourScaleStep"
                               :show="showAdjust" :scale="colourScale" @update="update" :metadata="metadata">
             </map-adjust-scale>
             <div class="legend-element map-control p-3">

--- a/src/app/static/src/app/components/plots/MapLegend.vue
+++ b/src/app/static/src/app/components/plots/MapLegend.vue
@@ -27,7 +27,7 @@
     import {LControl} from 'vue2-leaflet';
     import {
         colorFunctionFromName,
-        colourScaleStepFromMetadata,
+        scaleStepFromMetadata,
         roundToContext,
         formatOutput,
         formatLegend
@@ -61,7 +61,7 @@
 
     interface Methods {
         toggleAdjust: (e: Event) => void
-        update: (colourScale: ScaleSettings) => void
+        update: (scale: ScaleSettings) => void
     }
 
     export default Vue.extend<Data, Methods, Computed, Props>({
@@ -85,7 +85,7 @@
                 return !!this.colourScale;
             },
             colourScaleStep: function () {
-                return this.metadata ? colourScaleStepFromMetadata(this.metadata) : 1;
+                return this.metadata ? scaleStepFromMetadata(this.metadata) : 1;
             },
             levels: function () {
                 if (this.metadata) {
@@ -122,8 +122,8 @@
                 e.preventDefault();
                 this.showAdjust = !this.showAdjust;
             },
-            update: function (colourScale: ScaleSettings) {
-                this.$emit("update", colourScale);
+            update: function (scale: ScaleSettings) {
+                this.$emit("update", scale);
             }
         }
     });

--- a/src/app/static/src/app/components/plots/MapLegend.vue
+++ b/src/app/static/src/app/components/plots/MapLegend.vue
@@ -2,7 +2,7 @@
     <l-control position="bottomright">
         <div class="legend-container">
             <map-adjust-scale class="legend-element legend-adjust map-control" :step="colourScaleStep"
-                              :show="showAdjust" :colour-scale="colourScale" @update="update" :metadata="metadata">
+                              :show="showAdjust" :scale="colourScale" @update="update" :metadata="metadata">
             </map-adjust-scale>
             <div class="legend-element map-control p-3">
             <label v-if="metadata">{{metadata.name}}</label>
@@ -12,7 +12,7 @@
                     <span class="hidden" style="display: none">{{ level.style }}</span>
                     <br/>
                 </div>
-                <div v-if="adjustable" id="adjust-scale" class="mt-1">
+                <div v-if="adjustable" class="adjust-scale mt-1">
                     <a @click="toggleAdjust" href="">
                         <span v-if="showAdjust" v-translate="'done'"></span>
                         <span v-if="!showAdjust" v-translate="'adjustScale'"></span>

--- a/src/app/static/src/app/components/plots/MapLegend.vue
+++ b/src/app/static/src/app/components/plots/MapLegend.vue
@@ -33,14 +33,14 @@
         formatLegend
     } from "./utils";
     import {ChoroplethIndicatorMetadata} from "../../generated";
-    import {ColourScaleSettings} from "../../store/plottingSelections/plottingSelections";
+    import {ScaleSettings} from "../../store/plottingSelections/plottingSelections";
     import MapAdjustScale from "./MapAdjustScale.vue";
     import {NumericRange} from "../../types";
     import numeral from 'numeral';
 
     interface Props {
         metadata: ChoroplethIndicatorMetadata,
-        colourScale: ColourScaleSettings,
+        colourScale: ScaleSettings,
         colourRange: NumericRange
     }
 
@@ -61,7 +61,7 @@
 
     interface Methods {
         toggleAdjust: (e: Event) => void
-        update: (colourScale: ColourScaleSettings) => void
+        update: (colourScale: ScaleSettings) => void
     }
 
     export default Vue.extend<Data, Methods, Computed, Props>({
@@ -122,7 +122,7 @@
                 e.preventDefault();
                 this.showAdjust = !this.showAdjust;
             },
-            update: function (colourScale: ColourScaleSettings) {
+            update: function (colourScale: ScaleSettings) {
                 this.$emit("update", colourScale);
             }
         }

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -84,9 +84,9 @@
     import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../../generated";
     import {
         BubblePlotSelections,
-        ColourScaleSelections,
-        ColourScaleSettings,
-        ColourScaleType
+        ScaleSelections,
+        ScaleSettings,
+        ScaleType
     } from "../../../store/plottingSelections/plottingSelections";
     import {getFeatureIndicators} from "./utils";
     import {getIndicatorRange, toIndicatorNameLookup, formatOutput} from "../utils";
@@ -104,7 +104,7 @@
         filters: Filter[],
         selections: BubblePlotSelections,
         areaFilterId: string,
-        colourScales: ColourScaleSelections,
+        colourScales: ScaleSelections,
     }
 
     interface Data {
@@ -128,7 +128,7 @@
         changeSelections: (newSelections: Partial<BubblePlotSelections>) => void,
         getFeatureFromAreaId: (id: string) => Feature,
         normalizeIndicators: (node: ChoroplethIndicatorMetadata) => any,
-        updateColourScale: (colourScale: ColourScaleSettings) => void,
+        updateColourScale: (colourScale: ScaleSettings) => void,
     }
 
     interface Computed {
@@ -151,7 +151,7 @@
         colorIndicator: ChoroplethIndicatorMetadata,
         sizeRange: NumericRange,
         colourRange: NumericRange,
-        colourIndicatorScale: ColourScaleSettings | null
+        colourIndicatorScale: ScaleSettings | null
         selectedAreaIds: string[]
     }
 
@@ -235,7 +235,7 @@
                 const colorId = this.selections.colorIndicatorId;
                 const type = this.colourScales[colorId] && this.colourScales[colorId].type;
                 switch (type) {
-                    case  ColourScaleType.DynamicFull:
+                    case  ScaleType.DynamicFull:
                         if (!this.fullIndicatorRanges.hasOwnProperty(colorId)) {
                             // cache the result in the fullIndicatorRanges object for future lookups
                             /* eslint vue/no-side-effects-in-computed-properties: "off" */
@@ -243,7 +243,7 @@
                                 getIndicatorRange(this.chartdata, this.colorIndicator)
                         }
                         return this.fullIndicatorRanges[colorId];
-                    case ColourScaleType.DynamicFiltered:
+                    case ScaleType.DynamicFiltered:
                         return getIndicatorRange(
                             this.chartdata,
                             this.colorIndicator,
@@ -251,12 +251,12 @@
                             this.selections.selectedFilterOptions,
                             this.selectedAreaIds.filter(a => this.currentLevelFeatureIds.indexOf(a) > -1)
                         );
-                    case ColourScaleType.Custom:
+                    case ScaleType.Custom:
                         return {
                             min: this.colourScales[colorId].customMin,
                             max: this.colourScales[colorId].customMax
                         };
-                    case ColourScaleType.Default:
+                    case ScaleType.Default:
                     default:
                         return {max: this.colorIndicator.max, min: this.colorIndicator.min}
                 }
@@ -349,7 +349,7 @@
             sizeIndicator(): ChoroplethIndicatorMetadata {
                 return this.indicators.find(i => i.indicator == this.selections.sizeIndicatorId)!;
             },
-            colourIndicatorScale(): ColourScaleSettings | null {
+            colourIndicatorScale(): ScaleSettings | null {
                 const current = this.colourScales[this.selections.colorIndicatorId];
                 if (current) {
                     return current
@@ -428,7 +428,7 @@
             normalizeIndicators(node: ChoroplethIndicatorMetadata) {
                 return {id: node.indicator, label: node.name};
             },
-            updateColourScale: function (colourScale: ColourScaleSettings) {
+            updateColourScale: function (colourScale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
                 newColourScales[this.selections.colorIndicatorId] = colourScale;
                 this.$emit("update-colour-scales", newColourScales);

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -128,7 +128,7 @@
         changeSelections: (newSelections: Partial<BubblePlotSelections>) => void,
         getFeatureFromAreaId: (id: string) => Feature,
         normalizeIndicators: (node: ChoroplethIndicatorMetadata) => any,
-        updateColourScale: (colourScale: ScaleSettings) => void,
+        updateColourScale: (scale: ScaleSettings) => void,
     }
 
     interface Computed {
@@ -428,7 +428,7 @@
             normalizeIndicators(node: ChoroplethIndicatorMetadata) {
                 return {id: node.indicator, label: node.name};
             },
-            updateColourScale: function (colourScale: ScaleSettings) {
+            updateColourScale: function (scale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
                 newColourScales[this.selections.colorIndicatorId] = colourScale;
                 this.$emit("update-colour-scales", newColourScales);

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -66,7 +66,13 @@
                             :colour-scale="colourIndicatorScale"
                             @update="updateColourScale"
                 ></map-legend>
-                <size-legend :indicatorRange="sizeRange" :max-radius="maxRadius" :min-radius="minRadius" :metadata="sizeIndicator"></size-legend>
+                <size-legend :indicatorRange="sizeRange"
+                             :max-radius="maxRadius"
+                             :min-radius="minRadius"
+                             :metadata="sizeIndicator"
+                             :size-scale="sizeIndicatorScale"
+                             @update="updateSizeScale"
+                ></size-legend>
             </l-map>
         </div>
     </div>
@@ -93,7 +99,7 @@
     import {BubbleIndicatorValuesDict, Dict, Filter, LevelLabel, NumericRange} from "../../../types";
     import {flattenOptions, flattenToIdSet} from "../../../utils";
     import SizeLegend from "./SizeLegend.vue";
-    import {initialiseColourScaleFromMetadata} from "../choropleth/utils";
+    import {initialiseScaleFromMetadata} from "../choropleth/utils";
 
 
     interface Props {
@@ -105,6 +111,7 @@
         selections: BubblePlotSelections,
         areaFilterId: string,
         colourScales: ScaleSelections,
+        sizeScales: ScaleSelections
     }
 
     interface Data {
@@ -129,6 +136,7 @@
         getFeatureFromAreaId: (id: string) => Feature,
         normalizeIndicators: (node: ChoroplethIndicatorMetadata) => any,
         updateColourScale: (scale: ScaleSettings) => void,
+        updateSizeScale: (scale: ScaleSettings) => void,
     }
 
     interface Computed {
@@ -152,6 +160,7 @@
         sizeRange: NumericRange,
         colourRange: NumericRange,
         colourIndicatorScale: ScaleSettings | null
+        sizeIndicatorScale: ScaleSettings | null
         selectedAreaIds: string[]
     }
 
@@ -180,6 +189,9 @@
         colourScales: {
             type: Object
         },
+        sizeScales: {
+            type: Object
+        }
     };
 
     export default Vue.extend<Data, Methods, Computed, Props>({
@@ -354,8 +366,18 @@
                 if (current) {
                     return current
                 } else {
-                    const newScale = initialiseColourScaleFromMetadata(this.colorIndicator);
+                    const newScale = initialiseScaleFromMetadata(this.colorIndicator);
                     this.updateColourScale(newScale);
+                    return newScale;
+                }
+            },
+            sizeIndicatorScale(): ScaleSettings | null {
+                const current = this.sizeScales[this.selections.sizeIndicatorId];
+                if (current) {
+                    return current
+                } else {
+                    const newScale = initialiseScaleFromMetadata(this.colorIndicator);
+                    this.updateSizeScale(newScale);
                     return newScale;
                 }
             }
@@ -430,8 +452,13 @@
             },
             updateColourScale: function (scale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
-                newColourScales[this.selections.colorIndicatorId] = colourScale;
+                newColourScales[this.selections.colorIndicatorId] = scale;
                 this.$emit("update-colour-scales", newColourScales);
+            },
+            updateSizeScale: function (scale: ScaleSettings) {
+                const newColourScales = {...this.sizeScales};
+                newColourScales[this.selections.sizeIndicatorId] = scale;
+                this.$emit("update-size-scales", newColourScales);
             },
         },
         watch:

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -1,26 +1,28 @@
 <template>
     <l-control position="bottomleft">
-        <map-adjust-scale class="legend-element legend-adjust map-control" :step="scaleStep"
-                          :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata"
-                          :hide-static-custom="'true'" :hide-static-default="'true'">
-        </map-adjust-scale>
-        <div class="map-control p-1 d-flex flex-column">
-            <label class="text-center pt-1 pb-1">{{metadata.name}}</label>
-            <svg :width="width" :height="height">
-                <circle v-for="(circle, index) in circles" :key="'circle-' + index" stroke="#aaa" stroke-width="1"
-                        fill-opacity="0"
-                        :r="circle.radius" :cx="midX" :cy="circle.y"></circle>
-                <text v-for="(circle, index) in circles" :key="'text-' + index" text-anchor="middle"
-                      :x="midX" :y="circle.textY">{{ circle.text }}
-                </text>
-            </svg>
+        <div class="legend-container">
+            <div class="legend-element map-control p-3">
+                <label class="text-center pt-1 pb-1 d-block">{{metadata.name}}</label>
+                <svg :width="width" :height="height" class="d-block">
+                    <circle v-for="(circle, index) in circles" :key="'circle-' + index" stroke="#aaa" stroke-width="1"
+                            fill-opacity="0"
+                            :r="circle.radius" :cx="midX" :cy="circle.y"></circle>
+                    <text v-for="(circle, index) in circles" :key="'text-' + index" text-anchor="middle"
+                          :x="midX" :y="circle.textY">{{ circle.text }}
+                    </text>
+                </svg>
+                <div class="adjust-scale mt-1">
+                    <a @click="toggleAdjust" href="" class="float-right">
+                        <span v-if="showAdjust" v-translate="'done'"></span>
+                        <span v-if="!showAdjust" v-translate="'adjustScale'"></span>
+                    </a>
+                </div>
+            </div>
+            <map-adjust-scale class="legend-element legend-adjust map-control" :step="scaleStep"
+                              :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata"
+                              :hide-static-custom="true" :hide-static-default="true">
+            </map-adjust-scale>
         </div>
-        <div v-if="adjustable" id="adjust-scale" class="mt-1">
-            <a @click="toggleAdjust" href="">
-                <span v-if="showAdjust" v-translate="'done'"></span>
-                <span v-if="!showAdjust" v-translate="'adjustScale'"></span>
-            </a>
-        </div>div>
     </l-control>
 </template>
 
@@ -33,6 +35,7 @@
     import {formatOutput, formatLegend, scaleStepFromMetadata} from "./../utils";
     import {ChoroplethIndicatorMetadata} from "../../../generated";
     import {ScaleSettings} from "../../../store/plottingSelections/plottingSelections";
+    import MapAdjustScale from "../MapAdjustScale.vue";
 
     interface Circle {
         y: number,
@@ -51,7 +54,7 @@
         minRadius: number,
         maxRadius: number,
         metadata: ChoroplethIndicatorMetadata
-        colourScale: ScaleSettings,
+        sizeScale: ScaleSettings,
     }
 
     interface Computed {
@@ -77,10 +80,11 @@
             "minRadius": Number,
             "maxRadius": Number,
             "metadata": Object,
-            "colourScale": Object
+            "sizeScale": Object
         },
         components: {
-            LControl
+            LControl,
+            MapAdjustScale
         },
         data: function () {
             return {

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -18,7 +18,7 @@
                     </a>
                 </div>
             </div>
-            <map-adjust-scale class="legend-element legend-adjust map-control" :step="scaleStep"
+            <map-adjust-scale class="legend-element legend-adjust map-control" name="size" :step="scaleStep"
                               :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata"
                               :hide-static-custom="true" :hide-static-default="true">
             </map-adjust-scale>

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -45,7 +45,7 @@
         ScaleType
     } from "../../../store/plottingSelections/plottingSelections";
     import {getIndicatorRange, toIndicatorNameLookup, formatOutput} from "../utils";
-    import {getFeatureIndicator, initialiseColourScaleFromMetadata} from "./utils";
+    import {getFeatureIndicator, initialiseScaleFromMetadata} from "./utils";
     import {Dict, Filter, IndicatorValuesDict, LevelLabel, NumericRange} from "../../../types";
     import {flattenOptions, flattenToIdSet} from "../../../utils";
 
@@ -269,7 +269,7 @@
                 if (current) {
                     return current
                 } else {
-                    const newScale = initialiseColourScaleFromMetadata(this.colorIndicator);
+                    const newScale = initialiseScaleFromMetadata(this.colorIndicator);
                     this.updateColourScale(newScale);
                     return newScale;
                 }
@@ -359,7 +359,7 @@
             },
             updateColourScale: function (scale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
-                newColourScales[this.selections.indicatorId] = colourScale;
+                newColourScales[this.selections.indicatorId] = scale;
                 this.$emit("update-colour-scales", newColourScales);
             },
             getFeatureFromAreaId(areaId: string): Feature {

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -40,9 +40,9 @@
     import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../../generated";
     import {
         ChoroplethSelections,
-        ColourScaleSelections,
-        ColourScaleSettings,
-        ColourScaleType
+        ScaleSelections,
+        ScaleSettings,
+        ScaleType
     } from "../../../store/plottingSelections/plottingSelections";
     import {getIndicatorRange, toIndicatorNameLookup, formatOutput} from "../utils";
     import {getFeatureIndicator, initialiseColourScaleFromMetadata} from "./utils";
@@ -56,7 +56,7 @@
         chartdata: any[],
         filters: Filter[],
         selections: ChoroplethSelections,
-        colourScales: ColourScaleSelections,
+        colourScales: ScaleSelections,
         areaFilterId: string,
         includeFilters: boolean
     }
@@ -75,7 +75,7 @@
         onIndicatorChange: (newVal: string) => void,
         onFilterSelectionsChange: (newSelections: Dict<FilterOption[]>) => void,
         changeSelections: (newSelections: Partial<ChoroplethSelections>) => void,
-        updateColourScale: (colourScale: ColourScaleSettings) => void,
+        updateColourScale: (colourScale: ScaleSettings) => void,
         getFeatureFromAreaId: (id: string) => Feature,
         normalizeIndicators: (node: ChoroplethIndicatorMetadata) => any
     }
@@ -89,7 +89,7 @@
         currentLevelFeatureIds: string[],
         maxLevel: number,
         indicatorNameLookup: Dict<string>,
-        indicatorColourScale: ColourScaleSettings | null,
+        indicatorColourScale: ScaleSettings | null,
         areaFilter: Filter,
         nonAreaFilters: Filter[],
         selectedAreaFilterOptions: FilterOption[],
@@ -158,7 +158,7 @@
                 const indicator = this.selections.indicatorId;
                 const type = this.colourScales[indicator] && this.colourScales[indicator].type;
                 switch (type) {
-                    case  ColourScaleType.DynamicFull:
+                    case  ScaleType.DynamicFull:
                         if (!this.fullIndicatorRanges.hasOwnProperty(indicator)) {
                             // cache the result in the fullIndicatorRanges object for future lookups
                             /* eslint vue/no-side-effects-in-computed-properties: "off" */
@@ -166,7 +166,7 @@
                                 getIndicatorRange(this.chartdata, this.colorIndicator)
                         }
                         return this.fullIndicatorRanges[indicator];
-                    case  ColourScaleType.DynamicFiltered:
+                    case  ScaleType.DynamicFiltered:
                         return getIndicatorRange(
                             this.chartdata,
                             this.colorIndicator,
@@ -174,12 +174,12 @@
                             this.selections.selectedFilterOptions,
                             this.selectedAreaIds.filter(a => this.currentLevelFeatureIds.indexOf(a) > -1)
                         );
-                    case ColourScaleType.Custom:
+                    case ScaleType.Custom:
                         return {
                             min: this.colourScales[indicator].customMin,
                             max: this.colourScales[indicator].customMax
                         };
-                    case ColourScaleType.Default:
+                    case ScaleType.Default:
                     default:
                         if (!this.initialised) {
                             return {max: 1, min: 0}
@@ -264,7 +264,7 @@
             colorIndicator(): ChoroplethIndicatorMetadata {
                 return this.indicators.find(i => i.indicator == this.selections.indicatorId)!;
             },
-            indicatorColourScale(): ColourScaleSettings | null {
+            indicatorColourScale(): ScaleSettings | null {
                 const current = this.colourScales[this.selections.indicatorId];
                 if (current) {
                     return current
@@ -357,7 +357,7 @@
             changeSelections(newSelections: Partial<ChoroplethSelections>) {
                 this.$emit("update", newSelections)
             },
-            updateColourScale: function (colourScale: ColourScaleSettings) {
+            updateColourScale: function (colourScale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
                 newColourScales[this.selections.indicatorId] = colourScale;
                 this.$emit("update-colour-scales", newColourScales);

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -75,7 +75,7 @@
         onIndicatorChange: (newVal: string) => void,
         onFilterSelectionsChange: (newSelections: Dict<FilterOption[]>) => void,
         changeSelections: (newSelections: Partial<ChoroplethSelections>) => void,
-        updateColourScale: (colourScale: ScaleSettings) => void,
+        updateColourScale: (scale: ScaleSettings) => void,
         getFeatureFromAreaId: (id: string) => Feature,
         normalizeIndicators: (node: ChoroplethIndicatorMetadata) => any
     }
@@ -357,7 +357,7 @@
             changeSelections(newSelections: Partial<ChoroplethSelections>) {
                 this.$emit("update", newSelections)
             },
-            updateColourScale: function (colourScale: ScaleSettings) {
+            updateColourScale: function (scale: ScaleSettings) {
                 const newColourScales = {...this.colourScales};
                 newColourScales[this.selections.indicatorId] = colourScale;
                 this.$emit("update-colour-scales", newColourScales);

--- a/src/app/static/src/app/components/plots/choropleth/utils.ts
+++ b/src/app/static/src/app/components/plots/choropleth/utils.ts
@@ -1,7 +1,7 @@
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../../generated";
 import {Dict, Filter, IndicatorValuesDict, NumericRange} from "../../../types";
 import {getColor, iterateDataValues} from "../utils";
-import {initialColourScaleSettings} from "../../../store/plottingSelections/plottingSelections";
+import {initialScaleSettings} from "../../../store/plottingSelections/plottingSelections";
 
 export const getFeatureIndicator = function (data: any[],
                                              selectedAreaIds: string[],
@@ -22,8 +22,8 @@ export const getFeatureIndicator = function (data: any[],
     return result;
 };
 
-export const initialiseColourScaleFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
-    const result = initialColourScaleSettings();
+export const initialiseScaleFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
+    const result = initialScaleSettings();
     if (meta) {
         result.customMin = meta.min;
         result.customMax = meta.max;

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -30,7 +30,7 @@ export const getColor = (value: number, metadata: ChoroplethIndicatorMetadata,
     return colorFunction(colorValue);
 };
 
-export const colourScaleStepFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
+export const scaleStepFromMetadata = function (meta: ChoroplethIndicatorMetadata) {
     return (meta.max - meta.min) / 10;
 };
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.0.0";
+export const currentHintVersion = "1.1.0";

--- a/src/app/static/src/app/store/plottingSelections/getters.ts
+++ b/src/app/static/src/app/store/plottingSelections/getters.ts
@@ -1,9 +1,9 @@
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
 import {RootState} from "../../root";
-import {ColourScaleSelections, PlottingSelectionsState} from "./plottingSelections";
+import {ScaleSelections, PlottingSelectionsState} from "./plottingSelections";
 
 export const getters = {
-    selectedSAPColourScales: (state: PlottingSelectionsState, getters: any, rootState: RootState): ColourScaleSelections => {
+    selectedSAPColourScales: (state: PlottingSelectionsState, getters: any, rootState: RootState): ScaleSelections => {
         const dataType = rootState.surveyAndProgram.selectedDataType;
         switch (dataType) {
             case DataType.Survey:

--- a/src/app/static/src/app/store/plottingSelections/mutations.ts
+++ b/src/app/static/src/app/store/plottingSelections/mutations.ts
@@ -3,7 +3,7 @@ import {
     PlottingSelectionsState,
     BarchartSelections,
     BubblePlotSelections,
-    ChoroplethSelections, ColourScaleSelections, ColourScalesState
+    ChoroplethSelections, ScaleSelections, ColourScalesState
 } from "./plottingSelections";
 import {PayloadWithType} from "../../types";
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
@@ -16,7 +16,8 @@ export interface PlottingSelectionsMutations {
     updateSAPChoroplethSelections: PlottingSelectionsMutation,
     updateOutputChoroplethSelections: PlottingSelectionsMutation,
     updateSAPColourScales: PlottingSelectionsMutation,
-    updateOutputColourScales: PlottingSelectionsMutation
+    updateOutputColourScales: PlottingSelectionsMutation,
+    updateOutputBubbleSizeScales: PlottingSelectionsMutation
 }
 
 export const mutations: MutationTree<PlottingSelectionsState> & PlottingSelectionsMutations = {
@@ -32,7 +33,7 @@ export const mutations: MutationTree<PlottingSelectionsState> & PlottingSelectio
     updateOutputChoroplethSelections(state: PlottingSelectionsState, action: PayloadWithType<Partial<ChoroplethSelections>>) {
         state.outputChoropleth = {...state.outputChoropleth, ...action.payload}
     },
-    updateSAPColourScales(state: PlottingSelectionsState, action: PayloadWithType<[DataType, ColourScaleSelections]>) {
+    updateSAPColourScales(state: PlottingSelectionsState, action: PayloadWithType<[DataType, ScaleSelections]>) {
         const value = action.payload[1];
         switch (action.payload[0]) {
             case DataType.Survey:
@@ -48,7 +49,10 @@ export const mutations: MutationTree<PlottingSelectionsState> & PlottingSelectio
 
         }
     },
-    updateOutputColourScales(state: PlottingSelectionsState, action: PayloadWithType<ColourScaleSelections>) {
+    updateOutputColourScales(state: PlottingSelectionsState, action: PayloadWithType<ScaleSelections>) {
         state.colourScales.output = action.payload;
+    },
+    updateOutputBubbleSizeScales(state: PlottingSelectionsState, action: PayloadWithType<ScaleSelections>) {
+        state.bubbleSizeScales.output = action.payload;
     }
 };

--- a/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
+++ b/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
@@ -83,7 +83,7 @@ export const initialChorplethSelections = (): ChoroplethSelections => {
     };
 };
 
-export const initialColourScaleSettings = (): ScaleSettings => {
+export const initialScaleSettings = (): ScaleSettings => {
     return {
         type: ScaleType.DynamicFiltered,
         customMin: 0,

--- a/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
+++ b/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
@@ -11,7 +11,8 @@ export interface PlottingSelectionsState {
     bubble: BubblePlotSelections,
     sapChoropleth: ChoroplethSelections,
     outputChoropleth: ChoroplethSelections,
-    colourScales: ColourScalesState
+    colourScales: ColourScalesState,
+    bubbleSizeScales: BubbleSizeScalesState
 }
 
 export interface BarchartSelections {
@@ -36,18 +37,22 @@ export interface ChoroplethSelections {
 }
 
 export interface ColourScalesState {
-    survey: ColourScaleSelections,
-    anc: ColourScaleSelections,
-    program: ColourScaleSelections,
-    output: ColourScaleSelections
+    survey: ScaleSelections,
+    anc: ScaleSelections,
+    program: ScaleSelections,
+    output: ScaleSelections
 }
 
-export enum ColourScaleType {Default, Custom, DynamicFull, DynamicFiltered}
+export interface BubbleSizeScalesState {
+    output: ScaleSelections
+}
 
-export type ColourScaleSelections = Dict<ColourScaleSettings>;
+export enum ScaleType {Default, Custom, DynamicFull, DynamicFiltered}
 
-export interface ColourScaleSettings {
-    type: ColourScaleType
+export type ScaleSelections = Dict<ScaleSettings>;
+
+export interface ScaleSettings {
+    type: ScaleType
     customMin: number,
     customMax: number
 }
@@ -78,9 +83,9 @@ export const initialChorplethSelections = (): ChoroplethSelections => {
     };
 };
 
-export const initialColourScaleSettings = (): ColourScaleSettings => {
+export const initialColourScaleSettings = (): ScaleSettings => {
     return {
-        type: ColourScaleType.DynamicFiltered,
+        type: ScaleType.DynamicFiltered,
         customMin: 0,
         customMax: 0
     }
@@ -95,13 +100,22 @@ export const initialColourScalesState = (): ColourScalesState => {
     }
 };
 
+
+export const initialBubbleSizeScalesState = (): BubbleSizeScalesState => {
+    return {
+        output: {}
+    }
+};
+
+
 export const initialPlottingSelectionsState = (): PlottingSelectionsState => {
     return {
         barchart: initialBarchartSelections(),
         bubble: initialBubblePlotSelections(),
         sapChoropleth: initialChorplethSelections(),
         outputChoropleth: initialChorplethSelections(),
-        colourScales: initialColourScalesState()
+        colourScales: initialColourScalesState(),
+        bubbleSizeScales: initialBubbleSizeScalesState()
     }
 };
 

--- a/src/app/static/src/scss/partials/maps.scss
+++ b/src/app/static/src/scss/partials/maps.scss
@@ -23,14 +23,24 @@
   margin-right: 8px;
 }
 
-#adjust-scale {
+.adjust-scale {
   min-width: 4.1rem;
+}
+
+.adjust-scale a {
   text-decoration: underline;
 }
 
 .legend-adjust {
-  height: 252px;
   width: 190px;
+}
+
+.legend-adjust .static-container {
+  height: 140px;
+}
+
+.legend-adjust .dynamic-container {
+  height: 80px;
 }
 
 .legend-adjust input[type='number'] {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -122,6 +122,7 @@ describe("ModelOutput component", () => {
         expect(bubble.props().selections).toStrictEqual({test: "TEST BUBBLE SELECTIONS"});
         expect(bubble.props().indicators).toStrictEqual(["TEST BUBBLE INDICATORS"]);
         expect(bubble.props().colourScales).toStrictEqual({test: "TEST OUTPUT COLOUR SCALES"});
+        expect(bubble.props().sizeScales).toStrictEqual({test: "TEST OUTPUT BUBBLE SIZE SCALES"});
     });
 
     it("renders barchart", () => {
@@ -287,6 +288,16 @@ describe("ModelOutput component", () => {
         const bubbleColourScales = {test: "NEW BUBBLE COLOUR SCALES"};
         bubble.vm.$emit("update-colour-scales", bubbleColourScales);
         expect(store.state.plottingSelections.colourScales.output).toBe(bubbleColourScales);
+    });
+
+    it("commits updated size scale from bubble plot", () => {
+        const store = getStore({selectedTab: "bubble"});
+        const wrapper = shallowMount(ModelOutput, {store, localVue});
+
+        const bubble = wrapper.find(BubblePlot);
+        const bubbleSizeScales = {test: "NEW BUBBLE SIZE SCALES"};
+        bubble.vm.$emit("update-colour-scales", bubbleSizeScales);
+        expect(store.state.plottingSelections.colourScales.output).toBe(bubbleSizeScales);
     });
 
     it("renders choropleth table", () => {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -78,6 +78,9 @@ function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGette
                     colourScales: {
                         output: {test: "TEST OUTPUT COLOUR SCALES"} as any
                     },
+                    bubbleSizeScales: {
+                        output: {test: "TEST OUTPUT BUBBLE SIZE SCALES"} as any
+                    },
                     ...partialSelections
                 },
                 mutations: plottingSelectionMutations

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -42,9 +42,9 @@ const propsData = {
     },
     sizeScales: {
         plhiv: {
-            type: ScaleType.Default,
-            customMin: 0,
-            customMax: 1000
+            type: ScaleType.Custom,
+            customMin: 1,
+            customMax: 20
         }
     }
 };

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -39,6 +39,13 @@ const propsData = {
             customMin: 0,
             customMax: 1
         }
+    },
+    sizeScales: {
+        plhiv: {
+            type: ScaleType.Default,
+            customMin: 0,
+            customMax: 1000
+        }
     }
 };
 
@@ -536,7 +543,8 @@ describe("BubblePlot component", () => {
                 {id: "age", label: "Age", column_id: "age", options: []},
                 {id: "sex", label: "Sex", column_id: "sex", options: []}
             ],
-            colourScales: {...propsData.colourScales}
+            colourScales: {...propsData.colourScales},
+            sizeScales: {...propsData.sizeScales}
         });
         const vm = wrapper.vm as any;
         vm.updateBounds = mockUpdateBounds;

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -13,7 +13,7 @@ import Vue from "vue";
 import MapLegend from "../../../../app/components/plots/MapLegend.vue";
 import SizeLegend from "../../../../app/components/plots/bubble/SizeLegend.vue";
 import {expectFilter, plhiv, prev, testData} from "../testHelpers"
-import {ColourScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
 const localVue = createLocalVue();
 const store = new Vuex.Store({
@@ -35,7 +35,7 @@ const propsData = {
     },
     colourScales: {
         prevalence: {
-            type: ColourScaleType.Default,
+            type: ScaleType.Default,
             customMin: 0,
             customMax: 1
         }
@@ -162,7 +162,7 @@ describe("BubblePlot component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.Custom,
+                    type: ScaleType.Custom,
                     customMin: 1,
                     customMax: 2
                 }
@@ -178,7 +178,7 @@ describe("BubblePlot component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.DynamicFull,
+                    type: ScaleType.DynamicFull,
                     customMin: 1,
                     customMax: 2
                 }
@@ -194,7 +194,7 @@ describe("BubblePlot component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.DynamicFiltered,
+                    type: ScaleType.DynamicFiltered,
                     customMin: 1,
                     customMax: 2
                 }
@@ -555,7 +555,7 @@ describe("BubblePlot component", () => {
     it("emits event when colour scale updated", () => {
         const wrapper = getWrapper();
         const legend = wrapper.find(MapLegend);
-        const newColourScale = {type: ColourScaleType.DynamicFiltered, customMin: -5, customMax: 5};
+        const newColourScale = {type: ScaleType.DynamicFiltered, customMin: -5, customMax: 5};
         legend.vm.$emit("update", newColourScale);
 
         expect(wrapper.emitted("update-colour-scales").length).toBe(1);

--- a/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
@@ -5,22 +5,28 @@ import {LControl} from "vue2-leaflet";
 import Vuex from "vuex";
 import {emptyState} from "../../../../app/root";
 import registerTranslations from "../../../../app/store/translations/registerTranslations";
+import MapAdjustScale from "../../../../app/components/plots/MapAdjustScale.vue";
+import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
 const store = new Vuex.Store({
     state: emptyState()
 });
 registerTranslations(store);
 
-const getWrapper = () => {
+const propsData = {
+    minRadius: 10,
+    maxRadius: 110,
+    indicatorRange: {min: 1, max: 101},
+    metadata: { format: '', accuracy: null, name: 'indicator'},
+    sizeScale: {
+        type: ScaleType.Default,
+        customMin: 1.5,
+        customMax: 2.5
+    }
+};
 
-    return shallowMount(SizeLegend, {
-        propsData: {
-            minRadius: 10,
-            maxRadius: 110,
-            indicatorRange: {min: 1, max: 101},
-            metadata: { format: '', accuracy: null, name: 'indicator'}
-        }
-    });
+const getWrapper = () => {
+    return shallowMount(SizeLegend, {propsData});
 };
 
 const expectCirclesEqual = (actual: any, expected: any) => {
@@ -123,6 +129,15 @@ describe("SizeLegend component", () => {
         });
     });
 
+    it("renders MapAdjustScale as expected", () => {
+        const wrapper = getWrapper();
+        const adjust = wrapper.find(MapAdjustScale);
+        expect(adjust.props("name")).toBe("size");
+        expect(adjust.props("show")).toBe(false);
+        expect(adjust.props("scale")).toBe(propsData.sizeScale);
+        expect(adjust.props("metadata")).toBe(propsData.metadata);
+    });
+
     it("renders text for circle with 0 value as expected", () => {
         const wrapper = shallowMount(SizeLegend, {
             propsData: {
@@ -152,5 +167,38 @@ describe("SizeLegend component", () => {
 
         const lastText = wrapper.findAll("text").at(4);
         expect(lastText.text()).toBe("10k");
+    });
+
+    it("toggles show adjust scale", () => {
+        const wrapper = getWrapper();
+
+        const adjust = wrapper.find(MapAdjustScale);
+
+        const showAdjust = wrapper.find(".adjust-scale a");
+        expect(showAdjust.find("span").text()).toBe("Adjust scale");
+
+        showAdjust.trigger("click");
+        expect(adjust.props().show).toBe(true);
+        expect(showAdjust.find("span").text()).toBe("Done");
+
+        showAdjust.trigger("click");
+        expect(adjust.props().show).toBe(false);
+        expect(showAdjust.find("span").text()).toBe("Adjust scale");
+    });
+
+    it("emits update event when scale changes", () => {
+        const wrapper = getWrapper();
+
+        const newScale = {
+            type: ScaleType.Custom,
+            customMin: 0,
+            customMax: 1
+        };
+
+        const adjust = wrapper.find(MapAdjustScale);
+        adjust.vm.$emit("update", newScale);
+
+        expect(wrapper.emitted("update").length).toBe(1);
+        expect(wrapper.emitted("update")[0][0]).toBe(newScale);
     });
 });

--- a/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
@@ -2,6 +2,14 @@ import {shallowMount} from "@vue/test-utils";
 import SizeLegend from "../../../../app/components/plots/bubble/SizeLegend.vue";
 import {getRadius} from "../../../../app/components/plots/bubble/utils";
 import {LControl} from "vue2-leaflet";
+import Vuex from "vuex";
+import {emptyState} from "../../../../app/root";
+import registerTranslations from "../../../../app/store/translations/registerTranslations";
+
+const store = new Vuex.Store({
+    state: emptyState()
+});
+registerTranslations(store);
 
 const getWrapper = () => {
 

--- a/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
@@ -9,7 +9,7 @@ import {emptyState} from "../../../../app/root";
 import MapLegend from "../../../../app/components/plots/MapLegend.vue";
 import {prev, testData} from "../testHelpers";
 import Filters from "../../../../app/components/plots/Filters.vue";
-import {ColourScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 import Vue from "vue";
 
 const localVue = createLocalVue();
@@ -32,7 +32,7 @@ const propsData = {
     includeFilters: true,
     colourScales: {
         prevalence: {
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 1,
             customMax: 2
         }
@@ -129,7 +129,7 @@ describe("Choropleth component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.Default,
+                    type: ScaleType.Default,
                     customMin: 1,
                     customMax: 2
                 }
@@ -145,7 +145,7 @@ describe("Choropleth component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.DynamicFull,
+                    type: ScaleType.DynamicFull,
                     customMin: 1,
                     customMax: 2
                 }
@@ -161,7 +161,7 @@ describe("Choropleth component", () => {
         wrapper.setProps({
             colourScales: {
                 prevalence: {
-                    type: ColourScaleType.DynamicFiltered,
+                    type: ScaleType.DynamicFiltered,
                     customMin: 1,
                     customMax: 2
                 }
@@ -403,7 +403,7 @@ describe("Choropleth component", () => {
 
         const legend = wrapper.find(MapLegend);
         const newScale = {
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 5,
             customMax: 10
         };
@@ -424,7 +424,7 @@ describe("Choropleth component", () => {
         expect(wrapper.emitted("update-colour-scales")[0][0]).toStrictEqual({
             ...propsData.colourScales,
             plhiv: {
-                type: ColourScaleType.DynamicFiltered,
+                type: ScaleType.DynamicFiltered,
                 customMin: 1,
                 customMax: 100
             }

--- a/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
@@ -1,4 +1,4 @@
-import {initialiseColourScaleFromMetadata} from "../../../../app/components/plots/choropleth/utils";
+import {initialiseScaleFromMetadata} from "../../../../app/components/plots/choropleth/utils";
 import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
 describe("Choropleth utils", () => {
@@ -16,7 +16,7 @@ describe("Choropleth utils", () => {
             accuracy: null
         };
 
-        const result = initialiseColourScaleFromMetadata(meta);
+        const result = initialiseScaleFromMetadata(meta);
         expect(result.type).toBe(ScaleType.DynamicFiltered);
         expect(result.customMin).toBe(1.5);
         expect(result.customMax).toBe(2.5);

--- a/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/utils.test.ts
@@ -1,5 +1,5 @@
 import {initialiseColourScaleFromMetadata} from "../../../../app/components/plots/choropleth/utils";
-import {ColourScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 
 describe("Choropleth utils", () => {
     it("initialiseColourScaleFromMetatata sets min and max from meta", () => {
@@ -17,7 +17,7 @@ describe("Choropleth utils", () => {
         };
 
         const result = initialiseColourScaleFromMetadata(meta);
-        expect(result.type).toBe(ColourScaleType.DynamicFiltered);
+        expect(result.type).toBe(ScaleType.DynamicFiltered);
         expect(result.customMin).toBe(1.5);
         expect(result.customMax).toBe(2.5);
     });

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -53,8 +53,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected with custom scale", () => {
-        const wrapper = mount(MapAdjustScale, {
-            store, propsData: {
+        const wrapper = mount(MapAdjustScale, {store, propsData: {
                 metadata: {
                     max: 2,
                     min: 1,
@@ -170,6 +169,62 @@ describe("MapAdjustScale component", () => {
 
         expect((wrapper.find("#custom-min-input").element as HTMLInputElement).disabled).toBe(true);
         expect((wrapper.find("#custom-max-input").element as HTMLInputElement).disabled).toBe(true);
+    });
+
+    const showAllProps = {
+        metadata: {
+            max: 2,
+            min: 1,
+            format: '',
+            scale: 1,
+            accuracy: null
+        },
+        show: true,
+        step: 0.1,
+        colourScale: {
+            type: ColourScaleType.Custom,
+            customMin: 0,
+            customMax: 1
+        }
+    };
+
+    it("renders as expected when hide props both false", () => {
+        const wrapper = mount(MapAdjustScale, {store, propsData: showAllProps});
+
+        expect(wrapper.find(".static-container").exists()).toBe(true);
+        expect(wrapper.find(".static-default").exists()).toBe(true);
+        expect(wrapper.find(".static-custom").exists()).toBe(true);
+        expect(wrapper.find(".static-custom-values").exists()).toBe(true);
+    });
+
+    it("renders as expected when hide static defaults", () => {
+        const propsData = {...showAllProps, hideStaticDefault: true};
+        const wrapper = mount(MapAdjustScale, {store, propsData});
+
+        expect(wrapper.find(".static-container").exists()).toBe(true);
+        expect(wrapper.find(".static-default").exists()).toBe(false);
+        expect(wrapper.find(".static-custom").exists()).toBe(true);
+        expect(wrapper.find(".static-custom-values").exists()).toBe(true);
+    });
+
+    it("renders as expected when hide static custom", () => {
+        const propsData = {...showAllProps, hideStaticCustom: true};
+        const wrapper = mount(MapAdjustScale, {store, propsData});
+
+        expect(wrapper.find(".static-container").exists()).toBe(true);
+        expect(wrapper.find(".static-default").exists()).toBe(true);
+        expect(wrapper.find(".static-custom").exists()).toBe(false);
+        expect(wrapper.find(".static-custom-values").exists()).toBe(false);
+    });
+
+    it("renders as expected when hide static default and custom", () => {
+        const propsData = {...showAllProps, hideStaticDefault: true, hideStaticCustom: true};
+        const wrapper = mount(MapAdjustScale, {store, propsData});
+
+        expect(wrapper.find(".static-container").exists()).toBe(false);
+        expect(wrapper.find(".static-default").exists()).toBe(false);
+        expect(wrapper.find(".static-custom").exists()).toBe(false);
+        expect(wrapper.find(".static-custom-values").exists()).toBe(false);
     });
 
     it("emits update event when type changes", () => {

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -1,6 +1,6 @@
 import {mount, shallowMount} from '@vue/test-utils';
 import MapAdjustScale from "../../../app/components/plots/MapAdjustScale.vue";
-import {ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../../app/store/plottingSelections/plottingSelections";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
@@ -36,7 +36,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Default,
+                    type: ScaleType.Default,
                     customMin: 0,
                     customMax: 1
                 }
@@ -64,7 +64,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Custom,
+                    type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
                 }
@@ -102,7 +102,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.DynamicFull,
+                    type: ScaleType.DynamicFull,
                     customMin: 0,
                     customMax: 1
                 }
@@ -131,7 +131,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.DynamicFull,
+                    type: ScaleType.DynamicFull,
                     customMin: 2,
                     customMax: 3
                 }
@@ -155,7 +155,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.DynamicFiltered,
+                    type: ScaleType.DynamicFiltered,
                     customMin: 0,
                     customMax: 1
                 }
@@ -182,7 +182,7 @@ describe("MapAdjustScale component", () => {
         show: true,
         step: 0.1,
         colourScale: {
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 0,
             customMax: 1
         }
@@ -240,7 +240,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Default,
+                    type: ScaleType.Default,
                     customMin: 0,
                     customMax: 1
                 }
@@ -251,7 +251,7 @@ describe("MapAdjustScale component", () => {
 
         expect(wrapper.emitted("update").length).toBe(1);
         expect(wrapper.emitted("update")[0][0]).toStrictEqual({
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 0,
             customMax: 1
         });
@@ -260,7 +260,7 @@ describe("MapAdjustScale component", () => {
 
         expect(wrapper.emitted("update").length).toBe(2);
         expect(wrapper.emitted("update")[1][0]).toStrictEqual({
-            type: ColourScaleType.Default,
+            type: ScaleType.Default,
             customMin: 0,
             customMax: 1
         });
@@ -269,7 +269,7 @@ describe("MapAdjustScale component", () => {
 
         expect(wrapper.emitted("update").length).toBe(3);
         expect(wrapper.emitted("update")[1][0]).toStrictEqual({
-            type: ColourScaleType.DynamicFull,
+            type: ScaleType.DynamicFull,
             customMin: 0,
             customMax: 1
         });
@@ -278,7 +278,7 @@ describe("MapAdjustScale component", () => {
 
         expect(wrapper.emitted("update").length).toBe(4);
         expect(wrapper.emitted("update")[1][0]).toStrictEqual({
-            type: ColourScaleType.DynamicFiltered,
+            type: ScaleType.DynamicFiltered,
             customMin: 0,
             customMax: 1
         });
@@ -297,7 +297,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Custom,
+                    type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
                 }
@@ -308,7 +308,7 @@ describe("MapAdjustScale component", () => {
         wrapper.find("#custom-min-input").trigger("change");
         expect(wrapper.emitted("update").length).toBe(1);
         expect(wrapper.emitted("update")[0][0]).toStrictEqual({
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 0.5,
             customMax: 1
         });
@@ -317,7 +317,7 @@ describe("MapAdjustScale component", () => {
         wrapper.find("#custom-max-input").trigger("keyup");
         expect(wrapper.emitted("update").length).toBe(2);
         expect(wrapper.emitted("update")[1][0]).toStrictEqual({
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 0.5,
             customMax: 1.5
         });
@@ -336,7 +336,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Custom,
+                    type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
                 }
@@ -365,7 +365,7 @@ describe("MapAdjustScale component", () => {
                 show: true,
                 step: 0.1,
                 colourScale: {
-                    type: ColourScaleType.Custom,
+                    type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
                 }
@@ -373,7 +373,7 @@ describe("MapAdjustScale component", () => {
         });
 
         const newScale = {
-            type: ColourScaleType.Default,
+            type: ScaleType.Default,
             customMin: 1,
             customMax: 2
         };

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -352,7 +352,7 @@ describe("MapAdjustScale component", () => {
         expect(wrapper.emitted("update").length).toBe(1);
     });
 
-    it("updates colourScaleToAdjust when colourScale property changes", () => {
+    it("updates scaleToAdjust when scale property changes", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
                 metadata: {

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -16,7 +16,7 @@ describe("MapAdjustScale component", () => {
         const wrapper = shallowMount(MapAdjustScale, {
             store, propsData: {
                 show: false,
-                colourScale: {}
+                scale: {}
             }
         });
 
@@ -35,7 +35,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Default,
                     customMin: 0,
                     customMax: 1
@@ -63,7 +63,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
@@ -101,7 +101,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.DynamicFull,
                     customMin: 0,
                     customMax: 1
@@ -130,7 +130,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.DynamicFull,
                     customMin: 2,
                     customMax: 3
@@ -154,7 +154,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.DynamicFiltered,
                     customMin: 0,
                     customMax: 1
@@ -181,7 +181,7 @@ describe("MapAdjustScale component", () => {
         },
         show: true,
         step: 0.1,
-        colourScale: {
+        scale: {
             type: ScaleType.Custom,
             customMin: 0,
             customMax: 1
@@ -239,7 +239,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Default,
                     customMin: 0,
                     customMax: 1
@@ -296,7 +296,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
@@ -335,7 +335,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
@@ -364,7 +364,7 @@ describe("MapAdjustScale component", () => {
                 },
                 show: true,
                 step: 0.1,
-                colourScale: {
+                scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
@@ -377,9 +377,9 @@ describe("MapAdjustScale component", () => {
             customMin: 1,
             customMax: 2
         };
-        wrapper.setProps({colourScale: newScale});
+        wrapper.setProps({scale: newScale});
 
-        expect((wrapper.vm as any).colourScaleToAdjust).toStrictEqual(newScale);
+        expect((wrapper.vm as any).scaleToAdjust).toStrictEqual(newScale);
 
     });
 });

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -12,36 +12,43 @@ describe("MapAdjustScale component", () => {
     });
     registerTranslations(store);
 
+    const propsData = {
+        name: "test",
+        metadata: {
+            max: 2,
+            min: 1,
+            format: '',
+            scale: 1,
+            accuracy: null
+        },
+        show: true,
+        step: 0.1,
+        scale: {
+            type: ScaleType.Default,
+            customMin: 0,
+            customMax: 1
+        }
+    };
+
     it("does not render if show is false", () => {
         const wrapper = shallowMount(MapAdjustScale, {
-            store, propsData: {
-                show: false,
-                scale: {}
-            }
+            store, propsData: {...propsData, show: false}
         });
 
         expect(wrapper.findAll("div").length).toBe(0);
     });
 
+    it("renders radio button names as expected", () => {
+        const wrapper = shallowMount(MapAdjustScale, {store, propsData});
+        const name = "test-scaleType";
+        expect((wrapper.find("#type-input-default").element as HTMLInputElement).name).toBe(name);
+        expect((wrapper.find("#type-input-custom").element as HTMLInputElement).name).toBe(name);
+        expect((wrapper.find("#type-input-dynamic-full").element as HTMLInputElement).name).toBe(name);
+        expect((wrapper.find("#type-input-dynamic-filtered").element as HTMLInputElement).name).toBe(name);
+    });
+
     it("renders as expected with default scale", () => {
-        const wrapper = mount(MapAdjustScale, {
-            store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
-                scale: {
-                    type: ScaleType.Default,
-                    customMin: 0,
-                    customMax: 1
-                }
-            }
-        });
+        const wrapper = mount(MapAdjustScale, {store, propsData});
 
         expect((wrapper.find("#type-input-default").element as HTMLInputElement).checked).toBe(true);
         expect((wrapper.find("#type-input-custom").element as HTMLInputElement).checked).toBe(false);
@@ -54,16 +61,8 @@ describe("MapAdjustScale component", () => {
 
     it("renders as expected with custom scale", () => {
         const wrapper = mount(MapAdjustScale, {store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
-                scale: {
+            ...propsData,
+            scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
                     customMax: 1
@@ -92,15 +91,7 @@ describe("MapAdjustScale component", () => {
     it("renders as expected with full dynamic scale", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
+                ...propsData,
                 scale: {
                     type: ScaleType.DynamicFull,
                     customMin: 0,
@@ -121,6 +112,7 @@ describe("MapAdjustScale component", () => {
     it("renders scale input modifier when scale parameter given", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
+                ...propsData,
                 metadata: {
                     max: 2,
                     min: 1,
@@ -128,8 +120,6 @@ describe("MapAdjustScale component", () => {
                     scale: 100,
                     accuracy: null
                 },
-                show: true,
-                step: 0.1,
                 scale: {
                     type: ScaleType.DynamicFull,
                     customMin: 2,
@@ -145,15 +135,7 @@ describe("MapAdjustScale component", () => {
     it("renders as expected with filtered dynamic scale", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
+                ...propsData,
                 scale: {
                     type: ScaleType.DynamicFiltered,
                     customMin: 0,
@@ -171,25 +153,8 @@ describe("MapAdjustScale component", () => {
         expect((wrapper.find("#custom-max-input").element as HTMLInputElement).disabled).toBe(true);
     });
 
-    const showAllProps = {
-        metadata: {
-            max: 2,
-            min: 1,
-            format: '',
-            scale: 1,
-            accuracy: null
-        },
-        show: true,
-        step: 0.1,
-        scale: {
-            type: ScaleType.Custom,
-            customMin: 0,
-            customMax: 1
-        }
-    };
-
     it("renders as expected when hide props both false", () => {
-        const wrapper = mount(MapAdjustScale, {store, propsData: showAllProps});
+        const wrapper = mount(MapAdjustScale, {store, propsData});
 
         expect(wrapper.find(".static-container").exists()).toBe(true);
         expect(wrapper.find(".static-default").exists()).toBe(true);
@@ -198,8 +163,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected when hide static defaults", () => {
-        const propsData = {...showAllProps, hideStaticDefault: true};
-        const wrapper = mount(MapAdjustScale, {store, propsData});
+        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticDefault: true}});
 
         expect(wrapper.find(".static-container").exists()).toBe(true);
         expect(wrapper.find(".static-default").exists()).toBe(false);
@@ -208,8 +172,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected when hide static custom", () => {
-        const propsData = {...showAllProps, hideStaticCustom: true};
-        const wrapper = mount(MapAdjustScale, {store, propsData});
+        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticCustom: true}});
 
         expect(wrapper.find(".static-container").exists()).toBe(true);
         expect(wrapper.find(".static-default").exists()).toBe(true);
@@ -218,8 +181,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("renders as expected when hide static default and custom", () => {
-        const propsData = {...showAllProps, hideStaticDefault: true, hideStaticCustom: true};
-        const wrapper = mount(MapAdjustScale, {store, propsData});
+        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticDefault: true, hideStaticCustom: true}});
 
         expect(wrapper.find(".static-container").exists()).toBe(false);
         expect(wrapper.find(".static-default").exists()).toBe(false);
@@ -228,24 +190,7 @@ describe("MapAdjustScale component", () => {
     });
 
     it("emits update event when type changes", () => {
-        const wrapper = mount(MapAdjustScale, {
-            store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
-                scale: {
-                    type: ScaleType.Default,
-                    customMin: 0,
-                    customMax: 1
-                }
-            }
-        });
+        const wrapper = mount(MapAdjustScale, {store, propsData});
 
         wrapper.find("#type-input-custom").trigger("click");
 
@@ -287,15 +232,7 @@ describe("MapAdjustScale component", () => {
     it("emits update event when custom min or max changes", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
+                ...propsData,
                 scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
@@ -326,15 +263,7 @@ describe("MapAdjustScale component", () => {
     it("does not emit update event when type is Custom and custom max is not greater than custom min", () => {
         const wrapper = mount(MapAdjustScale, {
             store, propsData: {
-                metadata: {
-                    max: 2,
-                    min: 1,
-                    format: '',
-                    scale: 1,
-                    accuracy: null
-                },
-                show: true,
-                step: 0.1,
+                ...propsData,
                 scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
@@ -354,7 +283,9 @@ describe("MapAdjustScale component", () => {
 
     it("updates scaleToAdjust when scale property changes", () => {
         const wrapper = mount(MapAdjustScale, {
+            name: "test",
             store, propsData: {
+                ...propsData,
                 metadata: {
                     max: 2,
                     min: 1,
@@ -362,8 +293,6 @@ describe("MapAdjustScale component", () => {
                     scale: 1,
                     accuracy: null
                 },
-                show: true,
-                step: 0.1,
                 scale: {
                     type: ScaleType.Custom,
                     customMin: 0,
@@ -380,6 +309,5 @@ describe("MapAdjustScale component", () => {
         wrapper.setProps({scale: newScale});
 
         expect((wrapper.vm as any).scaleToAdjust).toStrictEqual(newScale);
-
     });
 });

--- a/src/app/static/src/tests/components/plots/mapLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/mapLegend.test.ts
@@ -38,26 +38,26 @@ describe("Map legend component", () => {
             .getPropertyValue("background")).toBe("rgb(0, 0, 0)");
     };
 
-    const wrapper = shallowMount(MapLegend, {
-        propsData: {
-            metadata: {
-                max: 2,
-                min: 1,
-                colour: "interpolateGreys",
-                invert_scale: false,
-                name: "indicator",
-                format: '',
-                scale: 1,
-                accuracy: null
-            },
-            colourScale: {
-                type: ScaleType.Default,
+    const propsData = {
+        metadata: {
+            max: 2,
+            min: 1,
+            colour: "interpolateGreys",
+            invert_scale: false,
+            name: "indicator",
+            format: '',
+            scale: 1,
+            accuracy: null
+        },
+        colourScale: {
+            type: ScaleType.Default,
                 customMin: 1.5,
                 customMax: 2.5
-            },
-            colourRange
-        }
-    });
+        },
+        colourRange
+    };
+
+    const wrapper = shallowMount(MapLegend, {propsData});
 
     it("renders the label", () => {
         const label = wrapper.find("label");
@@ -72,6 +72,15 @@ describe("Map legend component", () => {
     it("renders icons with colors", () => {
         const icons = wrapper.findAll("i");
         expectIcons(icons);
+    });
+
+    it("renders MapAdjustScale as expected", () => {
+        const adjust = wrapper.find(MapAdjustScale);
+        expect(adjust.props("name")).toBe("colour");
+        expect(adjust.props("show")).toBe(false);
+        expect(adjust.props("scale")).toBe(propsData.colourScale);
+        expect(adjust.props("metadata")).toBe(propsData.metadata);
+        expect(adjust.props("step")).toBe(0.1);
     });
 
     it("calculates 6 levels from min to max with negative min", () => {
@@ -288,9 +297,6 @@ describe("Map legend component", () => {
         });
 
         const adjust = wrapper.find(MapAdjustScale);
-        expect(adjust.props().show).toBe(false);
-        expect(adjust.props().scale).toBe(colourScale);
-        expect(adjust.props().step).toBe(2);
 
         const showAdjust = wrapper.find(".adjust-scale a");
         expect(showAdjust.find("span").text()).toBe("Adjust scale");

--- a/src/app/static/src/tests/components/plots/mapLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/mapLegend.test.ts
@@ -180,7 +180,7 @@ describe("Map legend component", () => {
     });
 
     it("does not render adjust link if no colour scale", () => {
-        expect(wrapper.find("#adjust-scale").exists()).toBe(true);
+        expect(wrapper.find(".adjust-scale").exists()).toBe(true);
 
         const noScaleWrapper = shallowMount(MapLegend, {
             propsData: {
@@ -289,10 +289,10 @@ describe("Map legend component", () => {
 
         const adjust = wrapper.find(MapAdjustScale);
         expect(adjust.props().show).toBe(false);
-        expect(adjust.props().colourScale).toBe(colourScale);
+        expect(adjust.props().scale).toBe(colourScale);
         expect(adjust.props().step).toBe(2);
 
-        const showAdjust = wrapper.find("#adjust-scale a");
+        const showAdjust = wrapper.find(".adjust-scale a");
         expect(showAdjust.find("span").text()).toBe("Adjust scale");
 
         showAdjust.trigger("click");

--- a/src/app/static/src/tests/components/plots/mapLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/mapLegend.test.ts
@@ -1,7 +1,7 @@
 import {createLocalVue, shallowMount, WrapperArray} from '@vue/test-utils';
 import MapLegend from "../../../app/components/plots/MapLegend.vue";
 import {Vue} from "vue/types/vue";
-import {ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../../app/store/plottingSelections/plottingSelections";
 import MapAdjustScale from "../../../app/components/plots/MapAdjustScale.vue";
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
@@ -51,7 +51,7 @@ describe("Map legend component", () => {
                 accuracy: null
             },
             colourScale: {
-                type: ColourScaleType.Default,
+                type: ScaleType.Default,
                 customMin: 1.5,
                 customMax: 2.5
             },
@@ -215,7 +215,7 @@ describe("Map legend component", () => {
                     accuracy: null
                 },
                 colourScale: {
-                    type: ColourScaleType.Default
+                    type: ScaleType.Default
                 },
                 colourRange
             }
@@ -255,7 +255,7 @@ describe("Map legend component", () => {
                     accuracy: null
                 },
                 colourScale: {
-                    type: ColourScaleType.Default
+                    type: ScaleType.Default
                 },
                 colourRange: {max: 60000, min: 1000}
             }
@@ -267,7 +267,7 @@ describe("Map legend component", () => {
 
     it("toggles show adjust scale", () => {
         const colourScale = {
-            type: ColourScaleType.Default
+            type: ScaleType.Default
         };
 
         const wrapper = shallowMount(MapLegend, {
@@ -317,13 +317,13 @@ describe("Map legend component", () => {
                     scale: 1,
                     accuracy: null
                 },
-                colourScale: {type: ColourScaleType.Default},
+                colourScale: {type: ScaleType.Default},
                 colourRange
             }
         });
 
         const newColourScale = {
-            type: ColourScaleType.Custom,
+            type: ScaleType.Custom,
             customMin: 0,
             customMax: 1
         };

--- a/src/app/static/src/tests/components/plots/testHelpers.ts
+++ b/src/app/static/src/tests/components/plots/testHelpers.ts
@@ -124,7 +124,7 @@ export const testData = {
             area_id: "MWI_3_2", plhiv: 20, prevalence: 0, age: "0:15", sex: "female"
         },
         {
-            area_id: "MWI_4_2", plhiv: 20, prevalence: 0.1, age: "0:15", sex: "male"
+            area_id: "MWI_4_2", plhiv: 19, prevalence: 0.1, age: "0:15", sex: "male"
         },
         {
             area_id: "MWI_4_1", plhiv: 20, prevalence: 0.9, age: "0:15", sex: "male"

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -3,7 +3,7 @@ import {
     getColor,
     getIndicatorRange,
     toIndicatorNameLookup,
-    roundToContext, colourScaleStepFromMetadata, roundRange, iterateDataValues, findPath, formatOutput, formatLegend
+    roundToContext, scaleStepFromMetadata, roundRange, iterateDataValues, findPath, formatOutput, formatLegend
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 import {Filter} from "../../../app/generated";
@@ -372,12 +372,12 @@ describe("plot utils", () => {
         expect(roundToContext(-0.3614, [-0.45, 0])).toBe(-0.361);
     });
 
-    it("colourScaleStepFromMetadata returns expected value", () => {
+    it("scaleStepFromMetadata returns expected value", () => {
         const meta = {
             min: 0,
             max: 1
         };
-        expect(colourScaleStepFromMetadata(meta as any)).toBe(0.1);
+        expect(scaleStepFromMetadata(meta as any)).toBe(0.1);
     });
 
     it("roundRange rounds as expected", () => {

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -18,7 +18,7 @@ import {actions} from "../../../app/store/surveyAndProgram/actions";
 import {mutations} from "../../../app/store/surveyAndProgram/mutations";
 import {getters} from "../../../app/store/surveyAndProgram/getters";
 import {mutations as selectionsMutations} from "../../../app/store/plottingSelections/mutations";
-import {ColourScaleSelections, ColourScaleType} from "../../../app/store/plottingSelections/plottingSelections";
+import {ScaleSelections, ScaleType} from "../../../app/store/plottingSelections/plottingSelections";
 import {expectTranslated} from "../../testHelpers";
 import ManageFile from "../../../app/components/files/ManageFile.vue";
 
@@ -70,11 +70,11 @@ describe("Survey and programme component", () => {
                         selectedSAPColourScales: () => {
                             return {
                                 prevalence: {
-                                    type: ColourScaleType.Custom,
+                                    type: ScaleType.Custom,
                                     customMin: 1,
                                     customMax: 2
                                 }
-                            } as ColourScaleSelections
+                            } as ScaleSelections
                         }
                     },
                     mutations: selectionsMutations
@@ -144,7 +144,7 @@ describe("Survey and programme component", () => {
         expect(choro.props().selections).toStrictEqual({selectedFilterOptions: "TEST SELECTIONS"});
         expect(choro.props().colourScales).toEqual({
             prevalence: {
-                type: ColourScaleType.Custom,
+                type: ScaleType.Custom,
                 customMin: 1,
                 customMax: 2
             }

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -15,6 +15,7 @@ import {
 import {localStorageManager, serialiseState} from "../app/localStorageManager";
 import {RootState} from "../app/root";
 import {DataType} from "../app/store/surveyAndProgram/surveyAndProgram";
+import {currentHintVersion} from "../app/hintVersion";
 
 declare const currentUser: string; // set in jest config, or on the index page when run for real
 
@@ -110,7 +111,7 @@ describe("LocalStorageManager", () => {
         const testState = {baseline: mockBaselineState()};
         localStorageManager.savePartialState(testState);
 
-        expect(spy.mock.calls[0][0]).toBe("hintAppState_v1.0.0");
+        expect(spy.mock.calls[0][0]).toBe(`hintAppState_v${currentHintVersion}`);
         expect(spy.mock.calls[0][1]).toBe(JSON.stringify(testState));
     });
 });

--- a/src/app/static/src/tests/plottingSelections/mutations.test.ts
+++ b/src/app/static/src/tests/plottingSelections/mutations.test.ts
@@ -1,7 +1,7 @@
 import {mutations} from "../../app/store/plottingSelections/mutations";
 import {mockColourScales, mockPlottingSelections} from "../mocks";
 import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
-import {ColourScaleType} from "../../app/store/plottingSelections/plottingSelections";
+import {ScaleType} from "../../app/store/plottingSelections/plottingSelections";
 
 describe("Plotting selections mutations", () => {
 
@@ -66,9 +66,9 @@ describe("Plotting selections mutations", () => {
         });
     });
 
-    const colourScales = {
+    const testScales = {
         prevalence: {
-            type: ColourScaleType.Default
+            type: ScaleType.Default
         }
     };
 
@@ -76,43 +76,52 @@ describe("Plotting selections mutations", () => {
         const testState = mockPlottingSelections();
         mutations.updateOutputColourScales(testState, {
             type: "updateOutputColourScales",
-            payload: colourScales
+            payload: testScales
         });
-        expect(testState.colourScales.output).toBe(colourScales);
+        expect(testState.colourScales.output).toBe(testScales);
+    });
+
+    it("updateOutputBubbleSizeScales updates bubble size output scales", () => {
+        const testState = mockPlottingSelections();
+        mutations.updateOutputBubbleSizeScales(testState, {
+            type: "updateOutputBubbleSizeScales",
+            payload: testScales
+        });
+        expect(testState.bubbleSizeScales.output).toBe(testScales);
     });
 
     it("updateSAPColourScales updates colour scales correctly for survey", () => {
         const testState = mockPlottingSelections();
         mutations.updateSAPColourScales(testState, {
             type: "updateSAPColourScales",
-            payload: [DataType.Survey, colourScales]
+            payload: [DataType.Survey, testScales]
         });
-        expect(testState.colourScales.survey).toBe(colourScales);
+        expect(testState.colourScales.survey).toBe(testScales);
     });
 
     it("updateSAPColourScales updates colour scales correctly for program", () => {
         const testState = mockPlottingSelections();
         mutations.updateSAPColourScales(testState, {
             type: "updateSAPColourScales",
-            payload: [DataType.Program, colourScales]
+            payload: [DataType.Program, testScales]
         });
-        expect(testState.colourScales.program).toBe(colourScales);
+        expect(testState.colourScales.program).toBe(testScales);
     });
 
     it("updateSAPColourScales updates colour scales correctly for anc", () => {
         const testState = mockPlottingSelections();
         mutations.updateSAPColourScales(testState, {
             type: "updateSAPColourScales",
-            payload: [DataType.ANC, colourScales]
+            payload: [DataType.ANC, testScales]
         });
-        expect(testState.colourScales.anc).toBe(colourScales);
+        expect(testState.colourScales.anc).toBe(testScales);
     });
 
     it("updateSAPColourScales does nothgin if unknown DataType", () => {
         const testState = mockPlottingSelections();
         mutations.updateSAPColourScales(testState, {
             type: "updateSAPColourScales",
-            payload: [99 as DataType, colourScales]
+            payload: [99 as DataType, testScales]
         });
         expect(testState.colourScales.survey).toStrictEqual({});
         expect(testState.colourScales.program).toStrictEqual({});

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -23,7 +23,7 @@ import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {RootState} from "../../app/root";
 import {
     BarchartSelections,
-    ColourScaleType,
+    ScaleType,
     initialPlottingSelectionsState
 } from "../../app/store/plottingSelections/plottingSelections";
 import {initialMetadataState} from "../../app/store/metadata/metadata";
@@ -198,7 +198,7 @@ describe("Root mutations", () => {
         //These should not be reset
         state.plottingSelections.sapChoropleth.detail = 2;
         state.plottingSelections.colourScales.anc = {
-            testIndicator: {type: ColourScaleType.Custom} as any
+            testIndicator: {type: ScaleType.Custom} as any
         };
 
         mutations.ResetOutputs(state);
@@ -208,7 +208,7 @@ describe("Root mutations", () => {
         expect(state.plottingSelections.barchart.xAxisId).toBe("");
         expect(state.plottingSelections.outputChoropleth.detail).toBe(-1);
         expect(state.plottingSelections.sapChoropleth.detail).toBe(2);
-        expect(state.plottingSelections.colourScales.anc.testIndicator.type).toBe(ColourScaleType.Custom);
+        expect(state.plottingSelections.colourScales.anc.testIndicator.type).toBe(ScaleType.Custom);
 
         expect(state.modelCalibrate).toStrictEqual(initialModelCalibrateState())
     });


### PR DESCRIPTION
# Pull Request Template

## Description

Sorry, this is a big changeset, but a lot of the changes are just from renaming 'ColourScale..' types to just 'Scale..' as they are being re-used for size scale now as well.

I was able to completely re-use the logic for finding the colour range, and pulled it out into a method to be used both for finding colour range and size range.  I did put a couple of properties into the MapAdjustScale component to allow the static range options to be hidden for now, but the other tickets for enabling the two static ranges should just be a case of switching off these properties for the Bubble Plot and testing that the scaling works. 

The only other significant changes is adding bubble size scales to the plotting selections modules and percolating updates from MapAdjustScale. 

This PR is using the new template which I merged in order to try it out, but I think we should change its checklist, since at the moment the expectation is that the user won't check all the boxes to complete the PR (e.g it'll be one of major, minor or patch version update). However, github helpfully labels the PR as having completed 'x of y' items so this will look incomplete. So I think we should either put a note into the template to delete options which are not relevant, or combine options (e.g. 'The build is passing, or failing only because of ADR tests'). Could probably also lose the 'Pull Request Template' heading, doesn't seem necessary. What do you think?

## Type of changes

- [ ] Major
- [x] Minor
- [ ] Patches

## Checklist

- [x] I have incremented version number
- [ ] The build passed successfully
- [x] The build failed because of ADR tests
