### PR TITLE
capitalise Fischier Spectrum in FR localisation

### DIFF
--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -460,7 +460,7 @@ const fr: Partial<Translations> = {
     passwordValidation: "Veuillez entrer votre mot de passe.",
     passwordWasReset: "Merci, votre mot de passe a été mis à jour. Cliquez ici pour vous connecter.",
     period: "Période",
-    PJNZ: "fichier Spectrum",
+    PJNZ: "Fichier Spectrum",
     population: "Population",
     projectsHeaderCreate: "Créer un nouveau projet",
     projectsHeaderReturn: "retour au projet actuel",


### PR DESCRIPTION
## Description

On the first file upload page in French localisation the label for PJNZ file is **"fichier Spectrum"** (pasted below). I don't speak French, but it looks a bit odd that it is not capitalised.  This PR capitalises the label.

![image](https://user-images.githubusercontent.com/7427899/101262039-7de5bd00-3733-11eb-8594-67a836489523.png)


## Type of version change
_Delete as appropriate_

 None

## Checklist

- [X] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
