### PR TITLE
mrc-1953 Add custom values to bubble scales, and do not exceed max/min bubble size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hint 1.2.3
+# hint 1.2.0
 
 * Support custom value ranges for bubble plot scales.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.2.3
+
+* Support custom value ranges for bubble plot scales.
+
 # hint 1.1.3
 
 * Display text on map when no data in selections.

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -1,7 +1,7 @@
 import {ScaleType} from "../../store/plottingSelections/plottingSelections";
 <template>
     <div v-if="show" class="pt-2 pl-3">
-        <div v-if="!(hideStaticCustom && hideStaticDefault)" class="static-container">
+        <div class="static-container">
             <div><span v-translate="'static'"></span></div>
             <div class="ml-2">
                 <div v-if="!hideStaticDefault" class="form-check static-default">
@@ -12,7 +12,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
                         <span v-translate="'default'"></span>
                     </label>
                 </div>
-                <div v-if="!hideStaticCustom" class="form-check mt-1 static-custom">
+                <div class="form-check mt-1 static-custom">
                     <label class="form-check-label">
                         <input id="type-input-custom" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.Custom"
@@ -21,7 +21,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
                     </label>
                 </div>
 
-                <div v-if="!hideStaticCustom" class="mt-2 ml-2 static-custom-values">
+                <div class="mt-2 ml-2 static-custom-values">
                     <form novalidate>
                         <div class="row p-0 mb-2">
                             <label for="custom-min-input" class="col col-form-label col-2"><span v-translate="'min'"></span></label>
@@ -85,8 +85,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
         scale: ScaleSettings,
         step: number,
         metadata: any,
-        hideStaticDefault: boolean,
-        hideStaticCustom: boolean
+        hideStaticDefault: boolean
     }
 
     interface Computed {
@@ -112,8 +111,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
             scale: Object,
             step: Number,
             metadata: Object,
-            hideStaticDefault: Boolean,
-            hideStaticCustom: Boolean
+            hideStaticDefault: Boolean
         },
         data(): any {
             return {

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -339,7 +339,7 @@
                 if (current) {
                     return current
                 } else {
-                    const newScale = initialiseScaleFromMetadata(this.colorIndicator);
+                    const newScale = initialiseScaleFromMetadata(this.sizeIndicator);
                     this.updateSizeScale(newScale);
                     return newScale;
                 }
@@ -452,9 +452,9 @@
                 this.$emit("update-colour-scales", newColourScales);
             },
             updateSizeScale: function (scale: ScaleSettings) {
-                const newColourScales = {...this.sizeScales};
-                newColourScales[this.selections.sizeIndicatorId] = scale;
-                this.$emit("update-size-scales", newColourScales);
+                const newSizeScales = {...this.sizeScales};
+                newSizeScales[this.selections.sizeIndicatorId] = scale;
+                this.$emit("update-size-scales", newSizeScales);
             },
         },
         watch:

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -103,7 +103,9 @@
                 return this.width / 2;
             },
             circles: function () {
-                if (this.indicatorRange.min == this.indicatorRange.max) {
+                if (isNaN(this.indicatorRange.min) || isNaN(this.indicatorRange.max)) {
+                    return [];
+                } else if (this.indicatorRange.min == this.indicatorRange.max) {
                     // only one value in range - show max circle only
                     return [this.circleFromRadius(this.maxRadius, this.indicatorRange.max, false)];
                 } else {

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -20,7 +20,7 @@
             </div>
             <map-adjust-scale class="legend-element legend-adjust map-control" name="size" :step="scaleStep"
                               :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata"
-                              :hide-static-custom="true" :hide-static-default="true">
+                              :hide-static-default="true">
             </map-adjust-scale>
         </div>
     </l-control>

--- a/src/app/static/src/app/components/plots/bubble/utils.ts
+++ b/src/app/static/src/app/components/plots/bubble/utils.ts
@@ -8,7 +8,9 @@ export const getRadius = function (value: number, minValue: number, maxValue: nu
         return maxRadius;
     }
 
+    //Clip value to range so do not exceed max or min bubble sizes
     value = Math.min(value, maxValue);
+    value = Math.max(value, minValue);
 
     //where is value on a scale of 0-1 between minValue and maxValue
     const scalePoint = (value - minValue) / (maxValue - minValue);

--- a/src/app/static/src/app/components/plots/bubble/utils.ts
+++ b/src/app/static/src/app/components/plots/bubble/utils.ts
@@ -8,6 +8,8 @@ export const getRadius = function (value: number, minValue: number, maxValue: nu
         return maxRadius;
     }
 
+    value = Math.min(value, maxValue);
+
     //where is value on a scale of 0-1 between minValue and maxValue
     const scalePoint = (value - minValue) / (maxValue - minValue);
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.1.3";
+export const currentHintVersion = "1.2.3";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.2.3";
+export const currentHintVersion = "1.2.0";

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -479,14 +479,34 @@ describe("BubblePlot component", () => {
         expect((wrapper.vm as any).colorIndicator).toBe(propsData.indicators[1]);
     });
 
-    it("computes colourIndicatorScale", () => {
+    it("computes existing colourIndicatorScale", () => {
         const wrapper = getWrapper();
         expect((wrapper.vm as any).colourIndicatorScale).toStrictEqual(propsData.colourScales.prevalence);
     });
 
-    it("computes sizeIndicatorScale", () => {
+    it("computes existing sizeIndicatorScale", () => {
         const wrapper = getWrapper();
         expect((wrapper.vm as any).sizeIndicatorScale).toStrictEqual(propsData.sizeScales.plhiv);
+    });
+
+    it("initialises colourIndicatorScale", () => {
+        const wrapper = getWrapper({colourScales: {}});
+        const expectedScale = {
+            customMin: 0,
+            customMax: 0.8,
+            type: ScaleType.DynamicFiltered
+        };
+        expect((wrapper.vm as any).colourIndicatorScale).toStrictEqual(expectedScale);
+    });
+
+    it("initialises sizeIndicatorScale", () => {
+        const wrapper = getWrapper({sizeScales: {}});
+        const expectedScale = {
+          customMin: 1,
+          customMax: 100,
+          type: ScaleType.DynamicFiltered
+        };
+        expect((wrapper.vm as any).sizeIndicatorScale).toStrictEqual(expectedScale);
     });
 
     it("updateBounds updates bounds of map from features geojson", () => {

--- a/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
@@ -101,6 +101,18 @@ describe("SizeLegend component", () => {
         expectCirclesEqual(circles[0], {y: 120, radius: 110, text: "1", textY: 10});
     });
 
+    it("computes circles where range includes NaN", () => {
+        let wrapper = getWrapper({indicatorRange: {min: NaN, max: 1}});
+        let vm = wrapper.vm as any;
+        let circles = vm.circles;
+        expect(circles.length).toBe(0);
+
+        wrapper = getWrapper({indicatorRange: {min: 1, max: NaN}});
+        vm = wrapper.vm as any;
+        circles = vm.circles;
+        expect(circles.length).toBe(0);
+    });
+
     it("renders as expected", () => {
         const wrapper = getWrapper();
 

--- a/src/app/static/src/tests/components/plots/bubble/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/utils.test.ts
@@ -186,4 +186,11 @@ describe("Bubble plot utils", () => {
         expect(getRadius(5, 0, 10, 0, 10)).toBeCloseTo(expectedRadius, 5);
     });
 
+    it("can get radius where value is greater than max", () => {
+        expect(getRadius(20, 0, 10, 5, 50)).toBe(50);
+    });
+
+    it("can get radius where value is less than min", () => {
+        expect(getRadius(1, 2, 10, 5, 50)).toBe(5);
+    });
 });

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -171,24 +171,6 @@ describe("MapAdjustScale component", () => {
         expect(wrapper.find(".static-custom-values").exists()).toBe(true);
     });
 
-    it("renders as expected when hide static custom", () => {
-        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticCustom: true}});
-
-        expect(wrapper.find(".static-container").exists()).toBe(true);
-        expect(wrapper.find(".static-default").exists()).toBe(true);
-        expect(wrapper.find(".static-custom").exists()).toBe(false);
-        expect(wrapper.find(".static-custom-values").exists()).toBe(false);
-    });
-
-    it("renders as expected when hide static default and custom", () => {
-        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticDefault: true, hideStaticCustom: true}});
-
-        expect(wrapper.find(".static-container").exists()).toBe(false);
-        expect(wrapper.find(".static-default").exists()).toBe(false);
-        expect(wrapper.find(".static-custom").exists()).toBe(false);
-        expect(wrapper.find(".static-custom-values").exists()).toBe(false);
-    });
-
     it("emits update event when type changes", () => {
         const wrapper = mount(MapAdjustScale, {store, propsData});
 


### PR DESCRIPTION
## Description
Show custom values for range, and fix bug in bubble plot which meant wrong range was being used to initialise size scale values! Added missing test for this. 

Also ensure we clip bubble size to min and max values. 

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
