### PR TITLE
mrc-2105 Get model results from new calibrate endpoint on load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.12.1
+
+* fix reload project post-calibrate
+
 # hint 1.12.0
 
 * adds a map reset button

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.12.0";
+export const currentHintVersion = "1.12.1";

--- a/src/app/static/src/app/index.ts
+++ b/src/app/static/src/app/index.ts
@@ -30,7 +30,7 @@ export const app = new Vue({
     methods: {
         ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
         ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'}),
-        ...mapActions({loadModelRun: 'modelRun/getResult'}),
+        ...mapActions({loadModelRun: 'modelCalibrate/getResult'}),
         ...mapActions({getADRSchemas: 'getADRSchemas'}),
         ...mapActions({getCurrentProject: 'projects/getCurrentProject'}),
     },

--- a/src/app/static/src/app/index.ts
+++ b/src/app/static/src/app/index.ts
@@ -30,7 +30,8 @@ export const app = new Vue({
     methods: {
         ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
         ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'}),
-        ...mapActions({loadModelRun: 'modelCalibrate/getResult'}),
+        ...mapActions({loadModelRun: 'modelRun/getResult'}),
+        ...mapActions({loadModelCalibrate: 'modelCalibrate/getResult'}),
         ...mapActions({getADRSchemas: 'getADRSchemas'}),
         ...mapActions({getCurrentProject: 'projects/getCurrentProject'}),
     },
@@ -38,6 +39,7 @@ export const app = new Vue({
         this.loadBaseline();
         this.loadSurveyAndProgram();
         this.loadModelRun();
+        this.loadModelCalibrate();
         this.getADRSchemas();
         this.getCurrentProject();
     }

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -83,7 +83,8 @@ const resetState = (store: Store<RootState>) => {
 
         if (state.baseline.ready
             && state.surveyAndProgram.ready
-            && state.modelRun.ready) {
+            && state.modelRun.ready
+            && state.modelCalibrate.ready) {
 
             const type = stripNamespace(mutation.type);
 

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -7,7 +7,6 @@ import {ModelCalibrateMutation} from "./mutations";
 import {ModelRunMutation} from "../modelRun/mutations";
 import {ModelResultResponse, ModelStatusResponse, ModelSubmitResponse} from "../../generated";
 import {freezer} from "../../utils";
-import {ModelRunState} from "../modelRun/modelRun";
 
 export interface ModelCalibrateActions {
     fetchModelCalibrateOptions: (store: ActionContext<ModelCalibrateState, RootState>) => void
@@ -87,9 +86,11 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 }
 
                 commit(ModelCalibrateMutation.Calibrated);
+                commit(ModelCalibrateMutation.Ready);
             }
+        } else {
+            commit(ModelCalibrateMutation.Ready);
         }
-        commit({type: "modelRun/Ready", payload: true}, {root: true});
     }
 };
 

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -86,11 +86,9 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 }
 
                 commit(ModelCalibrateMutation.Calibrated);
-                commit(ModelCalibrateMutation.Ready);
             }
-        } else {
-            commit(ModelCalibrateMutation.Ready);
         }
+        commit(ModelCalibrateMutation.Ready);
     }
 };
 

--- a/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
+++ b/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
@@ -1,12 +1,12 @@
 import {Module} from "vuex";
-import {RootState} from "../../root";
+import {ReadyState, RootState} from "../../root";
 import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {mutations} from "./mutations";
 import {localStorageManager} from "../../localStorageManager";
 import {actions} from "./actions";
 import {VersionInfo, Error, CalibrateStatusResponse} from "../../generated";
 
-export interface ModelCalibrateState {
+export interface ModelCalibrateState extends ReadyState {
     optionsFormMeta: DynamicFormMeta
     options: DynamicFormData
     fetching: boolean
@@ -21,6 +21,7 @@ export interface ModelCalibrateState {
 
 export const initialModelCalibrateState = (): ModelCalibrateState => {
     return {
+        ready: false,
         optionsFormMeta: {controlSections: []},
         options: {},
         fetching: false,
@@ -40,7 +41,7 @@ const existingState = localStorageManager.getState();
 
 export const modelCalibrate: Module<ModelCalibrateState, RootState> = {
     namespaced,
-    state: {...initialModelCalibrateState(), ...existingState && existingState.modelCalibrate},
+    state: {...initialModelCalibrateState(), ...existingState && existingState.modelCalibrate, ready: false},
     mutations,
     actions
 };

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -9,6 +9,7 @@ import {
     Error,
     VersionInfo
 } from "../../generated";
+import {ModelRunState} from "../modelRun/modelRun";
 
 export enum ModelCalibrateMutation {
     FetchingModelCalibrateOptions = "FetchingModelCalibrateOptions",
@@ -20,10 +21,15 @@ export enum ModelCalibrateMutation {
     Calibrated = "Calibrated",
     SetOptionsData = "SetOptionsData",
     SetError = "SetError",
-    PollingForStatusStarted = "PollingForStatusStarted"
+    PollingForStatusStarted = "PollingForStatusStarted",
+    Ready = "Ready"
 }
 
 export const mutations: MutationTree<ModelCalibrateState> = {
+    [ModelCalibrateMutation.Ready](state: ModelCalibrateState) {
+        state.ready = true;
+    },
+
     [ModelCalibrateMutation.FetchingModelCalibrateOptions](state: ModelCalibrateState) {
         state.fetching = true;
     },

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -89,6 +89,7 @@ export const mutations: MutationTree<RootState> = {
         state.surveyAndProgram.ready = true;
         state.baseline.ready = true;
         state.modelRun.ready = true;
+        state.modelCalibrate.ready = true;
     },
 
     [RootMutation.SetProject](state: RootState, action: PayloadWithType<Project>) {
@@ -111,6 +112,7 @@ export const mutations: MutationTree<RootState> = {
         state.surveyAndProgram.ready = true;
         state.baseline.ready = true;
         state.modelRun.ready = true;
+        state.modelCalibrate.ready = true;
 
         router.push("/");
     },
@@ -149,6 +151,7 @@ export const mutations: MutationTree<RootState> = {
         Object.assign(state.modelRun, initialModelRunState());
         state.modelRun.ready = true;
         Object.assign(state.modelCalibrate, initialModelCalibrateState());
+        state.modelCalibrate.ready = true;
         Object.assign(state.modelOutput, initialModelOutputState());
         const sapSelections = state.plottingSelections.sapChoropleth;
         const colourScales = state.plottingSelections.colourScales;

--- a/src/app/static/src/app/store/stepper/getters.ts
+++ b/src/app/static/src/app/store/stepper/getters.ts
@@ -13,7 +13,8 @@ export const getters: StepperGetters & GetterTree<StepperState, RootState> = {
         return !!rootState.adrSchemas &&
             rootState.baseline.ready &&
             rootState.surveyAndProgram.ready &&
-            rootState.modelRun.ready
+            rootState.modelRun.ready &&
+            rootState.modelCalibrate.ready
     },
     complete: (state: StepperState, getters: any, rootState: RootState, rootGetters: any) => {
         return {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -15,7 +15,7 @@ const surveyAndProgramActions = {
     getSurveyAndProgramData: jest.fn()
 };
 
-const modelRunActions = {
+const modelCalibrateActions = {
     getResult: jest.fn()
 };
 
@@ -29,7 +29,7 @@ const projectsActions = {
 
 storeOptions.modules!!.baseline!!.actions = baselineActions;
 storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
-storeOptions.modules!!.modelRun!!.actions = modelRunActions;
+storeOptions.modules!!.modelCalibrate!!.actions = modelCalibrateActions;
 storeOptions.modules!!.projects!!.actions = projectsActions;
 storeOptions.actions = actions
 
@@ -73,7 +73,7 @@ describe("App", () => {
         setTimeout(() => {
             expect(baselineActions.getBaselineData).toHaveBeenCalled();
             expect(surveyAndProgramActions.getSurveyAndProgramData).toHaveBeenCalled();
-            expect(modelRunActions.getResult).toHaveBeenCalled();
+            expect(modelCalibrateActions.getResult).toHaveBeenCalled();
             expect(actions.getADRSchemas).toHaveBeenCalled();
             expect(projectsActions.getCurrentProject).toHaveBeenCalled();
             done();

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -15,20 +15,25 @@ const surveyAndProgramActions = {
     getSurveyAndProgramData: jest.fn()
 };
 
+const modelRunActions = {
+    getResult: jest.fn()
+};
+
 const modelCalibrateActions = {
     getResult: jest.fn()
 };
 
 const actions = {
     getADRSchemas: jest.fn()
-}
+};
 
 const projectsActions = {
     getCurrentProject: jest.fn()
-}
+};
 
 storeOptions.modules!!.baseline!!.actions = baselineActions;
 storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
+storeOptions.modules!!.modelRun!!.actions = modelRunActions;
 storeOptions.modules!!.modelCalibrate!!.actions = modelCalibrateActions;
 storeOptions.modules!!.projects!!.actions = projectsActions;
 storeOptions.actions = actions
@@ -73,6 +78,7 @@ describe("App", () => {
         setTimeout(() => {
             expect(baselineActions.getBaselineData).toHaveBeenCalled();
             expect(surveyAndProgramActions.getSurveyAndProgramData).toHaveBeenCalled();
+            expect(modelRunActions.getResult).toHaveBeenCalled();
             expect(modelCalibrateActions.getResult).toHaveBeenCalled();
             expect(actions.getADRSchemas).toHaveBeenCalled();
             expect(projectsActions.getCurrentProject).toHaveBeenCalled();

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -63,6 +63,7 @@ describe("App", () => {
         localStoreOptions.modules!!.baseline.state.ready = ready;
         localStoreOptions.modules!!.surveyAndProgram.state.ready = ready;
         localStoreOptions.modules!!.modelRun.state.ready = ready;
+        localStoreOptions.modules!!.modelCalibrate.state.ready = ready;
         return new Vuex.Store<RootState>(localStoreOptions);
     };
 

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -51,11 +51,19 @@ describe("model calibrate actions integration", () => {
 
     it("can get calibrate result", async () => {
         const commit = jest.fn();
-        const state = {calibrateId: "123"} as any;
+        const state = {
+            calibrateId: "123",
+            status: {
+                done: true,
+                success: true
+            }
+        } as any;
         await actions.getResult({commit, state, rootState} as any);
 
-        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]["type"]).toBe("SetError");
         expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
+        expect(commit.mock.calls[1][0]["type"]).toBe("modelRun/Ready");
+        expect(commit.mock.calls[1][0]["payload"]).toBe(true);
     });
 });

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -63,7 +63,6 @@ describe("model calibrate actions integration", () => {
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]["type"]).toBe("SetError");
         expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
-        expect(commit.mock.calls[1][0]["type"]).toBe("modelRun/Ready");
-        expect(commit.mock.calls[1][0]["payload"]).toBe(true);
+        expect(commit.mock.calls[1][0]).toBe("Ready");
     });
 });

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -10,7 +10,6 @@ import {
 import {actions} from "../../app/store/modelCalibrate/actions";
 import {ModelCalibrateMutation} from "../../app/store/modelCalibrate/mutations";
 import {freezer} from "../../app/utils";
-import {ModelStatusResponse} from "../../app/generated";
 
 const rootState = mockRootState();
 describe("ModelCalibrate actions", () => {
@@ -197,8 +196,7 @@ describe("ModelCalibrate actions", () => {
             }
         });
         expect(commit.mock.calls[2][0]).toBe("Calibrated");
-        expect(commit.mock.calls[3][0].type).toBe("modelRun/Ready");
-        expect(commit.mock.calls[3][0].payload).toBe(true);
+        expect(commit.mock.calls[3][0]).toBe("Ready");
     });
 
     it("getResult commits error when unsuccessful fetch", async () => {
@@ -221,8 +219,7 @@ describe("ModelCalibrate actions", () => {
             type: "SetError",
             payload: mockError("Test Error")
         });
-        expect(commit.mock.calls[1][0].type).toBe("modelRun/Ready");
-        expect(commit.mock.calls[1][0].payload).toBe(true);
+        expect(commit.mock.calls[1][0]).toBe("Ready");
     });
 
     it("getResult does not fetch when status is not done and success is not true", async () => {
@@ -243,8 +240,7 @@ describe("ModelCalibrate actions", () => {
         expect(mockAxios.history.get.length).toBe(0);
 
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe("modelRun/Ready");
-        expect(commit.mock.calls[0][0].payload).toBe(true);
+        expect(commit.mock.calls[0][0]).toBe("Ready");
     });
 
     it("getResult does not fetch when status is done and success is not true", async () => {
@@ -265,7 +261,6 @@ describe("ModelCalibrate actions", () => {
         expect(mockAxios.history.get.length).toBe(0);
 
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe("modelRun/Ready");
-        expect(commit.mock.calls[0][0].payload).toBe(true);
+        expect(commit.mock.calls[0][0]).toBe("Ready");
     });
 });

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -12,6 +12,13 @@ describe("ModelCalibrate mutations", () => {
         expectAllMutationsDefined(ModelCalibrateMutation, mutations);
     });
 
+    it("sets Ready", () => {
+        const state = mockModelCalibrateState();
+        expect(state.ready).toBe(false);
+        mutations[ModelCalibrateMutation.Ready](state);
+        expect(state.ready).toBe(true);
+    });
+
     it("FetchingModelCalibrateOptions sets fetching to true", () => {
         const state = mockModelCalibrateState();
         mutations[ModelCalibrateMutation.FetchingModelCalibrateOptions](state);

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -45,7 +45,7 @@ describe("Root mutations", () => {
             modelOptions: mockModelOptionsState({valid: true}),
             modelOutput: mockModelOutputState({selectedTab: "Barchart"}),
             modelRun: mockModelRunState({modelRunId: "123", ready: true}),
-            modelCalibrate: mockModelCalibrateState({complete: true}),
+            modelCalibrate: mockModelCalibrateState({complete: true, ready: true}),
             plottingSelections: mockPlottingSelections({barchart: {indicatorId: "Test Indicator"} as BarchartSelections}),
             stepper: mockStepperState({activeStep: 7}),
             load: mockLoadState({loadError: mockError("Test Load Error")}),
@@ -65,6 +65,7 @@ describe("Root mutations", () => {
         expect(state.modelRun).toStrictEqual(modules.includes("modelRun") ? popState.modelRun : mockModelRunState({ready: true}));
 
         //These modules are always reset
+        expect(state.modelCalibrate).toStrictEqual({...initialModelCalibrateState(), ready: true});
         expect(state.modelOutput).toStrictEqual(initialModelOutputState());
         expect(state.plottingSelections).toStrictEqual(initialPlottingSelectionsState());
         expect(state.load).toStrictEqual(initialLoadState());
@@ -224,7 +225,7 @@ describe("Root mutations", () => {
         expect(state.plottingSelections.sapChoropleth.detail).toBe(2);
         expect(state.plottingSelections.colourScales.anc.testIndicator.type).toBe(ScaleType.Custom);
 
-        expect(state.modelCalibrate).toStrictEqual(initialModelCalibrateState())
+        expect(state.modelCalibrate).toStrictEqual({...initialModelCalibrateState(), ready: true})
     });
 
     it("can change language", () => {
@@ -262,6 +263,7 @@ describe("Root mutations", () => {
         expect(state.baseline.ready).toBe(true);
         expect(state.surveyAndProgram.ready).toBe(true);
         expect(state.modelRun.ready).toBe(true);
+        expect(state.modelCalibrate.ready).toBe(true);
 
         expect(mockRouterPush.mock.calls.length).toBe(1);
         expect(mockRouterPush.mock.calls[0][0]).toBe("/");

--- a/src/app/static/src/tests/stepper/getters.test.ts
+++ b/src/app/static/src/tests/stepper/getters.test.ts
@@ -1,5 +1,5 @@
 import {
-    mockBaselineState,
+    mockBaselineState, mockModelCalibrateState,
     mockModelRunState,
     mockRootState,
     mockStepperState,
@@ -35,13 +35,14 @@ describe("stepper getters", () => {
         }
     };
 
-    it("is ready iff baseline, surveyAndProgram, modelRun are ready and adrSchemas present", () => {
+    it("is ready iff baseline, surveyAndProgram, modelRun, modelCalibrate are ready and adrSchemas present", () => {
         const rootState = mockRootState({
             adrSchemas: {baseUrl: "something"} as any,
             baseline: mockBaselineState({ready: true}),
             surveyAndProgram: mockSurveyAndProgramState({ready: true}),
-            modelRun: mockModelRunState({ready: true})
-        })
+            modelRun: mockModelRunState({ready: true}),
+            modelCalibrate: mockModelCalibrateState({ready: true})
+        });
         let ready = getters.ready(state, testGetters, rootState, null as any);
         expect(ready).toBe(true);
 
@@ -55,6 +56,10 @@ describe("stepper getters", () => {
 
         const modelRunNotReady = {...rootState, modelRun: mockModelRunState({ready: false})};
         ready = getters.ready(state, testGetters, modelRunNotReady, null as any);
+        expect(ready).toBe(false);
+
+        const modelCalibrateNotReady = {...rootState, modelCalibrate: mockModelCalibrateState({ready: false})};
+        ready = getters.ready(state, testGetters, modelCalibrateNotReady, null as any);
         expect(ready).toBe(false);
 
         const schemasNotReady = {...rootState, adrSchemas: null};


### PR DESCRIPTION
## Description

This fixes bug where refreshing page (and loading project) would not fetch model outputs. This is because the load action on page load was using the old modelRun/getResult action, which just provides the pre-calibrate 'result'. Now using the post-calibrate result action modelCalibrate/getResult. 

Also needed to update the action itself to check if status indicated any results available (since this will also be called for projects where calibrate has not yet run), and to set Ready on the modelRun state when complete. (We should probably change the logic to use Ready on modelCalibrate state here, but this will require further changes, and may be better done at same time as mrc-2064.

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
