### PR TITLE
mrc-2064 Added modelrun complete state

### DIFF
--- a/src/app/static/src/app/components/modelRun/ModelRun.vue
+++ b/src/app/static/src/app/components/modelRun/ModelRun.vue
@@ -40,6 +40,7 @@
     import LoadingSpinner from "../LoadingSpinner.vue";
 
     interface ComputedState {
+        complete: boolean
         runId: string
         pollId: number
         phases: ProgressPhase[]
@@ -47,7 +48,7 @@
 
     interface ComputedGetters {
         running: boolean
-        complete: boolean
+        // complete: boolean
     }
 
     interface Computed extends ComputedGetters, ComputedState {
@@ -66,6 +67,7 @@
         name: "ModelRun",
         computed: {
             ...mapStateProps<ModelRunState, keyof ComputedState>(namespace, {
+                complete: state => state.complete,
                 runId: state => state.modelRunId,
                 pollId: state => state.statusPollId,
                 errors: state => state.errors,
@@ -74,7 +76,8 @@
                     return progress.map((item, index) => ({...item, name: `${index + 1}. ${item.name}`}))
                 }
             }),
-            ...mapGettersByNames<keyof ComputedGetters>(namespace, ["running", "complete"])
+            // ...mapGettersByNames<keyof ComputedGetters>(namespace, ["running", "complete"])
+            ...mapGettersByNames<keyof ComputedGetters>(namespace, ["running"])
         },
         methods: {
             ...mapActionsByNames<keyof Methods>(namespace, ["run", "poll", "cancelRun"])

--- a/src/app/static/src/app/store/modelRun/modelRun.ts
+++ b/src/app/static/src/app/store/modelRun/modelRun.ts
@@ -6,6 +6,7 @@ import {localStorageManager} from "../../localStorageManager";
 import {ModelResultResponse, ModelStatusResponse, Error} from "../../generated";
 
 export interface ModelRunState extends ReadyState {
+    complete: boolean,
     modelRunId: string
     statusPollId: number,
     status: ModelStatusResponse
@@ -18,6 +19,7 @@ export const maxPollErrors = 150;
 
 export const initialModelRunState = (): ModelRunState => {
     return {
+        complete: false,
         modelRunId: "",
         errors: [],
         status: {} as ModelStatusResponse,
@@ -29,9 +31,9 @@ export const initialModelRunState = (): ModelRunState => {
 };
 
 export const modelRunGetters = {
-    complete: (state: ModelRunState) => {
-        return !!state.status.success && state.errors.length == 0 && !!state.result
-    },
+    // complete: (state: ModelRunState) => {
+    //     return !!state.status.success && state.errors.length == 0 && !!state.result
+    // },
     running: (state: ModelRunState) => {
         const started = !!state.status.id;
         const finished = state.status.done && (!state.status.success || !!state.result);

--- a/src/app/static/src/app/store/modelRun/mutations.ts
+++ b/src/app/static/src/app/store/modelRun/mutations.ts
@@ -20,11 +20,15 @@ export const mutations: MutationTree<ModelRunState> = {
         state.modelRunId = action.payload.id;
         state.status = {id: action.payload.id} as ModelStatusResponse;
         state.errors = [];
+        state.complete = false
     },
 
     [ModelRunMutation.RunStatusUpdated](state: ModelRunState, action: PayloadWithType<ModelStatusResponse>) {
         if (action.payload.done) {
             stopPolling(state);
+        }
+        if (action.payload.progress[0].complete){
+            state.complete = true
         }
         state.status = action.payload;
         state.errors = [];

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -21,7 +21,8 @@ export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
             1: rootGetters['baseline/complete'] && rootGetters['metadata/complete'],
             2: rootGetters['surveyAndProgram/complete'],
             3: rootGetters['modelOptions/complete'],
-            4: rootGetters['modelRun/complete'],
+            // 4: rootGetters['modelRun/complete'],
+            4: rootState.modelRun.complete,
             5: rootState.modelCalibrate.complete,
             6: rootState.modelCalibrate.complete,
             7: false


### PR DESCRIPTION
## Description

Do not rely on on model run result object to determine completion of model run step
Currently, the HINT front end decides whether it thinks that the model run result step is complete by checking if there is a non-null model run result in the store state.
We expect that model run result will eventually be removed, so we should use a flag instead to determine run result state, setting the flag when we get a successful complete status from the run status endpoint, and unsetting it when a new run is submitted.

We should also consider storing the real model result as part of the calibrate state (Since it is really returned when calibration complets) - this might not be worth the effort though.

## Type of version change
Minor

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
