### PR TITLE
mrc-2063 Use new hintr calibration options endpoint

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -137,7 +137,7 @@ class HintrFuelAPIClient(
 
     override fun getModelCalibrationOptions(): ResponseEntity<String>
     {
-        return postEmpty("model/calibration-options")
+        return postEmpty("calibrate/options")
     }
 
     override fun validateBaselineCombined(files: Map<String, VersionFileWithPath?>): ResponseEntity<String>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
@@ -58,7 +58,7 @@ class ModelRunController(val fileManager: FileManager, val apiClient: HintrAPICl
         return apiClient.getModelRunOptions(allFiles)
     }
 
-    @GetMapping("/calibration-options/")
+    @GetMapping("/calibrate/options/")
     @ResponseBody
     fun calibrationOptions(): ResponseEntity<String>
     {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
@@ -47,7 +47,7 @@ class ModelRunTests : SecureIntegrationTests()
     @Test
     fun `can get model calibration options`()
     {
-        val responseEntity = testRestTemplate.getForEntity<String>("/model/calibration-options/")
+        val responseEntity = testRestTemplate.getForEntity<String>("/calibrate/options/")
         assertSuccess(responseEntity, "ModelRunOptions")
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
@@ -47,7 +47,7 @@ class ModelRunTests : SecureIntegrationTests()
     @Test
     fun `can get model calibration options`()
     {
-        val responseEntity = testRestTemplate.getForEntity<String>("/calibrate/options/")
+        val responseEntity = testRestTemplate.getForEntity<String>("/model/calibrate/options/")
         assertSuccess(responseEntity, "ModelRunOptions")
     }
 

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -21,7 +21,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
         const response = await api<ModelCalibrateMutation, ModelCalibrateMutation>(context)
             .withSuccess(ModelCalibrateMutation.ModelCalibrateOptionsFetched)
             .ignoreErrors()
-            .get<DynamicFormMeta>("/calibrate/options/");
+            .get<DynamicFormMeta>("/model/calibrate/options/");
 
         if (response) {
             commit({type: ModelCalibrateMutation.SetModelCalibrateOptionsVersion, payload: response.version});

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -21,7 +21,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
         const response = await api<ModelCalibrateMutation, ModelCalibrateMutation>(context)
             .withSuccess(ModelCalibrateMutation.ModelCalibrateOptionsFetched)
             .ignoreErrors()
-            .get<DynamicFormMeta>("/model/calibration-options/");
+            .get<DynamicFormMeta>("/calibrate/options/");
 
         if (response) {
             commit({type: ModelCalibrateMutation.SetModelCalibrateOptionsVersion, payload: response.version});

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -27,7 +27,7 @@ describe("ModelCalibrate actions", () => {
     it("fetchModelCalibrateOptions fetches option and commits mutations", async () => {
         const commit = jest.fn();
         const state = mockModelCalibrateState();
-        mockAxios.onGet("/model/calibration-options/").reply(200, mockSuccess("TEST", "v1"));
+        mockAxios.onGet("/calibrate/options/").reply(200, mockSuccess("TEST", "v1"));
 
         await actions.fetchModelCalibrateOptions({commit, state, rootState} as any);
 

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -24,10 +24,10 @@ describe("ModelCalibrate actions", () => {
         (console.log as jest.Mock).mockClear();
     });
 
-    it("fetchModelCalibrateOptions fetches option and commits mutations", async () => {
+    it("fetchModelCalibrateOptions fetches options and commits mutations", async () => {
         const commit = jest.fn();
         const state = mockModelCalibrateState();
-        mockAxios.onGet("/calibrate/options/").reply(200, mockSuccess("TEST", "v1"));
+        mockAxios.onGet("/model/calibrate/options/").reply(200, mockSuccess("TEST", "v1"));
 
         await actions.fetchModelCalibrateOptions({commit, state, rootState} as any);
 


### PR DESCRIPTION
## Description

Update to use new hintr caibration options endpoint (`/calibrate/options`), and update endpoint to be similar, but retain `model` in route to reflect that it is dealt with by ModelController

## Type of version change
None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
