### PR TITLE
mrc-1981 Fix bubble plot for value ranges with one value only

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hint 1.1.1
+* Fixed bug where bubble plot failed to display bubble for single-value range.
+
 # hint 1.1.0
 
 * Bubble plot size can be scaled by filtered dataset

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -103,20 +103,25 @@
                 return this.width / 2;
             },
             circles: function () {
-                //We treat the minimum circle differently, since the smallest radius is actually likely to cover quite
-                //a wide range of low outliers, so we show the value for the next pixel up and prefix with '<'
-                const nextMinRadius = this.minRadius + 1;
-                const valueScalePoint = this.valueScalePointFromRadius(nextMinRadius);
-                const nextValue = this.valueFromValueScalePoint(valueScalePoint);
-                const minCircle = this.circleFromRadius(this.minRadius, nextValue, true);
+                if (this.indicatorRange.min == this.indicatorRange.max) {
+                    // only one value in range - show max circle only
+                    return [this.circleFromRadius(this.maxRadius, this.indicatorRange.max, false)];
+                } else {
+                    //We treat the minimum circle differently, since the smallest radius is actually likely to cover quite
+                    //a wide range of low outliers, so we show the value for the next pixel up and prefix with '<'
+                    const nextMinRadius = this.minRadius + 1;
+                    const valueScalePoint = this.valueScalePointFromRadius(nextMinRadius);
+                    const nextValue = this.valueFromValueScalePoint(valueScalePoint);
+                    const minCircle = this.circleFromRadius(this.minRadius, nextValue, true);
 
-                const nonMinCircles = this.steps.map((s: number) => {
-                    const value = this.indicatorRange.min + (s * (this.indicatorRange.max - this.indicatorRange.min));
-                    const r = getRadius(value, this.indicatorRange.min, this.indicatorRange.max, this.minRadius, this.maxRadius);
-                    return this.circleFromRadius(r, value, false)
-                });
+                    const nonMinCircles = this.steps.map((s: number) => {
+                        const value = this.indicatorRange.min + (s * (this.indicatorRange.max - this.indicatorRange.min));
+                        const r = getRadius(value, this.indicatorRange.min, this.indicatorRange.max, this.minRadius, this.maxRadius);
+                        return this.circleFromRadius(r, value, false)
+                    });
 
-                return [minCircle, ...nonMinCircles];
+                    return [minCircle, ...nonMinCircles];
+                }
             },
             scaleStep: function () {
                 return this.metadata ? scaleStepFromMetadata(this.metadata) : 1;

--- a/src/app/static/src/app/components/plots/bubble/utils.ts
+++ b/src/app/static/src/app/components/plots/bubble/utils.ts
@@ -3,6 +3,11 @@ import {getColor, iterateDataValues} from "../utils";
 import {ChoroplethIndicatorMetadata, FilterOption} from "../../../generated";
 
 export const getRadius = function (value: number, minValue: number, maxValue: number, minRadius: number, maxRadius: number) {
+    //if range is a single value, just return max radius as no interpolation possible
+    if (minValue == maxValue) {
+        return maxRadius;
+    }
+
     //where is value on a scale of 0-1 between minValue and maxValue
     const scalePoint = (value - minValue) / (maxValue - minValue);
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.1.0";
+export const currentHintVersion = "1.1.1";

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -149,6 +149,50 @@ describe("BubblePlot component", () => {
         expect(sizeLegend.props().sizeScale).toBe(propsData.sizeScales.plhiv);
     });
 
+    it("renders plot as expected with single bubble range value", () => {
+        const customProps = {
+          ...propsData,
+          selections: {
+              ...propsData.selections,
+              selectedFilterOptions: {
+                  age: [{id: "0:15", label: "0-15"}],
+                  sex: [{id: "female", label: "Female"}],
+                  area: [{id: "MWI_4_1", label: "4.1"}]
+              }
+          },
+          sizeScales: {
+            plhiv: {
+                type: ScaleType.DynamicFiltered,
+                customMin: 0,
+                customMax: 100
+            }
+          }
+        };
+        const wrapper = getWrapper(customProps);
+
+        expect((wrapper.vm as any).sizeRange).toStrictEqual({min: 10, max: 10});
+
+        const maxRadius = 70;
+
+        //expect single circle with max radius
+        const circles = wrapper.findAll(LCircleMarker);
+        expect(circles.length).toBe(1);
+        expect(circles.at(0).props().latLng).toEqual([-15.2047, 35.7083]);
+        expect(circles.at(0).props().radius).toEqual(maxRadius);
+        expect(circles.at(0).find(LTooltip).props().content).toEqual(`<div>
+                            <strong>North West</strong>
+                            <br/>Prevalence: 10.00%
+                            <br/>PLHIV: 100
+                        </div>`);
+        const meta = propsData.indicators[1];
+        const colourRange = {min: meta.min, max: meta.max};
+        let color = getColor(0.1, meta, colourRange);
+        expect(circles.at(0).props().color).toEqual(color);
+        expect(circles.at(0).props().fillColor).toEqual(color);
+
+    });
+
+
     it("computes sizeRange", async () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;

--- a/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
@@ -25,8 +25,9 @@ const propsData = {
     }
 };
 
-const getWrapper = () => {
-    return shallowMount(SizeLegend, {propsData});
+const getWrapper = (partialProps = {}) => {
+    const testProps = {...propsData, ...partialProps};
+    return shallowMount(SizeLegend, {propsData: testProps});
 };
 
 const expectCirclesEqual = (actual: any, expected: any) => {
@@ -90,6 +91,14 @@ describe("SizeLegend component", () => {
         circles.forEach((circle: any, index: number) => {
             expectCirclesEqual(circle, expected[index])
         });
+    });
+
+    it("computes circles for single value range", () => {
+        const wrapper = getWrapper({indicatorRange: {min: 1, max: 1}});
+        const vm = wrapper.vm as any;
+        const circles = vm.circles;
+        expect(circles.length).toBe(1);
+        expectCirclesEqual(circles[0], {y: 120, radius: 110, text: "1", textY: 10});
     });
 
     it("renders as expected", () => {


### PR DESCRIPTION
## Description

As I suspected, the problem was that the bubble plot wasn't prepared for a value range with a single value, i.e. where min == max, and was getting itself into all sorts of divide-by-0 difficulty. 

In fixing this, I've introduced a slight inconsistency - it felt natural to make the only bubble size for the sole value the maximum bubble size. However I noticed that the colour we use for such a value is the colour representing the lower end of the colour scale. What do you think? Should it be consistified by taking min bubble size, or max colour value? Or is no-one going to care?

## Type of changes

- [ ] Major
- [ ] Minor
- [x] Patches

## Checklist

- [x] I have incremented version number
- [ ] The build passed successfully
- [x] The build failed because of ADR tests
