### PR TITLE
mrc-2007 Set a separate (long) timeout for front end ADR integration tests

### DIFF
--- a/src/app/static/jest.integration.adr.config.js
+++ b/src/app/static/jest.integration.adr.config.js
@@ -1,0 +1,4 @@
+var config = require('./jest.integration.config');
+
+config.testTimeout = 20000;
+module.exports = config;

--- a/src/app/static/jest.integration.config.js
+++ b/src/app/static/jest.integration.config.js
@@ -3,5 +3,5 @@ var config = require('./jest.config');
 config.testRegex = "(/__tests__/.*|(\\.|/)(itest))\\.[jt]sx?$";
 config.globals = {...config.globals, "appUrl": "http://localhost:8080/"};
 config.coverageDirectory = "./coverage/integration/";
-config.testTimeout = 20000;
+config.testTimeout = 6000;
 module.exports = config;

--- a/src/app/static/jest.integration.docker.adr.config.js
+++ b/src/app/static/jest.integration.docker.adr.config.js
@@ -1,0 +1,4 @@
+var config = require('./jest.integration.docker.config');
+
+config.testTimeout = 20000;
+module.exports = config;

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -9,7 +9,7 @@
     "build": "gulp copy-templates && gulp styles && webpack",
     "test": "jest -c jest.config.js",
     "integration-test": "jest --testPathIgnorePatterns adr -c jest.integration.config.js",
-    "adr-integration-test": "jest --testPathPattern adr -c jest.integration.config.js",
+    "adr-integration-test": "jest --testPathPattern adr -c jest.integration.adr.config.js",
     "integration-test-docker": "jest --testPathIgnorePatterns adr -c jest.integration.docker.config.js",
     "adr-integration-test-docker": "jest --testPathPattern adr -c jest.integration.docker.config.js",
     "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx,vue"

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -11,7 +11,7 @@
     "integration-test": "jest --testPathIgnorePatterns adr -c jest.integration.config.js",
     "adr-integration-test": "jest --testPathPattern adr -c jest.integration.adr.config.js",
     "integration-test-docker": "jest --testPathIgnorePatterns adr -c jest.integration.docker.config.js",
-    "adr-integration-test-docker": "jest --testPathPattern adr -c jest.integration.docker.config.js",
+    "adr-integration-test-docker": "jest --testPathPattern adr -c jest.integration.docker.adr.config.js",
     "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx,vue"
   },
   "author": "",


### PR DESCRIPTION
## Description

We needed to set a long timeout (up to 20s) for slow ADR dev server responses in integration tests. These don't apply to non-ADR integration tests, so separate out the config for ADR tests here, and reset the timeout for non-ADR tests to more reasonable 6s.

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
