### PR TITLE
mrc-1954 Support bubble scaling by min and max from indicator metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hint 1.4.0
+
+* Include metadata default scale for bubble size
 
 # hint 1.3.0
 

--- a/src/app/static/src/app/components/plots/MapAdjustScale.vue
+++ b/src/app/static/src/app/components/plots/MapAdjustScale.vue
@@ -4,7 +4,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
         <div class="static-container">
             <div><span v-translate="'static'"></span></div>
             <div class="ml-2">
-                <div v-if="!hideStaticDefault" class="form-check static-default">
+                <div class="form-check static-default">
                     <label class="form-check-label">
                         <input id="type-input-default" class="form-check-input" type="radio" :name="scaleTypeGroup"
                                :value="ScaleType.Default"
@@ -84,8 +84,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
         show: boolean,
         scale: ScaleSettings,
         step: number,
-        metadata: any,
-        hideStaticDefault: boolean
+        metadata: any
     }
 
     interface Computed {
@@ -110,8 +109,7 @@ import {ScaleType} from "../../store/plottingSelections/plottingSelections";
             show: Boolean,
             scale: Object,
             step: Number,
-            metadata: Object,
-            hideStaticDefault: Boolean
+            metadata: Object
         },
         data(): any {
             return {

--- a/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
+++ b/src/app/static/src/app/components/plots/bubble/SizeLegend.vue
@@ -19,8 +19,7 @@
                 </div>
             </div>
             <map-adjust-scale class="legend-element legend-adjust map-control" name="size" :step="scaleStep"
-                              :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata"
-                              :hide-static-default="true">
+                              :show="showAdjust" :scale="sizeScale" @update="update" :metadata="metadata">
             </map-adjust-scale>
         </div>
     </l-control>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.3.0";
+export const currentHintVersion = "1.4.0";

--- a/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
+++ b/src/app/static/src/tests/components/plots/mapAdjustScale.test.ts
@@ -153,20 +153,11 @@ describe("MapAdjustScale component", () => {
         expect((wrapper.find("#custom-max-input").element as HTMLInputElement).disabled).toBe(true);
     });
 
-    it("renders as expected when hide props both false", () => {
+    it("renders static scale controls as expected", () => {
         const wrapper = mount(MapAdjustScale, {store, propsData});
 
         expect(wrapper.find(".static-container").exists()).toBe(true);
         expect(wrapper.find(".static-default").exists()).toBe(true);
-        expect(wrapper.find(".static-custom").exists()).toBe(true);
-        expect(wrapper.find(".static-custom-values").exists()).toBe(true);
-    });
-
-    it("renders as expected when hide static defaults", () => {
-        const wrapper = mount(MapAdjustScale, {store, propsData: {...propsData, hideStaticDefault: true}});
-
-        expect(wrapper.find(".static-container").exists()).toBe(true);
-        expect(wrapper.find(".static-default").exists()).toBe(false);
         expect(wrapper.find(".static-custom").exists()).toBe(true);
         expect(wrapper.find(".static-custom-values").exists()).toBe(true);
     });


### PR DESCRIPTION
## Description
Allow configuration of metadata default scale for bubble sizes.

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
