### PR TITLE
mrc-2061 Front end for async calibrate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.10.1
+
+* Do model calibration asynchronously.
+
 # hint 1.10.0
 
 * fix ok button accessibility bug in share project

--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -7,7 +7,7 @@
         <dynamic-form ref="form"
                       v-if="!loading"
                       v-model="calibrateOptions"
-                      @submit="calibrate"
+                      @submit="submitCalibrate"
                       :required-text="requiredText"
                       :select-text="selectText"
                       :include-submit-button="false"></dynamic-form>
@@ -48,7 +48,7 @@
 
     interface Methods {
         fetchOptions: () => void
-        calibrate: (data: DynamicFormData) => void
+        submitCalibrate: (data: DynamicFormData) => void
         update: (data: DynamicFormMeta) => void
         submitForm: (e: Event) => void
     }
@@ -114,7 +114,7 @@
         },
         methods: {
             update: mapMutationByName(namespace, ModelCalibrateMutation.Update),
-            calibrate: mapActionByName(namespace,"calibrate"),
+            submitCalibrate: mapActionByName(namespace,"submit"),
             fetchOptions: mapActionByName(namespace, "fetchModelCalibrateOptions"),
             submitForm() {
                 (this.$refs.form as any).submit()

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,3 +1,3 @@
 
-export const currentHintVersion = "1.10.0";
+export const currentHintVersion = "1.10.1";
 

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -57,7 +57,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 .withError(ModelCalibrateMutation.SetError)
                 .get<ModelStatusResponse>(`/model/calibrate/status/${calibrateId}`)
                 .then(() => {
-                    if (state.status.done) {
+                    if (state.status.done && state.status.success) {
                         dispatch("getResult");
                     }
                 });

--- a/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
+++ b/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
@@ -4,12 +4,15 @@ import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {mutations} from "./mutations";
 import {localStorageManager} from "../../localStorageManager";
 import {actions} from "./actions";
-import {VersionInfo, Error} from "../../generated";
+import {VersionInfo, Error, CalibrateStatusResponse} from "../../generated";
 
 export interface ModelCalibrateState {
     optionsFormMeta: DynamicFormMeta
     options: DynamicFormData
     fetching: boolean
+    calibrateId: string
+    statusPollId: number
+    status: CalibrateStatusResponse
     calibrating: boolean
     complete: boolean
     version: VersionInfo
@@ -21,6 +24,9 @@ export const initialModelCalibrateState = (): ModelCalibrateState => {
         optionsFormMeta: {controlSections: []},
         options: {},
         fetching: false,
+        calibrateId: "",
+        statusPollId: -1,
+        status: {} as CalibrateStatusResponse,
         calibrating: false,
         complete: false,
         version: {hintr: "unknown", naomi: "unknown", rrq: "unknown"},

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -42,6 +42,7 @@ export const mutations: MutationTree<ModelCalibrateState> = {
     [ModelCalibrateMutation.CalibrateStarted](state: ModelCalibrateState, action: PayloadWithType<CalibrateSubmitResponse>) {
         state.calibrateId = action.payload.id;
         state.calibrating = true;
+        state.complete = false;
         state.error = null;
     },
 

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -19,7 +19,8 @@ export enum ModelCalibrateMutation {
     CalibrateStatusUpdated = "CalibrateStatusUpdated",
     Calibrated = "Calibrated",
     SetOptionsData = "SetOptionsData",
-    SetError = "SetError"
+    SetError = "SetError",
+    PollingForStatusStarted = "PollingForStatusStarted"
 }
 
 export const mutations: MutationTree<ModelCalibrateState> = {
@@ -71,7 +72,11 @@ export const mutations: MutationTree<ModelCalibrateState> = {
         if (state.statusPollId > -1) {
             stopPolling(state);
         }
-    }
+    },
+
+    [ModelCalibrateMutation.PollingForStatusStarted](state: ModelCalibrateState, action: PayloadWithType<number>) {
+        state.statusPollId = action.payload;
+    },
 };
 
 const stopPolling = (state: ModelCalibrateState) => {

--- a/src/app/static/src/app/store/modelRun/actions.ts
+++ b/src/app/static/src/app/store/modelRun/actions.ts
@@ -48,22 +48,7 @@ export const actions: ActionTree<ModelRunState, RootState> & ModelRunActions = {
                 .withSuccess(ModelRunMutation.RunResultFetched)
                 .withError(ModelRunMutation.RunResultError)
                 .freezeResponse()
-                .get<ModelResultResponse>(`/model/result/${state.modelRunId}`)
-                .then(() => {
-                    if (state.result && state.result.plottingMetadata && state.result.plottingMetadata.barchart.defaults) {
-                        const defaults = state.result.plottingMetadata.barchart.defaults;
-                        commit({
-                                type: "plottingSelections/updateBarchartSelections",
-                                payload: {
-                                    indicatorId: defaults.indicator_id,
-                                    xAxisId: defaults.x_axis_id,
-                                    disaggregateById: defaults.disaggregate_by_id,
-                                    selectedFilterOptions: {...defaults.selected_filter_options}
-                                }
-                            },
-                            {root: true});
-                    }
-                });
+                .get<ModelResultResponse>(`/model/result/${state.modelRunId}`);
         }
         commit({type: "Ready", payload: true});
     },

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -13,7 +13,7 @@ import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 import {ModelCalibrateMutation} from "../../../app/store/modelCalibrate/mutations";
 
 describe("Model calibrate component", () => {
-    const getStore = (state: Partial<ModelCalibrateState> = {}, fetchAction = jest.fn(), submitction = jest.fn(),
+    const getStore = (state: Partial<ModelCalibrateState> = {}, fetchAction = jest.fn(), submitAction = jest.fn(),
                       updateMutation = jest.fn()) => {
         const store = new Vuex.Store({
             state: mockRootState(),
@@ -23,7 +23,7 @@ describe("Model calibrate component", () => {
                     state: mockModelCalibrateState(state),
                     actions: {
                         fetchModelCalibrateOptions: fetchAction,
-                        submit: submitction
+                        submit: submitAction
                     },
                     mutations: {
                         [ModelCalibrateMutation.Update]: updateMutation

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -13,7 +13,7 @@ import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 import {ModelCalibrateMutation} from "../../../app/store/modelCalibrate/mutations";
 
 describe("Model calibrate component", () => {
-    const getStore = (state: Partial<ModelCalibrateState> = {}, fetchAction = jest.fn(), calibrateAction = jest.fn(),
+    const getStore = (state: Partial<ModelCalibrateState> = {}, fetchAction = jest.fn(), submitction = jest.fn(),
                       updateMutation = jest.fn()) => {
         const store = new Vuex.Store({
             state: mockRootState(),
@@ -23,7 +23,7 @@ describe("Model calibrate component", () => {
                     state: mockModelCalibrateState(state),
                     actions: {
                         fetchModelCalibrateOptions: fetchAction,
-                        calibrate: calibrateAction
+                        submit: submitction
                     },
                     mutations: {
                         [ModelCalibrateMutation.Update]: updateMutation
@@ -133,12 +133,12 @@ describe("Model calibrate component", () => {
         expect(newFormData.controlSections[0].controlGroups[0].controls[0].value).toBe(6);
     });
 
-    it("clicking Calibrate button invokes calibrate action", () => {
-        const mockCalibrate = jest.fn();
-        const store = getStore({optionsFormMeta: mockOptionsFormMeta}, jest.fn(), mockCalibrate);
+    it("clicking Calibrate button invokes submit calibrate action", () => {
+        const mockSubmit = jest.fn();
+        const store = getStore({optionsFormMeta: mockOptionsFormMeta}, jest.fn(), mockSubmit);
         const wrapper = mount(ModelCalibrate, {store});
         wrapper.find("button").trigger("click");
-        expect(mockCalibrate.mock.calls.length).toBe(1);
+        expect(mockSubmit.mock.calls.length).toBe(1);
 
     });
 });

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -1,11 +1,18 @@
-import {actions} from "../../app/store/modelCalibrate/actions";
-import {rootState} from "./integrationTest";
+import {actions, getCalibrateStatus} from "../../app/store/modelCalibrate/actions";
 import {isDynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {rootState} from "./integrationTest";
 import {Language} from "../../app/store/translations/locales";
+import {login} from "./integrationTest";
 
 describe("model calibrate actions integration", () => {
+
+    beforeAll(async () => {
+        await login();
+    });
+
     it("can get model calibrate options", async () => {
         const commit = jest.fn();
+
         await actions.fetchModelCalibrateOptions({commit, rootState} as any);
         expect(commit.mock.calls[1][0]["type"]).toBe("ModelCalibrateOptionsFetched");
         const payload = commit.mock.calls[1][0]["payload"];
@@ -15,26 +22,45 @@ describe("model calibrate actions integration", () => {
         expect(commit.mock.calls[2][0]["payload"]).toBeDefined();
     });
 
-    it("can calibrate model run", async () => {
+    it("can submit calibrate", async () => {
         const commit = jest.fn();
-        const testRootState = {
-            language: Language.en,
-            modelRun:{
-                modelRunId: "1234"
-            }
-        };
-
         const testState = {
             version: {hintr: "0.1.3", naomi: "1.0.4", rrq: "0.2.7"}
         };
-
-        await actions.calibrate({commit, state: testState, rootState: testRootState} as any, {});
+        const testRootState = {
+           language: Language.en,
+           modelRun:{
+               modelRunId: "1234"
+           }
+       };
+        await actions.submit({commit, state: testState, rootState: testRootState} as any, {});
 
         // passing an invalid run id so this will return an error
         // but the expected error message confirms
         // that we're hitting the correct endpoint
-        expect(commit.mock.calls.length).toBe(3);
-        expect(commit.mock.calls[2][0]["type"]).toBe("SetError");
-        expect(commit.mock.calls[2][0]["payload"].detail).toBe("Failed to fetch result");
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[1][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
+    });
+
+
+    it("can get calibrate status", async () => {
+        const commit = jest.fn();
+        const state = {calibrateId: "123"} as any;
+        await getCalibrateStatus({commit, state, rootState} as any);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]["type"]).toBe("CalibrateStatusUpdated");
+        expect(commit.mock.calls[0][0]["payload"].status).toBe("MISSING");
+    });
+
+    it("can get calibrate result", async () => {
+        const commit = jest.fn();
+        const state = {calibrateId: "123"} as any;
+        await actions.getResult({commit, state, rootState} as any);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
     });
 });

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -2,13 +2,8 @@ import {actions, getCalibrateStatus} from "../../app/store/modelCalibrate/action
 import {isDynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {rootState} from "./integrationTest";
 import {Language} from "../../app/store/translations/locales";
-import {login} from "./integrationTest";
 
 describe("model calibrate actions integration", () => {
-
-    beforeAll(async () => {
-        await login();
-    });
 
     it("can get model calibrate options", async () => {
         const commit = jest.fn();

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -48,7 +48,7 @@ describe("ModelCalibrate actions", () => {
             modelRun: mockModelRunState({modelRunId: "123A"})
         });
         const mockOptions = {"param_1": "value 1"};
-        const url = `/model/calibrate/submit/123A`;
+        const url = `model/calibrate/submit/123A`;
         mockAxios.onPost(url).reply(200, mockSuccess("TEST"));
         const freezeSpy = jest.spyOn(freezer, "deepFreeze");
         await actions.submit({commit, dispatch, state, rootState: root} as any, mockOptions);

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -9,8 +9,8 @@ import {
 } from "../mocks";
 import {actions} from "../../app/store/modelCalibrate/actions";
 import {ModelCalibrateMutation} from "../../app/store/modelCalibrate/mutations";
-import {ModelRunMutation} from "../../app/store/modelRun/mutations";
 import {freezer} from "../../app/utils";
+import {ModelStatusResponse} from "../../app/generated";
 
 const rootState = mockRootState();
 describe("ModelCalibrate actions", () => {
@@ -39,35 +39,36 @@ describe("ModelCalibrate actions", () => {
         expect(commit.mock.calls[2][0].payload).toBe("v1")
     });
 
-    it("calibrate action calls calibrate endpoints and commits mutations", async () => {
+    it("submit action calls submit endpoint, commits mutations and starts polling", async () => {
         const commit = jest.fn();
+        const dispatch = jest.fn();
         const mockVersion = {naomi: "1.0.0", hintr: "1.0.0", rrq: "1.0.0"};
         const state = mockModelCalibrateState({version: mockVersion});
         const root = mockRootState({
             modelRun: mockModelRunState({modelRunId: "123A"})
         });
         const mockOptions = {"param_1": "value 1"};
-        const url = `/model/calibrate/123A`;
+        const url = `/model/calibrate/submit/123A`;
         mockAxios.onPost(url).reply(200, mockSuccess("TEST"));
         const freezeSpy = jest.spyOn(freezer, "deepFreeze");
-        await actions.calibrate({commit, state, rootState: root} as any, mockOptions);
+        await actions.submit({commit, dispatch, state, rootState: root} as any, mockOptions);
 
         expect(mockAxios.history.post.length).toBe(1);
         expect(mockAxios.history.post[0].url).toBe(url);
         expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({version: mockVersion, options: mockOptions});
 
-        expect(commit.mock.calls.length).toBe(4);
+        expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toBe(ModelCalibrateMutation.SetOptionsData);
         expect(commit.mock.calls[0][1]).toBe(mockOptions);
-        expect(commit.mock.calls[1][0]).toBe(ModelCalibrateMutation.Calibrating);
-        expect(commit.mock.calls[2][0].type).toBe("modelRun/RunResultFetched");
-        expect(commit.mock.calls[2][0].payload).toBe("TEST");
-        expect(freezeSpy.mock.calls[0][0]).toBe("TEST");
-        expect(commit.mock.calls[3][0]).toBe(ModelCalibrateMutation.Calibrated);
+        expect(commit.mock.calls[1][0].type).toBe(ModelCalibrateMutation.CalibrateStarted);
+
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("poll");
     });
 
-    it("calibrate action commits error on unsuccessful request", async () => {
+    it("submit action commits error on unsuccessful request", async () => {
         const commit = jest.fn();
+        const dispatch = jest.fn();
         const mockVersion = {naomi: "1.0.0", hintr: "1.0.0", rrq: "1.0.0"};
         const state = mockModelCalibrateState({version: mockVersion});
         const root = mockRootState({
@@ -75,13 +76,141 @@ describe("ModelCalibrate actions", () => {
         });
 
         const testError =  mockError("TEST ERROR");
-        mockAxios.onPost(`/model/calibrate/123A`).reply(400, mockFailure("TEST ERROR"));
-        await actions.calibrate({commit, state, rootState: root} as any, {});
+        mockAxios.onPost(`/model/calibrate/submit/123A`).reply(400, mockFailure("TEST ERROR"));
+        await actions.submit({commit, dispatch, state, rootState: root} as any, {});
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]).toBe(ModelCalibrateMutation.SetOptionsData);
+        expect(commit.mock.calls[1][0].type).toBe(ModelCalibrateMutation.SetError);
+        expect(commit.mock.calls[1][0].payload).toStrictEqual(testError);
+        expect(dispatch.mock.calls.length).toBe(0);
+    });
+
+    it("poll commits status when successfully fetched", async (done) => {
+        mockAxios.onGet(`/model/calibrate/status/1234`)
+            .reply(200, mockSuccess("TEST DATA"));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockModelCalibrateState({calibrateId: "1234"});
+
+        actions.poll({commit, dispatch, state, rootState} as any);
+
+        setTimeout(() => {
+            expect(commit.mock.calls.length).toBe(2);
+            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+            expect(commit.mock.calls[0][0].payload).toBeGreaterThan(-1);
+            expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
+            expect(commit.mock.calls[1][0].payload).toBe("TEST DATA");
+            expect(dispatch.mock.calls.length).toBe(0);
+
+            done();
+        }, 2100);
+    });
+
+    it("poll commits error when unsuccessful fetch", (done) => {
+        mockAxios.onGet(`/model/calibrate/status/1234`)
+            .reply(500, mockFailure("Test Error"));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockModelCalibrateState({calibrateId: "1234"});
+
+        actions.poll({commit, dispatch, state, rootState} as any);
+
+        setTimeout(() => {
+            expect(commit.mock.calls.length).toBe(2);
+            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+
+            expect(commit.mock.calls[1][0]).toStrictEqual({
+                type: "SetError",
+                payload: mockError("Test Error")
+            });
+            expect(dispatch.mock.calls.length).toBe(0);
+
+            done();
+        }, 2100);
+    });
+
+    it("poll dispatches getResult when status done and status success", async (done) => {
+        mockAxios.onGet(`/model/calibrate/status/1234`)
+            .reply(200, mockSuccess("TEST DATA"));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockModelCalibrateState({calibrateId: "1234", status: {done: true, success: true} as any});
+
+        actions.poll({commit, dispatch, state, rootState} as any);
+
+        setTimeout(() => {
+            expect(commit.mock.calls.length).toBe(2);
+            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+            expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
+
+            expect(dispatch.mock.calls.length).toBe(1);
+            expect(dispatch.mock.calls[0][0]).toBe("getResult");
+
+            done();
+        }, 2100);
+    });
+
+    it("getResult commits result when successfully fetched, and sets default plotting selections", async () => {
+        const testResult = {
+            data: "TEST DATA",
+            plottingMetadata: {
+                barchart: {
+                    defaults: {
+                        indicator_id: "test indicator",
+                        x_axis_id: "test_x",
+                        disaggregate_by_id: "test_dis",
+                        selected_filter_options: {"test_name": "test_value"}
+                    }
+                }
+            }
+        };
+        mockAxios.onGet(`/model/calibrate/result/1234`)
+            .reply(200, mockSuccess(testResult));
+
+        const commit = jest.fn();
+        const state = mockModelCalibrateState({
+            calibrateId: "1234"
+        });
+
+        await actions.getResult({commit, state, rootState} as any);
 
         expect(commit.mock.calls.length).toBe(3);
-        expect(commit.mock.calls[0][0]).toBe(ModelCalibrateMutation.SetOptionsData);
-        expect(commit.mock.calls[1][0]).toBe(ModelCalibrateMutation.Calibrating);
-        expect(commit.mock.calls[2][0].type).toBe(ModelCalibrateMutation.SetError);
-        expect(commit.mock.calls[2][0].payload).toStrictEqual(testError);
-    })
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type:"modelRun/RunResultFetched",
+            payload: testResult
+        });
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "plottingSelections/updateBarchartSelections",
+            payload: {
+                indicatorId: "test indicator",
+                xAxisId: "test_x",
+                disaggregateById: "test_dis",
+                selectedFilterOptions: {"test_name": "test_value"}
+            }
+        });
+        expect(commit.mock.calls[2][0]).toBe("Calibrated");
+    });
+
+    it("getResult commits error when unsuccessful fetch", async () => {
+        mockAxios.onGet(`/model/calibrate/result/1234`)
+            .reply(500, mockFailure("Test Error"));
+
+        const commit = jest.fn();
+        const state = mockModelCalibrateState({
+            calibrateId: "1234"
+        });
+
+        await actions.getResult({commit, state, rootState} as any);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "SetError",
+            payload: mockError("Test Error")
+        });
+    });
+
 });

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -35,12 +35,13 @@ describe("ModelCalibrate mutations", () => {
     });
 
     it("CalibrateStarted sets calibrateId, calibrating to true, error to null", () => {
-        const state = mockModelCalibrateState({error: mockError("TEST ERROR")});
+        const state = mockModelCalibrateState({error: mockError("TEST ERROR"), complete: true});
         const payload = {id: "123"} as any;
         mutations[ModelCalibrateMutation.CalibrateStarted](state, {payload});
         expect(state.calibrateId).toBe("123");
         expect(state.calibrating).toBe(true);
         expect(state.error).toBeNull();
+        expect(state.complete).toBe(false);
     });
 
     it("CalibrateStatusUpdate sets status, resets error", () => {

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -1,9 +1,12 @@
 import {expectAllMutationsDefined} from "../testHelpers";
 import {ModelCalibrateMutation, mutations} from "../../app/store/modelCalibrate/mutations";
-import {mockError, mockModelCalibrateState, mockModelOptionsState} from "../mocks";
+import {mockError, mockModelCalibrateState,} from "../mocks";
 import {VersionInfo} from "../../app/generated";
 
 describe("ModelCalibrate mutations", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
 
     it("all mutation types are defined", () => {
         expectAllMutationsDefined(ModelCalibrateMutation, mutations);
@@ -31,11 +34,32 @@ describe("ModelCalibrate mutations", () => {
         expect(state.optionsFormMeta).toBe(payload);
     });
 
-    it("Calibrating sets calibrating to true, error to null", () => {
+    it("CalibrateStarted sets calibrateId, calibrating to true, error to null", () => {
         const state = mockModelCalibrateState({error: mockError("TEST ERROR")});
-        mutations[ModelCalibrateMutation.Calibrating](state);
+        const payload = {id: "123"} as any;
+        mutations[ModelCalibrateMutation.CalibrateStarted](state, {payload});
+        expect(state.calibrateId).toBe("123");
         expect(state.calibrating).toBe(true);
         expect(state.error).toBeNull();
+    });
+
+    it("CalibrateStatusUpdate sets status, resets error", () => {
+        const state = mockModelCalibrateState({error: mockError("TEST ERROR")});
+        const payload = ["TEST PAYLOAD"] as any;
+        mutations[ModelCalibrateMutation.CalibrateStatusUpdated](state, {payload});
+        expect(state.status).toStrictEqual(payload);
+        expect(state.error).toBeNull();
+    });
+
+    it("CalibrateStatusUpdate stops polling if status is done", () => {
+        const state = mockModelCalibrateState({statusPollId: 99});
+        const payload = {done: true} as any;
+        const spy = jest.spyOn(window, "clearInterval");
+
+        mutations[ModelCalibrateMutation.CalibrateStatusUpdated](state, {payload});
+        expect(state.statusPollId).toBe(-1);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(99);
     });
 
     it("Calibrated sets complete to true", () => {
@@ -64,10 +88,27 @@ describe("ModelCalibrate mutations", () => {
         expect(state.calibrating).toBe(false);
     });
 
+    it("SetError stops polling", () => {
+        const state = mockModelCalibrateState({statusPollId: 99});
+        const error = mockError("TEST ERROR");
+        const spy = jest.spyOn(window, "clearInterval");
+
+        mutations[ModelCalibrateMutation.SetError](state, {payload: error});
+        expect(state.statusPollId).toBe(-1);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(99);
+    });
+
     it("sets options", () => {
         const state = mockModelCalibrateState();
         const options = { "testOption": "testValue" };
         mutations[ModelCalibrateMutation.SetOptionsData](state, {payload: options});
         expect(state.options).toBe(options);
+    });
+
+    it("PollingForStatusStarted sets statusPollId", () => {
+        const state = mockModelCalibrateState();
+        mutations[ModelCalibrateMutation.PollingForStatusStarted](state, {payload: 99});
+        expect(state.statusPollId).toBe(99);
     });
 });

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -161,43 +161,6 @@ describe("Model run actions", () => {
         });
     });
 
-    it("getResult commits result when successfully fetched, and sets default plotting selections", async () => {
-        const testResult = {
-            data: "TEST DATA",
-            plottingMetadata: {
-                barchart: {
-                    defaults: {
-                        indicator_id: "test indicator",
-                        x_axis_id: "test_x",
-                        disaggregate_by_id: "test_dis",
-                        selected_filter_options: {"test_name": "test_value"}
-                    }
-                }
-            }
-        };
-        mockAxios.onGet(`/model/result/1234`)
-            .reply(200, mockSuccess(testResult));
-
-        const commit = jest.fn();
-        const state = mockModelRunState({
-            modelRunId: "1234",
-            status: {done: true} as ModelStatusResponse,
-            result: testResult as any
-        });
-
-        await actions.getResult({commit, state, rootState} as any);
-
-        expect(commit.mock.calls[1][0]).toStrictEqual({
-            type: "plottingSelections/updateBarchartSelections",
-            payload: {
-                indicatorId: "test indicator",
-                xAxisId: "test_x",
-                disaggregateById: "test_dis",
-                selectedFilterOptions: {"test_name": "test_value"}
-            }
-        });
-    });
-
     it("getResult commits error when unsuccessful fetch", async () => {
         mockAxios.onGet(`/model/result/1234`)
             .reply(500, mockFailure("Test Error"));


### PR DESCRIPTION
## Description

Add in the front end actions and mutations to execute model calibration asynchronously. The actions co-ordinate each other - a successful `submit` action dispatches an action to start polling for status, and when a status result comes back indicating successful completion, the `getResult` action is dispatched. Hence all the component needs to do is dispatch the initial submit action. 

This branch also moves using the barchart metadata from the model run result (it's no longer returned there) to using the metadata from the calibrate result. 

## Type of version change
_Delete as appropriate_
Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
