### PR TITLE
Mrc 1991 - Hide map legends when no data to display

### DIFF
--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -57,16 +57,19 @@
                         <l-tooltip :content="getTooltip(feature)"/>
                     </l-circle-marker>
                 </template>
+                <map-empty-feature v-if="emptyFeature"></map-empty-feature>
                 <map-control :initialDetail=selections.detail
                              :show-indicators="false"
                              :level-labels="featureLevels"
                              @detail-changed="onDetailChange"></map-control>
-                <map-legend :metadata="colorIndicator"
+                <map-legend v-show="!emptyFeature"
+                            :metadata="colorIndicator"
                             :colour-range="colourRange"
                             :colour-scale="colourIndicatorScale"
                             @update="updateColourScale"
                 ></map-legend>
-                <size-legend :indicatorRange="sizeRange"
+                <size-legend v-show="!emptyFeature"
+                             :indicatorRange="sizeRange"
                              :max-radius="maxRadius"
                              :min-radius="minRadius"
                              :metadata="sizeIndicator"
@@ -100,6 +103,7 @@
     import {flattenOptions, flattenToIdSet} from "../../../utils";
     import SizeLegend from "./SizeLegend.vue";
     import {initialiseScaleFromMetadata} from "../choropleth/utils";
+    import MapEmptyFeature from "../MapEmptyFeature.vue";
 
 
     interface Props {
@@ -163,6 +167,7 @@
         colourIndicatorScale: ScaleSettings | null
         sizeIndicatorScale: ScaleSettings | null
         selectedAreaIds: string[]
+        emptyFeature: boolean
     }
 
     const props = {
@@ -206,7 +211,8 @@
             MapLegend,
             SizeLegend,
             FilterSelect,
-            Treeselect
+            Treeselect,
+            MapEmptyFeature
         },
         props: props,
         data(): Data {
@@ -227,6 +233,10 @@
             },
             currentLevelFeatureIds() {
                 return this.currentFeatures.map(f => f.properties!["area_id"]);
+            },
+            emptyFeature() {
+                const nonEmptyFeature = (this.currentFeatures.filter(filtered => !!this.featureIndicators[filtered.properties!.area_id]))
+                return nonEmptyFeature.length == 0
             },
             sizeRange() {
                 const sizeScale = this.sizeScales[this.selections.sizeIndicatorId];

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -21,7 +21,7 @@
                              :level-labels="featureLevels"
                              @detail-changed="onDetailChange"
                              @indicator-changed="onIndicatorChange"></map-control>
-                <map-legend :metadata="colorIndicator"
+                <map-legend v-show="!emptyFeature" :metadata="colorIndicator"
                             :colour-scale="indicatorColourScale"
                             :colour-range="colourRange"
                             @update="updateColourScale"></map-legend>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.1.3";
+export const currentHintVersion = "1.1.4";

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -14,6 +14,7 @@ import MapLegend from "../../../../app/components/plots/MapLegend.vue";
 import SizeLegend from "../../../../app/components/plots/bubble/SizeLegend.vue";
 import {expectFilter, plhiv, prev, testData} from "../testHelpers"
 import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
+import MapEmptyFeature from "../../../../app/components/plots/MapEmptyFeature.vue";
 
 const localVue = createLocalVue();
 const store = new Vuex.Store({
@@ -300,6 +301,41 @@ describe("BubblePlot component", () => {
 
     });
 
+    it("computes emptyFeatures returns true when selections are empty", () => {
+        const wrapper = getWrapper({selections: {...propsData.selections, detail: 0}});
+        const vm = wrapper.vm as any;
+        expect(vm.emptyFeature).toBe(true);
+    });
+
+    it("computes emptyFeatures does not return true when selections are selected", () => {
+        const wrapper = getWrapper();
+        const vm = wrapper.vm as any;
+        expect(vm.emptyFeature).toBe(false);
+    });
+
+    it("render does not display translated no data message on map", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.findAll(MapEmptyFeature).length).toBe(0)
+        expect(wrapper.find(MapEmptyFeature).exists()).toBe(false)
+    });
+
+    it("render can display translated no data message on map", () => {
+        const wrapper = getWrapper({selections: {...propsData.selections, detail: 0}});
+        expect(wrapper.findAll(MapEmptyFeature).length).toBe(1)
+        expect(wrapper.find(MapEmptyFeature).exists()).toBe(true)
+    });
+
+    it("render does not display legends when selections have no data", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find(MapLegend).element.style.display).toBeFalsy()
+        expect(wrapper.find(SizeLegend).element.style.display).toBeFalsy()
+    });
+
+    it("render does display legends when selections have data", () => {
+        const wrapper = getWrapper({selections: {...propsData.selections, detail: 0}});
+        expect(wrapper.find(SizeLegend).element.style.display).toBeTruthy()
+        expect(wrapper.find(MapLegend).element.style.display).toBeTruthy()
+    });
 
     it("computes currentLevelFeatureIds", () => {
         const wrapper = getWrapper();

--- a/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
+++ b/src/app/static/src/tests/components/plots/choropleth/choropleth.test.ts
@@ -104,6 +104,16 @@ describe("Choropleth component", () => {
         expect(wrapper.find(MapEmptyFeature).exists()).toBe(true)
     });
 
+    it("render does not display legends when selections have no data", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find(MapLegend).element.style.display).toBeFalsy()
+    });
+
+    it("render does display legends when selections have data", () => {
+        const wrapper = getWrapper({selections: {...propsData.selections, detail: 0}});
+        expect(wrapper.find(MapLegend).element.style.display).toBeTruthy()
+    });
+
     it("computes featureIndicators", () => {
         const wrapper = getWrapper();
         const vm = wrapper.vm as any;


### PR DESCRIPTION
## Description

This PR hides legend control pane in maps when selections have not data to display. This PR doesn't hide indicator pane as it is useful for filtering prevalence even when there are not data to display on a particular prevalence.

## Type of version change

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
