### PR TITLE
mrc-2006 Add rows qs parameter to ADR datasets request, to avoid paged results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.1.4
+
+* Fetch all relevant datasets from ADR without paging
+
 # hint 1.1.3
 
 * Display text on map when no data in selections.

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -30,6 +30,10 @@ class ADRController(private val encryption: Encryption,
         HintrController(fileManager, apiClient, session, versionRepository)
 {
 
+    companion object {
+        const val MAX_DATASETS = 1000
+    }
+
     @GetMapping("/key")
     fun getAPIKey(): ResponseEntity<String>
     {
@@ -67,8 +71,7 @@ class ADRController(private val encryption: Encryption,
     fun getDatasets(@RequestParam showInaccessible: Boolean = false): ResponseEntity<String>
     {
         val adr = adrClientBuilder.build()
-        val maxRows = 1000;
-        var url = "package_search?q=type:${appProperties.adrDatasetSchema}&rows=$maxRows"
+        var url = "package_search?q=type:${appProperties.adrDatasetSchema}&rows=$MAX_DATASETS"
         url = if (showInaccessible)
         {
             // this flag is used for testing but will never

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -67,7 +67,8 @@ class ADRController(private val encryption: Encryption,
     fun getDatasets(@RequestParam showInaccessible: Boolean = false): ResponseEntity<String>
     {
         val adr = adrClientBuilder.build()
-        var url = "package_search?q=type:${appProperties.adrDatasetSchema}"
+        val maxRows = 1000;
+        var url = "package_search?q=type:${appProperties.adrDatasetSchema}&rows=$maxRows"
         url = if (showInaccessible)
         {
             // this flag is used for testing but will never

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -197,7 +197,7 @@ class ADRTests : SecureIntegrationTests()
         return if (isAuthorized == IsAuthorized.TRUE)
         {
             testRestTemplate.postForEntity<String>("/adr/key", getPostEntityWithKey())
-            val resultWithResources = testRestTemplate.getForEntity<String>("/adr/datasets?showInaccessible=true")
+            val resultWithResources = testRestTemplate.getForEntity<String>("/adr/datasets?showInaccessible=false")
             val data = ObjectMapper().readTree(resultWithResources.body!!)["data"]
             val resource = data[0]["resources"].find { it["resource_type"].textValue() == type }
             resource!!["url"].textValue()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -85,7 +85,7 @@ class ADRControllerTests : HintrControllerTests()
     @Test
     fun `gets datasets without inaccessible resources by default`()
     {
-        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
+        val expectedUrl = "package_search?q=type:adr-schema&rows=1000&hide_inaccessible_resources=true"
         val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
@@ -111,7 +111,7 @@ class ADRControllerTests : HintrControllerTests()
     @Test
     fun `gets datasets including inaccessible resources if flag is passed`()
     {
-        val expectedUrl = "package_search?q=type:adr-schema"
+        val expectedUrl = "package_search?q=type:adr-schema&rows=1000"
         val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
@@ -137,7 +137,7 @@ class ADRControllerTests : HintrControllerTests()
     @Test
     fun `filters datasets to only those with resources`()
     {
-        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
+        val expectedUrl = "package_search?q=type:adr-schema&rows=1000&hide_inaccessible_resources=true"
         val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn makeFakeSuccessResponse()
         }
@@ -165,7 +165,7 @@ class ADRControllerTests : HintrControllerTests()
     fun `passes error responses along`()
     {
         val badResponse = ResponseEntity<String>(HttpStatus.BAD_REQUEST)
-        val expectedUrl = "package_search?q=type:adr-schema&hide_inaccessible_resources=true"
+        val expectedUrl = "package_search?q=type:adr-schema&rows=1000&hide_inaccessible_resources=true"
         val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn badResponse
         }

--- a/src/app/static/jest.integration.config.js
+++ b/src/app/static/jest.integration.config.js
@@ -3,5 +3,5 @@ var config = require('./jest.config');
 config.testRegex = "(/__tests__/.*|(\\.|/)(itest))\\.[jt]sx?$";
 config.globals = {...config.globals, "appUrl": "http://localhost:8080/"};
 config.coverageDirectory = "./coverage/integration/";
-config.testTimeout = 6000;
+config.testTimeout = 10000;
 module.exports = config;

--- a/src/app/static/jest.integration.config.js
+++ b/src/app/static/jest.integration.config.js
@@ -3,5 +3,5 @@ var config = require('./jest.config');
 config.testRegex = "(/__tests__/.*|(\\.|/)(itest))\\.[jt]sx?$";
 config.globals = {...config.globals, "appUrl": "http://localhost:8080/"};
 config.coverageDirectory = "./coverage/integration/";
-config.testTimeout = 10000;
+config.testTimeout = 20000;
 module.exports = config;

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.1.3";
+export const currentHintVersion = "1.1.4";


### PR DESCRIPTION
## Description

Add hardcoded huge `rows` value to ADR `datasets` request as we want all results to be returned at once. We will filter out any results which have no available resources anyway.

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
