### PR TITLE
mrc-1992 Don't show ADR key to user after it has been entered

### DIFF
--- a/src/app/static/src/app/components/adr/ADRKey.vue
+++ b/src/app/static/src/app/components/adr/ADRKey.vue
@@ -11,7 +11,7 @@
                         <span class="pr-2">{{ keyText }}</span>
                         <span v-if="!key">
                            <a href="#"
-                              @click="edit"
+                              @click="add"
                               v-translate="'add'"></a>
                               <span>/</span>
                             <a :href="'https://adr.unaids.org/me/'"
@@ -20,10 +20,6 @@
                                v-tooltip="tooltipContent"></a>
                         </span>
                         <span v-if="key">
-                            <a href="#"
-                               @click="edit"
-                               v-translate="'edit'"> </a>
-                            <span>/</span>
                             <a href="#"
                                @click="remove"
                                v-translate="'remove'"></a>
@@ -77,7 +73,7 @@
     interface Methods {
         saveADRKey: (key: string | null) => void
         deleteADRKey: () => void
-        edit: (e: Event) => void
+        add: (e: Event) => void
         remove: (e: Event) => void
         save: (e: Event) => void
         cancel: (e: Event) => void
@@ -124,7 +120,7 @@
         },
         methods: {
             ...mapActionsByNames<keyof Methods>(null, ["saveADRKey", "deleteADRKey"]),
-            edit(e: Event) {
+            add(e: Event) {
                 e.preventDefault();
                 this.editing = true;
                 this.editableKey = this.key;

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.1.3";
+export const currentHintVersion = "1.1.4";

--- a/src/app/static/src/tests/components/adr/ADRKey.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRKey.test.ts
@@ -48,12 +48,11 @@ describe("ADR Key", function () {
         expect(rendered.find("span").text()).toBe("none provided");
     });
 
-    it("shows edit/remove links if key exists", () => {
+    it("shows remove links if key exists", () => {
         const rendered = shallowMount(ADRKey, {store: createStore("123-abc")});
         const links = rendered.findAll("a")
-        expect(links.length).toBe(2);
-        expect(links.at(0).text()).toBe("edit");
-        expect(links.at(1).text()).toBe("remove");
+        expect(links.length).toBe(1);
+        expect(links.at(0).text()).toBe("remove");
     });
 
     it("shows add link if key does not exist", () => {
@@ -80,7 +79,7 @@ describe("ADR Key", function () {
     it("can edit key", async () => {
         const rendered = mount(ADRKey,
             {
-                store: createStore("123-abc"),
+                store: createStore(),
                 attachToDocument: true,
                 stubs: ["tree-select"]
             });
@@ -89,7 +88,6 @@ describe("ADR Key", function () {
         links.at(0).trigger("click");
 
         await Vue.nextTick();
-
         expect(rendered.find("button").text()).toBe("Save");
         expect(rendered.find("input").element).toBe(document.activeElement);
 
@@ -103,7 +101,7 @@ describe("ADR Key", function () {
     });
 
     it("cannot save empty key", async () => {
-        const rendered = shallowMount(ADRKey, {store: createStore("123-abc")});
+        const rendered = shallowMount(ADRKey, {store: createStore()});
         expect(rendered.findAll(".input-group").length).toBe(0);
         const links = rendered.findAll("a")
         links.at(0).trigger("click");
@@ -123,7 +121,7 @@ describe("ADR Key", function () {
     });
 
     it("can cancel editing", async () => {
-        const rendered = shallowMount(ADRKey, {store: createStore("123-abc")});
+        const rendered = shallowMount(ADRKey, {store: createStore()});
         expect(rendered.findAll(".input-group").length).toBe(0);
         const links = rendered.findAll("a")
         links.at(0).trigger("click");
@@ -144,7 +142,7 @@ describe("ADR Key", function () {
         const rendered = shallowMount(ADRKey, {store: createStore("123-abc")});
         expect(rendered.findAll(".input-group").length).toBe(0);
         const links = rendered.findAll("a")
-        links.at(1).trigger("click");
+        links.at(0).trigger("click");
 
         await Vue.nextTick();
 

--- a/src/app/static/src/tests/components/adr/ADRKey.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRKey.test.ts
@@ -76,7 +76,7 @@ describe("ADR Key", function () {
                 "This can be found on your ADR profile page");
     });
 
-    it("can edit key", async () => {
+    it("can add key", async () => {
         const rendered = mount(ADRKey,
             {
                 store: createStore(),


### PR DESCRIPTION
## Description

This PR removes a link that shows 'edit' after entering ADR key, users can edit or remote the key
Edit allows them to see the unencrypted key. The PR removes the edit action, which leaves users with the option to remove the key if they want to alter/add a new key.

## Type of version change

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
