### PR TITLE
Mrc 1977 App uses data in validation after it has been removed

### DIFF
--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -85,7 +85,7 @@
                 } as PartialFileUploadProps),
                 hasBaselineError: state => !!state.baselineError,
                 baselineError: state => state.baselineError,
-                validating: state => state.validating
+                validating: state => state.validating,
             }),
             ...mapState<MetadataState>("metadata", {
                 plottingMetadataError: state => state.plottingMetadataError

--- a/src/app/static/src/app/components/baseline/Baseline.vue
+++ b/src/app/static/src/app/components/baseline/Baseline.vue
@@ -85,7 +85,7 @@
                 } as PartialFileUploadProps),
                 hasBaselineError: state => !!state.baselineError,
                 baselineError: state => state.baselineError,
-                validating: state => state.validating,
+                validating: state => state.validating
             }),
             ...mapState<MetadataState>("metadata", {
                 plottingMetadataError: state => state.plottingMetadataError

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -1,4 +1,4 @@
-import {ActionContext, ActionTree, Dispatch} from 'vuex';
+import {ActionContext, ActionTree, Dispatch, mapState} from 'vuex';
 import {BaselineState} from "./baseline";
 import {RootState} from "../../root";
 import {api} from "../../apiService";
@@ -7,6 +7,7 @@ import {BaselineMutation} from "./mutations";
 import qs from "qs";
 import {findResource} from "../../utils";
 import {DatasetResourceSet} from "../../types";
+import {MetadataState} from "../metadata/metadata";
 
 export interface BaselineActions {
     refreshDatasetMetadata: (store: ActionContext<BaselineState, RootState>) => void
@@ -24,28 +25,28 @@ export interface BaselineActions {
     validate: (store: ActionContext<BaselineState, RootState>) => void
 }
 
-enum uploadFileType {
+enum uploadedFileType {
     POPULATION = "population",
-    SHAPE = "shape",
+    SHAPE = "shape"
 }
 
 const fileHasValidated = {
     pjnz: false,
     population: false,
-    shape: false,
+    shape: false
 }
 
 const uploadCallback = (dispatch: Dispatch, response: any) => {
     if (response) {
         switch (response.data.type) {
-            case uploadFileType.POPULATION: {
+            case uploadedFileType.POPULATION: {
                 fileHasValidated.population = true
                 if (fileHasValidated.pjnz && fileHasValidated.shape) {
                     dispatch('validate');
                 }
                 break;
             }
-            case uploadFileType.SHAPE: {
+            case uploadedFileType.SHAPE: {
                 fileHasValidated.shape = true
                 if (fileHasValidated.pjnz && fileHasValidated.population) {
                     dispatch('validate');
@@ -91,7 +92,7 @@ async function uploadOrImportPopulation(context: ActionContext<BaselineState, Ro
         .freezeResponse()
         .postAndReturn<PopulationResponse>(options.url, options.payload)
         .then((response) => {
-            uploadCallback(dispatch, response)
+            uploadCallback(dispatch, response);
         });
 }
 

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -29,7 +29,7 @@ enum uploadFileType {
     SHAPE = "shape",
 }
 
-let syncValidation = {
+const fileHasValidated = {
     pjnz: false,
     population: false,
     shape: false,
@@ -39,15 +39,15 @@ const uploadCallback = (dispatch: Dispatch, response: any) => {
     if (response) {
         switch (response.data.type) {
             case uploadFileType.POPULATION: {
-                syncValidation.population = true
-                if (syncValidation.pjnz && syncValidation.shape) {
+                fileHasValidated.population = true
+                if (fileHasValidated.pjnz && fileHasValidated.shape) {
                     dispatch('validate');
                 }
                 break;
             }
             case uploadFileType.SHAPE: {
-                syncValidation.shape = true
-                if (syncValidation.pjnz && syncValidation.population) {
+                fileHasValidated.shape = true
+                if (fileHasValidated.pjnz && fileHasValidated.population) {
                     dispatch('validate');
                 }
                 break;
@@ -62,7 +62,6 @@ interface UploadImportOptions {
     payload: FormData | string
 }
 
-
 async function uploadOrImportPJNZ(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions) {
     const {commit, dispatch, state} = context;
     commit({type: BaselineMutation.PJNZUpdated, payload: null});
@@ -74,8 +73,8 @@ async function uploadOrImportPJNZ(context: ActionContext<BaselineState, RootStat
         .then((response) => {
             if (response) {
                 dispatch('metadata/getPlottingMetadata', state.iso3, {root: true});
-                syncValidation.pjnz = true
-                if (syncValidation.shape && syncValidation.population) {
+                fileHasValidated.pjnz = true
+                if (fileHasValidated.shape && fileHasValidated.population) {
                     dispatch('validate');
                 }
             }
@@ -168,7 +167,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
                 if (response) {
                     commit({type: BaselineMutation.PJNZUpdated, payload: null});
                     dispatch("surveyAndProgram/deleteAll", {}, {root: true});
-                    syncValidation.pjnz = false
+                    fileHasValidated.pjnz = false
                 }
             });
     },
@@ -181,7 +180,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
                 if (response) {
                     commit({type: BaselineMutation.ShapeUpdated, payload: null});
                     dispatch("surveyAndProgram/deleteAll", {}, {root: true});
-                    syncValidation.shape = false
+                    fileHasValidated.shape = false
                 }
             });
     },
@@ -194,7 +193,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
                 if (response) {
                     commit({type: BaselineMutation.PopulationUpdated, payload: null});
                     dispatch("surveyAndProgram/deleteAll", {}, {root: true});
-                    syncValidation.population = false
+                    fileHasValidated.population = false
                 }
             });
     },


### PR DESCRIPTION
## Description

This PR fixes baseline validation, for example, If no population data selected the app does validation on population data with just uploaded shape file.

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
