### PR TITLE
mrc-2021 make share project ok button work properly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.9.0
+
+* fix ok button accessibility bug in share project
+
 # hint 1.8.2
 
 * Update help document

--- a/src/app/static/src/app/components/projects/ShareProject.vue
+++ b/src/app/static/src/app/components/projects/ShareProject.vue
@@ -1,9 +1,9 @@
 <template>
     <div>
-        <button class="btn btn-sm btn-red-icons" 
-        v-tooltip= "tooltipShare"
-        @click="shareProject">
-        <share-2-icon size="20"></share-2-icon>
+        <button class="btn btn-sm btn-red-icons"
+                v-tooltip="tooltipShare"
+                @click="shareProject">
+            <share-2-icon size="20"></share-2-icon>
         </button>
         <modal :open="open">
             <h4 v-translate="'shareProject'"></h4>
@@ -17,6 +17,7 @@
                                class="form-control"
                                :class="{'is-invalid': email.valid === false}"
                                @blur="() => addEmail(email, index)"
+                               @mouseout="$event.target.blur()"
                                v-model="email.value"/>
                     </div>
                     <div class="col">
@@ -135,7 +136,6 @@
                     e.valid = null;
                     this.showValidationMessage = this.invalidEmails;
                 }
-
             },
             removeEmail(email: EmailToShareWith, index: number) {
                 // if email has been deleted and this is not the last input
@@ -172,9 +172,8 @@
             invalidEmails() {
                 return this.emailsToShareWith.filter(e => e.value && !e.valid).length > 0
             },
-
-            tooltipShare () {
-                 return i18next.t("share", {
+            tooltipShare() {
+                return i18next.t("share", {
                     lng: this.currentLanguage,
                 });
             }
@@ -191,7 +190,7 @@
         watch: {
             cloningProject(newVal: boolean) {
                 if (!newVal && !this.cloneProjectError) {
-                    this.emailsToShareWith = [];
+                    this.emailsToShareWith = [{value: "", valid: null}];
                     this.open = false;
                 }
             }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,3 +1,3 @@
 
-export const currentHintVersion = "1.8.2";
+export const currentHintVersion = "1.9.0";
 

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -50,7 +50,7 @@ export const mutations: MutationTree<ModelRunState> = {
         state.errors.push(action.payload);
     },
 
-    [ModelRunMutation.RunStatusError](state: ModelRunState, action: PayloadWithType<Error>) {
+    [ModelRunMutation.RunStatusError](state: ModelRunState) {
         state.pollingCounter += 1
         if (state.pollingCounter >= maxPollErrors) {
             stopPolling(state);

--- a/src/app/static/src/tests/modelRun/mutations.test.ts
+++ b/src/app/static/src/tests/modelRun/mutations.test.ts
@@ -66,7 +66,7 @@ describe("Model run mutations", () => {
         expect(testState.errors).toStrictEqual(["Test Error"]);
     });
 
-    it("run status error and stops polling if maxPollErrors exceeded", () => {
+    it("run status adds error and stops polling if maxPollErrors exceeded", () => {
         const testState = mockModelRunState({
             errors : [],
             statusPollId: 999,


### PR DESCRIPTION
## Description

This PR reviews how ok button interacts with email validation, maybe validation could be triggered on clicking OK? Main thing to fix is OK button should be enabled and it is confusing when OK button is disabled

The validation will lose its asynchronous behaviour if validation is implemented upon clicking ok button hence I adopted the approach of initialising blur event when mouse is out of the field, I notice this approach was initially adopted for on key enter as well. This way we can still maintain validation happening on each fields accordingly rather than validating upon clicking ok button which will show (n) number of messages at once.

## Type of version change

 Minor 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
