### PR TITLE
mrc-1995 Swap button colours in Save version confirmation dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hint 1.3.1
+
+* Swap button colours on Save new version confirmation dialog
 
 # hint 1.3.0
 

--- a/src/app/static/src/app/components/ResetConfirmation.vue
+++ b/src/app/static/src/app/components/ResetConfirmation.vue
@@ -16,12 +16,12 @@
 
             <template v-if="!waitingForVersion" v-slot:footer>
                 <button type="button"
-                        class="btn btn-white"
+                        class="btn btn-red"
                         @click="handleConfirm"
                         v-translate="isGuest? 'discardSteps' : 'saveVersionConfirm'">
                 </button>
                 <button type="button"
-                        class="btn btn-red"
+                        class="btn btn-white"
                         @click="cancelEditing"
                         v-translate="isGuest? 'cancelEdit': 'cancelEditLoggedIn'">
                 </button>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.3.0";
+export const currentHintVersion = "1.3.1";

--- a/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
+++ b/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
@@ -75,7 +75,7 @@ describe("File upload component", () => {
         };
 
         (wrapper.vm as any).handleFileSelect();
-        uploadConfirmationModal(wrapper).find(".btn-white").trigger("click");
+        uploadConfirmationModal(wrapper).find(".btn-red").trigger("click");
 
         setTimeout(() => {
             expect(uploader.mock.calls.length).toBe(1);
@@ -95,7 +95,7 @@ describe("File upload component", () => {
         };
 
         (wrapper.vm as any).handleFileSelect();
-        uploadConfirmationModal(wrapper).find(".btn-red").trigger("click");
+        uploadConfirmationModal(wrapper).find(".btn-white").trigger("click");
 
         setTimeout(() => {
             expect(uploader.mock.calls.length).toBe(0);

--- a/src/app/static/src/tests/components/files/manageFilewithDeleteConfirmation.test.ts
+++ b/src/app/static/src/tests/components/files/manageFilewithDeleteConfirmation.test.ts
@@ -85,7 +85,7 @@ describe("File upload component", () => {
         const removeLink = wrapper.find("a");
         expect(removeLink.text()).toBe("remove");
         removeLink.trigger("click");
-        deleteConfirmationModal(wrapper).find(".btn-white").trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-red").trigger("click");
         expect(removeHandler.mock.calls.length).toBe(1);
         expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
     });
@@ -99,7 +99,7 @@ describe("File upload component", () => {
         const removeLink = wrapper.find("a");
         expect(removeLink.text()).toBe("remove");
         removeLink.trigger("click");
-        deleteConfirmationModal(wrapper).find(".btn-red").trigger("click");
+        deleteConfirmationModal(wrapper).find(".btn-white").trigger("click");
         expect(removeHandler.mock.calls.length).toBe(0);
         expect(deleteConfirmationModal(wrapper).props("open")).toBe(false);
     });

--- a/src/app/static/src/tests/components/modelOptions/modelOptionsWithConfirmation.test.ts
+++ b/src/app/static/src/tests/components/modelOptions/modelOptionsWithConfirmation.test.ts
@@ -85,7 +85,7 @@ describe("Model options component when edit confirmation is required", () => {
     it("closes modal and commits UnValidate mutation if user confirms action", async () => {
         const rendered = mount(ModelOptions, {store});
         rendered.find(DynamicForm).trigger("mousedown");
-        rendered.find(ResetConfirmation).find(".btn-white").trigger("click");
+        rendered.find(ResetConfirmation).find(".btn-red").trigger("click");
         await Vue.nextTick();
         expect(rendered.find(ResetConfirmation).props("open")).toBe(false);
         expect(mockMutations[ModelOptionsMutation.UnValidate].mock.calls.length).toBe(1);
@@ -94,7 +94,7 @@ describe("Model options component when edit confirmation is required", () => {
     it("closes modal and does not commit UnValidate mutation if user cancels action", async () => {
         const rendered = mount(ModelOptions, {store});
         rendered.find(DynamicForm).trigger("mousedown");
-        rendered.find(ResetConfirmation).find(".btn-red").trigger("click");
+        rendered.find(ResetConfirmation).find(".btn-white").trigger("click");
         await Vue.nextTick();
         expect(mockMutations[ModelOptionsMutation.UnValidate].mock.calls.length).toBe(0);
         expect(rendered.find(ResetConfirmation).props("open")).toBe(false);


### PR DESCRIPTION
## Description

Make the Save button the more obvious selection, should be red while cancel button should be white

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
