### PR TITLE
mrc-2060 Regenerate front end types

### DIFF
--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -153,7 +153,8 @@
                 if (this.selections.detail === 0) {
                     return [areaArray[0]]
                 } else if (!this.selections.detail) {
-                    return this.selections.selectedFilterOptions.area.map(row => row.id)
+                    const selectedAreaOptions = this.selections.selectedFilterOptions.area || [];
+                    return selectedAreaOptions.map(row => row.id)
                 } else return areaArray.filter(val => parseInt(val[4]) === this.selections.detail);
             },
             selectedAreaFilterOptions() {

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -96,6 +96,113 @@ export interface BarchartMetadata {
     };
   };
 }
+export interface CalibrateResultResponse {
+  data: {
+    area_id: string;
+    sex: string;
+    age_group: string;
+    calendar_quarter: string;
+    indicator: string;
+    mode: number | null;
+    mean: number | null;
+    lower: number | null;
+    upper: number | null;
+    [k: string]: any;
+  }[];
+  plottingMetadata: {
+    barchart: {
+      indicators: {
+        indicator: string;
+        value_column: string;
+        indicator_column: string;
+        indicator_value: string;
+        indicator_sort_order?: number;
+        name: string;
+        error_low_column: string;
+        error_high_column: string;
+        scale: number;
+        accuracy: number | null;
+        format: string;
+      }[];
+      filters: {
+        id: string;
+        column_id: string;
+        label: string;
+        options: {
+          label: string;
+          id: string;
+        }[];
+        use_shape_regions?: boolean | null;
+      }[];
+      defaults?: {
+        indicator_id: string;
+        x_axis_id: string;
+        disaggregate_by_id: string;
+        selected_filter_options: {
+          [k: string]: any;
+        };
+      };
+    };
+    choropleth: {
+      indicators: {
+        indicator: string;
+        value_column: string;
+        error_low_column?: string;
+        error_high_column?: string;
+        indicator_column?: string;
+        indicator_value?: string;
+        indicator_sort_order?: number;
+        name: string;
+        min: number;
+        max: number;
+        colour: string;
+        invert_scale: boolean;
+        scale: number;
+        accuracy: number | null;
+        format: string;
+      }[];
+      filters: {
+        id: string;
+        column_id: string;
+        label: string;
+        options: {
+          label: string;
+          id: string;
+        }[];
+        use_shape_regions?: boolean | null;
+      }[];
+    };
+  };
+  [k: string]: any;
+}
+export interface CalibrateStatusResponse {
+  id: string;
+  done: boolean | null;
+  status: string;
+  success: boolean | null;
+  queue: number;
+  progress: {
+    started: boolean;
+    complete: boolean;
+    value?: number;
+    name: string;
+    helpText?: string;
+  }[];
+}
+export interface CalibrateSubmitRequest {
+  options: {
+    [k: string]: any;
+  };
+  version: {
+    hintr: string;
+    naomi: string;
+    rrq: string;
+    [k: string]: any;
+  };
+}
+export interface CalibrateSubmitResponse {
+  id: string;
+}
 export interface ChoroplethIndicatorMetadata {
   indicator: string;
   value_column: string;
@@ -249,82 +356,8 @@ export type ModelResultData = {
   [k: string]: any;
 }[];
 export interface ModelResultResponse {
-  data: {
-    area_id: string;
-    sex: string;
-    age_group: string;
-    calendar_quarter: string;
-    indicator: string;
-    mode: number | null;
-    mean: number | null;
-    lower: number | null;
-    upper: number | null;
-    [k: string]: any;
-  }[];
-  plottingMetadata: {
-    barchart: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        indicator_column: string;
-        indicator_value: string;
-        indicator_sort_order?: number;
-        name: string;
-        error_low_column: string;
-        error_high_column: string;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults?: {
-        indicator_id: string;
-        x_axis_id: string;
-        disaggregate_by_id: string;
-        selected_filter_options: {
-          [k: string]: any;
-        };
-      };
-    };
-    choropleth: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        error_low_column?: string;
-        error_high_column?: string;
-        indicator_column?: string;
-        indicator_value?: string;
-        indicator_sort_order?: number;
-        name: string;
-        min: number;
-        max: number;
-        colour: string;
-        invert_scale: boolean;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-    };
-  };
+  id: string;
+  complete: true;
   [k: string]: any;
 }
 export interface ModelResultRow {
@@ -345,6 +378,8 @@ export interface ModelRunOptions {
 export interface ControlSection {
   label: string;
   description?: string;
+  collapsible?: boolean;
+  collapsed?: boolean;
   controlGroups: ControlGroup[];
 }
 export interface ControlGroup {

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -50,7 +50,7 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
                 .freezeResponse()
                 .get<ModelResultResponse>(`/model/result/${state.modelRunId}`)
                 .then(() => {
-                    if (state.result && state.result.plottingMetadata.barchart.defaults) {
+                    if (state.result && state.result.plottingMetadata && state.result.plottingMetadata.barchart.defaults) {
                         const defaults = state.result.plottingMetadata.barchart.defaults;
                         commit({
                                 type: "plottingSelections/updateBarchartSelections",

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -3,14 +3,14 @@ import {ReadyState, RootState} from "../../root";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
 import {localStorageManager} from "../../localStorageManager";
-import {ModelResultResponse, ModelStatusResponse, Error} from "../../generated";
+import {ModelResultResponse, ModelStatusResponse, Error, CalibrateResultResponse} from "../../generated";
 
 export interface ModelRunState extends ReadyState {
     modelRunId: string
     statusPollId: number,
     status: ModelStatusResponse
     errors: Error[],
-    result: ModelResultResponse | null
+    result: CalibrateResultResponse | ModelResultResponse | null
     pollingCounter: number
 }
 

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -2,8 +2,7 @@ import {createLocalVue, shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
 import ModelOutput from "../../../app/components/modelOutput/ModelOutput.vue";
 import {
-    mockBaselineState,
-    mockModelResultResponse,
+    mockBaselineState, mockCalibrateResultResponse,
     mockModelRunState, mockShapeResponse,
 } from "../../mocks";
 import {mutations as modelOutputMutations} from "../../../app/store/modelOutput/mutations";
@@ -40,7 +39,7 @@ function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGette
             modelRun: {
                 namespaced: true,
                 state: mockModelRunState({
-                    result: mockModelResultResponse({data: ["TEST DATA"] as any})
+                    result: mockCalibrateResultResponse({data: ["TEST DATA"] as any})
                 })
             },
             modelOutput: {

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -21,7 +21,7 @@ import {
     SurveyFilters,
     SurveyResponse,
     ValidateBaselineResponse,
-    Error
+    Error, CalibrateResultResponse
 } from "../app/generated";
 import {initialModelRunState, ModelRunState} from "../app/store/modelRun/modelRun";
 import {emptyState, RootState} from "../app/root";
@@ -295,6 +295,14 @@ export const mockModelStatusResponse = (props: Partial<ModelStatusResponse> = {}
 
 export const mockModelResultResponse = (props: Partial<ModelResultResponse> = {}): ModelResultResponse => {
     return {
+        id: "123",
+        complete: true,
+        ...props
+    };
+};
+
+export const mockCalibrateResultResponse = (props: Partial<CalibrateResultResponse> = {}): CalibrateResultResponse => {
+    return {
         plottingMetadata: {
             barchart: {
                 indicators: [], filters: []
@@ -318,6 +326,8 @@ export const mockModelResultResponse = (props: Partial<ModelResultResponse> = {}
         ...props
     }
 };
+
+
 
 export const mockPlottingMetadataResponse = (props: Partial<PlottingMetadataResponse> = {}): PlottingMetadataResponse => {
     return {


### PR DESCRIPTION
## Description

Regen front end types for async calibration. The output barchart looks odd in this branch - I think this is probably because we're still using the old calibrate endpoint, and perhaps it has lost the plotting metadata from its result. Will check this is resolved in the next branch which will use the new endpoints. 

This should the console errors you were seeing in the last branch.  

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
