### PR TITLE
mrc-2159 Use model calibrate id for downloads, not initial model fit id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hint 1.15.1
+* fix download of wrong results set
+
 # hint 1.15.0
 * add custom event to open confirmation modal
 

--- a/src/app/static/src/app/components/downloadResults/DownloadResults.vue
+++ b/src/app/static/src/app/components/downloadResults/DownloadResults.vue
@@ -23,11 +23,11 @@
 <script lang="ts">
     import Vue from "vue";
     import {mapStateProps} from "../../utils";
-    import {ModelRunState} from "../../store/modelRun/modelRun";
+    import {ModelCalibrateState} from "../../store/modelCalibrate/modelCalibrate";
     import {DownloadIcon} from "vue-feather-icons";
 
     interface Computed {
-        modelRunId: string,
+        modelCalibrateId: string,
         spectrumUrl: string,
         coarseOutputUrl: string,
         summaryReportUrl: string
@@ -36,17 +36,17 @@
     export default Vue.extend<unknown, unknown, Computed>({
         name: "downloadResults",
         computed: {
-            ...mapStateProps<ModelRunState, keyof Computed>("modelRun", {
-                modelRunId: state => state.modelRunId
+            ...mapStateProps<ModelCalibrateState, keyof Computed>("modelCalibrate", {
+                modelCalibrateId: state => state.calibrateId
             }),
             spectrumUrl: function () {
-                return `/download/spectrum/${this.modelRunId}`
+                return `/download/spectrum/${this.modelCalibrateId}`
             },
             coarseOutputUrl: function () {
-                return `/download/coarse-output/${this.modelRunId}`
+                return `/download/coarse-output/${this.modelCalibrateId}`
             },
             summaryReportUrl: function () {
-                return `/download/summary/${this.modelRunId}`
+                return `/download/summary/${this.modelCalibrateId}`
             }
         },
         components: {

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,3 +1,3 @@
 
-export const currentHintVersion = "1.15.0";
+export const currentHintVersion = "1.15.1";
 

--- a/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
@@ -1,6 +1,6 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
-import {mockModelRunState} from "../../mocks";
+import {mockModelCalibrateState} from "../../mocks";
 import DownloadResults from "../../../app/components/downloadResults/DownloadResults.vue";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {emptyState} from "../../../app/root";
@@ -14,9 +14,9 @@ describe("Download Results component", () => {
         const store = new Vuex.Store({
             state: emptyState(),
             modules: {
-                modelRun: {
+                modelCalibrate: {
                     namespaced: true,
-                    state: mockModelRunState({modelRunId: "testId"})
+                    state: mockModelCalibrateState({calibrateId: "testId"})
                 }
             }
         });


### PR DESCRIPTION
## Description

As reported by Jeff:
It appears that the download buttons on the last page, are not downloading the 'calibrated' version of results.

The outputs on the 'Results' page (calibrated results), do not match the results in the download package, which looks to be the 'uncalibrated' results.

The total PLHIV (all ages, Sep 2023) on the results page is 1,010,000:

If I go to following steps:

'Download results' ->
'Export' button ->
Unzip and open the file 'indicators.csv'
Filter that sheet to 'MWI', 'Y000_999', indicator = "plhiv", "CY2020Q3"

The total in the spreadsheet is 1,070,458.23. Those numbers should match**

This is because the download component was using the modelRunId (used to generate the initial fit) rather than the model calibrateId.
NB for testing - plhiv is being rounded to nearest 100


## Type of version change
_Delete as appropriate_
Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
