### PR TITLE
Use resetState to wipe downstream steps from modelRun

### DIFF
--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -157,7 +157,7 @@
         },
         watch: {
             complete: function (){
-                if (this.activeStep === 4 && this.isEnabled(5)){
+                if (this.activeStep === 4 && this.isComplete(4) && this.isEnabled(5)){
                     this.next()
                 }
             },

--- a/src/app/static/src/app/components/Stepper.vue
+++ b/src/app/static/src/app/components/Stepper.vue
@@ -157,7 +157,7 @@
         },
         watch: {
             complete: function (){
-                if (this.activeStep === 4 && this.isComplete(4) && this.isEnabled(5)){
+                if (this.activeStep === 4 && this.isEnabled(5)){
                     this.next()
                 }
             },

--- a/src/app/static/src/app/components/modelRun/ModelRun.vue
+++ b/src/app/static/src/app/components/modelRun/ModelRun.vue
@@ -33,16 +33,22 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {mapActions} from "vuex";
     import {ModelRunState} from "../../store/modelRun/modelRun";
     import Modal from "../Modal.vue";
     import Tick from "../Tick.vue";
-    import {mapActionsByNames, mapGettersByNames, mapStateProps, mapGetterByName} from "../../utils";
+    import {
+        mapActionsByNames,
+        mapGettersByNames,
+        mapStateProps,
+        mapGetterByName,
+        mapMutationByName
+    } from "../../utils";
     import ErrorAlert from "../ErrorAlert.vue";
     import {ProgressPhase} from "../../generated";
     import ProgressBar from "../progress/ProgressBar.vue";
     import LoadingSpinner from "../LoadingSpinner.vue";
     import ResetConfirmation from "../ResetConfirmation.vue";
+    import {ModelRunMutation} from "../../store/modelRun/mutations";
 
     interface ComputedState {
         runId: string
@@ -71,7 +77,7 @@
         poll: (runId: string) => void;
         cancelRun: () => void;
         runModelWithParams: () => void;
-        resetFromFit: () => void;
+        clearResult: () => void;
     }
 
     const namespace = 'modelRun';
@@ -97,16 +103,16 @@
             ...mapGettersByNames<keyof ComputedGetters>(namespace, ["running", "complete"])
         },
         methods: {
-            ...mapActions(["resetFromFit"]),
             ...mapActionsByNames<keyof Methods>(namespace, ["run", "poll", "cancelRun"]),
+            clearResult: mapMutationByName(namespace, ModelRunMutation.ClearResult),
             handleRun(){
                 if (this.editsRequireConfirmation){
                     this.showReRunConfirmation = true
                 } else this.run()
             },
             confirmReRun() {
-                this.resetFromFit()
-                this.run()
+                this.clearResult();
+                this.run();
                 this.showReRunConfirmation = false;
             },
             cancelReRun() {

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -32,6 +32,7 @@ import {ADRSchemas} from "./types";
 import {modelCalibrate, initialModelCalibrateState, ModelCalibrateState} from "./store/modelCalibrate/modelCalibrate";
 import { initialHintrVersionState, hintrVersion, HintrVersionState } from "./store/hintrVersion/hintrVersion";
 import {currentHintVersion} from "./hintVersion";
+import {ModelRunMutation, ModelRunUpdates} from "./store/modelRun/mutations";
 
 export interface TranslatableState {
     language: Language
@@ -100,6 +101,10 @@ const resetState = (store: Store<RootState>) => {
             }
 
             if (type[0] == "modelOptions" && ModelOptionsUpdates.includes(type[1] as ModelOptionsMutation)) {
+                store.commit(RootMutation.ResetOutputs);
+            }
+
+            if (type[0] == "modelRun" && ModelRunUpdates.includes(type[1] as ModelRunMutation)) {
                 store.commit(RootMutation.ResetOutputs);
             }
         }

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -13,7 +13,7 @@ export enum ModelRunMutation {
     RunStatusError = "RunStatusError",
     RunCancelled = "RunCancelled",
     Ready = "Ready",
-    ClearResult = "ClearModelRun"
+    ClearResult = "ClearResult"
 }
 
 export const ModelRunUpdates = [

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -12,8 +12,13 @@ export enum ModelRunMutation {
     RunResultError = "RunResultError",
     RunStatusError = "RunStatusError",
     RunCancelled = "RunCancelled",
-    Ready = "Ready"
+    Ready = "Ready",
+    ClearResult = "ClearModelRun"
 }
+
+export const ModelRunUpdates = [
+    ModelRunMutation.ClearResult
+];
 
 export const mutations: MutationTree<ModelRunState> = {
     [ModelRunMutation.ModelRunStarted](state: ModelRunState, action: PayloadWithType<ModelSubmitResponse>) {
@@ -68,6 +73,10 @@ export const mutations: MutationTree<ModelRunState> = {
         stopPolling(state);
         Object.assign(state, initialModelRunState());
         state.ready = true;
+    },
+
+    [ModelRunMutation.ClearResult](state: ModelRunState) {
+        state.result = null;
     }
 };
 

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -15,7 +15,6 @@ export interface RootActions extends LanguageActions<RootState>{
     deleteADRKey: (store: ActionContext<RootState, RootState>) => void;
     getADRDatasets: (store: ActionContext<RootState, RootState>) => void;
     getADRSchemas: (store: ActionContext<RootState, RootState>) => void;
-    resetFromFit: (store: ActionContext<RootState, RootState>) => void;
 }
 
 export const actions: ActionTree<RootState, RootState> & RootActions = {
@@ -56,11 +55,6 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
                 }
             });
         }
-    },
-    async resetFromFit(store) {
-        const {commit} = store;
-        commit({type: RootMutation.ResetModelCalibrate});
-        commit({type: RootMutation.ResetOutputs});             
     },
 
     async changeLanguage(context, payload) {

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -20,7 +20,6 @@ export enum RootMutation {
     Reset = "Reset",
     ResetSelectedDataType = "ResetSelectedDataType",
     ResetOptions = "ResetOptions",
-    ResetModelCalibrate = "ResetModelCalibrate",
     ResetOutputs = "ResetOutputs",
     SetADRKeyError = "ADRKeyError",
     SetProject = "SetProject",
@@ -144,10 +143,6 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.ResetOptions](state: RootState) {
         Object.assign(state.modelOptions, initialModelOptionsState());
-    },
-
-    [RootMutation.ResetModelCalibrate](state: RootState) {
-        Object.assign(state.modelCalibrate, initialModelCalibrateState());
     },
 
     [RootMutation.ResetOutputs](state: RootState) {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -39,6 +39,7 @@ console.error = jest.fn();
 // as the app will call these actions on import
 import {app} from "../../app"
 import {RootMutation} from "../../app/store/root/mutations";
+import {ModelRunMutation} from "../../app/store/modelRun/mutations";
 
 describe("App", () => {
 
@@ -136,6 +137,15 @@ describe("App", () => {
         const store = getStore(true);
         const spy = jest.spyOn(store, "commit");
         store.commit(prefixNamespace("modelOptions", ModelOptionsMutation.UnValidate));
+
+        expect(spy.mock.calls[1][0]).toBe(RootMutation.ResetOutputs);
+        expect(spy).toBeCalledTimes(2);
+    });
+
+    it("resets outputs if modelRun ClearResult mutation is called and state is ready", () => {
+        const store = getStore(true);
+        const spy = jest.spyOn(store, "commit");
+        store.commit(prefixNamespace("modelRun", ModelRunMutation.ClearResult));
 
         expect(spy.mock.calls[1][0]).toBe(RootMutation.ResetOutputs);
         expect(spy).toBeCalledTimes(2);

--- a/src/app/static/src/tests/components/modelRun/modelRun.test.ts
+++ b/src/app/static/src/tests/components/modelRun/modelRun.test.ts
@@ -1,5 +1,6 @@
 import {createLocalVue, mount, shallowMount} from '@vue/test-utils';
 import Vuex, {Store} from 'vuex';
+import Vue from 'vue';
 import {
     mockAxios,
     mockError,
@@ -24,6 +25,7 @@ import LoadingSpinner from "../../../app/components/LoadingSpinner.vue";
 import ProgressBar from "../../../app/components/progress/ProgressBar.vue";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {expectTranslated} from "../../testHelpers";
+import {actions as rootActions} from "../../../app/store/root/actions";
 
 const localVue = createLocalVue();
 
@@ -341,6 +343,20 @@ describe("Model run component", () => {
             expect(store.state.modelRun.status).toStrictEqual({});
             done();
         });
+    });
+
+    it("confirmReRun clears and re-runs model and hides dialog", async () => {
+        const mockRun = jest.fn();
+        const store = createStore({result: ["TEST RESULT"] as any},  {run: mockRun});
+        const wrapper = shallowMount(ModelRun, {store, localVue});
+        wrapper.setData({showReRunConfirmation: true});
+
+        (wrapper.vm as any).confirmReRun();
+        await Vue.nextTick();
+
+        expect(store.state.modelRun.result).toBe(null);
+        expect(mockRun.mock.calls.length).toBe(1);
+        expect(wrapper.vm.$data.showReRunConfirmation).toBe(false);
     });
 
 });

--- a/src/app/static/src/tests/modelRun/mutations.test.ts
+++ b/src/app/static/src/tests/modelRun/mutations.test.ts
@@ -117,4 +117,12 @@ describe("Model run mutations", () => {
         expect(testState.errors).toStrictEqual([]);
         expect(testState.result).toBeNull();
     });
+
+    it("clears result", () => {
+        const testState = mockModelRunState({
+            result: mockModelResultResponse()
+        });
+        mutations.ClearResult(testState);
+        expect(testState.result).toBeNull();
+    });
 });

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -38,33 +38,6 @@ describe("root actions", () => {
         expect(mockContext.dispatch).not.toHaveBeenCalled();
     });
 
-    it("resets state of model calibrate and outputs", async () => {
-        const mockContext = {
-            commit: jest.fn(),
-            dispatch: jest.fn(),
-            getters: {
-                "stepper/complete": {
-                    1: true,
-                    2: true,
-                    3: true,
-                    4: true,
-                    5: true,
-                    6: true
-                }
-            },
-            state: {
-                stepper: mockStepperState({
-                    activeStep: 4
-                })
-            }
-        };
-
-        await actions.resetFromFit(mockContext as any);
-        
-        expect(mockContext.commit.mock.calls[0][0]).toStrictEqual({type: "ResetModelCalibrate"});
-        expect(mockContext.commit.mock.calls[1][0]).toStrictEqual({type: "ResetOutputs"});
-    });
-
     it("resets state if not all steps are valid", async () => {
 
 

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -198,16 +198,6 @@ describe("Root mutations", () => {
         expect(state.modelOptions).toStrictEqual(initialModelOptionsState());
     });
 
-    it("can reset model calibrate state", () => {
-
-        const state = mockRootState({
-            modelCalibrate: mockModelCalibrateState({options: "TEST" as any})
-        });
-
-        mutations.ResetModelCalibrate(state);
-        expect(state.modelCalibrate).toStrictEqual(initialModelCalibrateState());
-    });
-
     it("can reset model outputs state", () => {
 
         const state = mockRootState({


### PR DESCRIPTION
## Description

This really comprises only two small changes from your approach. 
1. Don't need `ResetCalibrate` mutation - `ResetOutputs` covers calibrate state too
2. Rather than a specific action to resetFromFit, make use of the existing `resetState` mechanism to designate clearing the model run result as an update which should wipe downstream state. 

The cause of your trouble with `validate` was my poor advice - I got confused between `validate` action, which is really about loading state correctly (hence the fact that it triggers load errors if something goes wrong) - and `resetState` which is triggered on every mutation and checks for 'update' mutations which should trigger downstream state wipes.  

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
