### PR TITLE
mrc-2184 display project name as default when rename is triggered with existin…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+#hint 1.16.0
+
+* show project name as default input value when a user clicks rename and copy project link
+
 # hint 1.15.3
 
 * Bug fix: Calibration error not returned to user

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -330,6 +330,11 @@
                 versionNumber: number
             ) {
                 event.preventDefault();
+                this.projects.map(project => {
+                    if (project.id === projectId) {
+                        this.newProjectName = project.name
+                    }
+                })
                 this.versionToPromote = {projectId, versionId};
                 this.selectedVersionNumber = `v${versionNumber}`;
             },

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -293,6 +293,11 @@
             },
             renameProject(event: Event, projectId: number) {
                 event.preventDefault();
+                this.projects.map(project => {
+                    if (project.id === projectId) {
+                        this.renamedProjectName = project.name
+                    }
+                })
                 this.projectToRename = projectId;
             },
             cancelRename() {

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -293,7 +293,7 @@
             },
             renameProject(event: Event, projectId: number) {
                 event.preventDefault();
-                this.projects.map(project => {
+                this.projects.filter(project => {
                     if (project.id === projectId) {
                         this.renamedProjectName = project.name
                     }
@@ -330,7 +330,7 @@
                 versionNumber: number
             ) {
                 event.preventDefault();
-                this.projects.map(project => {
+                this.projects.filter(project => {
                     if (project.id === projectId) {
                         this.newProjectName = project.name
                     }

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -146,6 +146,7 @@
             <input type="text"
                    class="form-control"
                    v-translate:placeholder="'projectName'"
+                   @keyup.enter="confirmPromotion(newProjectName)"
                    v-model="newProjectName"/>
             <template v-slot:footer>
                 <button type="button"
@@ -164,6 +165,7 @@
             <input type="text"
                    class="form-control"
                    v-translate:placeholder="'projectName'"
+                   @keyup.enter="confirmRename(renamedProjectName)"
                    v-model="renamedProjectName">
             <template v-slot:footer>
                 <button type="button"

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,3 +1,3 @@
 
-export const currentHintVersion = "1.15.3";
+export const currentHintVersion = "1.16.0";
 

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -302,7 +302,7 @@ describe("Project history component", () => {
         }
     };
 
-    it("shows modal when rename project link is clicked kand removes it when cancel is clicked", async () => {
+    it("does show project name as default value when a user clicks rename link", async () => {
         if (switches.renameProject) {
             const wrapper = getWrapper(testProjects);
             const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
@@ -313,6 +313,29 @@ describe("Project history component", () => {
             const proj1 = modal.find("input")
             const projectName1 = proj1.element as HTMLInputElement
             expect(projectName1.value).toBe("proj1")
+        }
+    });
+
+    it("does show project name as default value when a user clicks copy project", async () => {
+        if (switches.promoteProject && !switches.renameProject) {
+            const wrapper = getWrapper();
+            const copyLink = wrapper.find("#p-1").findAll(".project-cell");
+
+
+            copyLink.at(6).find("button").trigger("click")
+            await Vue.nextTick();
+            const modal = wrapper.findAll(".modal").at(1);
+            const proj1 = modal.find("input")
+            const projectName1 = proj1.element as HTMLInputElement
+            expect(projectName1.value).toBe("proj1")
+
+
+            copyLink.at(5).find("button").trigger("click")
+            await Vue.nextTick();
+            const modalVersion = wrapper.findAll(".modal").at(1);
+            const projVersion = modalVersion.find("input")
+            const projectNameVersion = projVersion.element as HTMLInputElement
+            expect(projectNameVersion.value).toBe("proj1")
         }
     });
 

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -464,7 +464,7 @@ describe("Project history component", () => {
     });
 
     it("can use carriage return to invokes promoteVersion action when confirm copy", async () => {
-        if (switches.promoteProject && !switches.renameProject) {
+        if (!switches.renameProject) {
             const wrapper = getWrapper(testProjects);
             const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
             copyLink.trigger("click");
@@ -475,7 +475,7 @@ describe("Project history component", () => {
             const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
             input.setValue("newProject");
             expect(copyBtn.attributes("disabled")).toBe(undefined);
-            await copyBtn.trigger("keyup.enter");
+            await input.trigger("keyup.enter");
 
             expect(mockPromoteVersion.mock.calls.length).toBe(1);
             expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
@@ -561,7 +561,6 @@ describe("Project history component", () => {
     });
 
     it("can use carriage return to invoke renameProject action", async () => {
-        if (switches.renameProject) {
             const wrapper = getWrapper(testProjects);
             const vm = wrapper.vm as any
             const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
@@ -583,8 +582,6 @@ describe("Project history component", () => {
                 });
             expect(vm.projectToRename).toBe(null);
             expect(vm.renamedProjectName).toBe("");
-
-        }
     });
 
     it("cannot invoke confirmRename if no project is selected", async () => {

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -464,29 +464,27 @@ describe("Project history component", () => {
     });
 
     it("can use carriage return to invokes promoteVersion action when confirm copy", async () => {
-        if (!switches.renameProject) {
-            const wrapper = getWrapper(testProjects);
-            const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
-            copyLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper(testProjects);
+        const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(6).find("button");
+        copyLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(1);
-            const input = modal.find("input");
-            const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
-            input.setValue("newProject");
-            expect(copyBtn.attributes("disabled")).toBe(undefined);
-            await input.trigger("keyup.enter");
+        const modal = wrapper.findAll(".modal").at(1);
+        const input = modal.find("input");
+        const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
+        input.setValue("newProject");
+        expect(copyBtn.attributes("disabled")).toBe(undefined);
+        await input.trigger("keyup.enter")
 
-            expect(mockPromoteVersion.mock.calls.length).toBe(1);
-            expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
-                {
-                    "name": "newProject",
-                    "version": {
-                        "projectId": 1,
-                        "versionId": "s11",
-                    }
-                });
-        }
+        expect(mockPromoteVersion.mock.calls.length).toBe(1);
+        expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
+            {
+                "name": "newProject",
+                "version": {
+                    "projectId": 1,
+                    "versionId": "s11",
+                }
+            });
     });
 
     it("cannot invoke promoteVersion action when input value is empty", async () => {

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -463,6 +463,32 @@ describe("Project history component", () => {
         }
     });
 
+    it("can use carriage return to invokes promoteVersion action when confirm copy", async () => {
+        if (switches.promoteProject && !switches.renameProject) {
+            const wrapper = getWrapper(testProjects);
+            const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
+            copyLink.trigger("click");
+            await Vue.nextTick();
+
+            const modal = wrapper.findAll(".modal").at(1);
+            const input = modal.find("input");
+            const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
+            input.setValue("newProject");
+            expect(copyBtn.attributes("disabled")).toBe(undefined);
+            await copyBtn.trigger("keyup.enter");
+
+            expect(mockPromoteVersion.mock.calls.length).toBe(1);
+            expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
+                {
+                    "name": "newProject",
+                    "version": {
+                        "projectId": 1,
+                        "versionId": "s11",
+                    }
+                });
+        }
+    });
+
     it("cannot invoke promoteVersion action when input value is empty", async () => {
         if (switches.promoteProject) {
             const wrapper = getWrapper(testProjects);
@@ -531,6 +557,33 @@ describe("Project history component", () => {
             await Vue.nextTick();
 
             expect(mockRenameProject.mock.calls.length).toBe(0);
+        }
+    });
+
+    it("can use carriage return to invoke renameProject action", async () => {
+        if (switches.renameProject) {
+            const wrapper = getWrapper(testProjects);
+            const vm = wrapper.vm as any
+            const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
+            renameLink.trigger("click");
+            await Vue.nextTick();
+
+            const modal = wrapper.findAll(".modal").at(2);
+            const input = modal.find("input");
+            const renameBtn = modal.find(".modal-footer").findAll("button").at(0);
+            input.setValue("renamedProject");
+            expect(renameBtn.attributes("disabled")).toBe(undefined);
+            await input.trigger("keyup.enter")
+
+            expect(mockRenameProject.mock.calls.length).toBe(1);
+            expect(mockRenameProject.mock.calls[0][1]).toStrictEqual(
+                {
+                    "name": "renamedProject",
+                    "projectId": 1
+                });
+            expect(vm.projectToRename).toBe(null);
+            expect(vm.renamedProjectName).toBe("");
+
         }
     });
 

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -302,6 +302,20 @@ describe("Project history component", () => {
         }
     };
 
+    it("shows modal when rename project link is clicked kand removes it when cancel is clicked", async () => {
+        if (switches.renameProject) {
+            const wrapper = getWrapper(testProjects);
+            const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
+            renameLink.trigger("click");
+            await Vue.nextTick();
+
+            const modal = wrapper.findAll(".modal").at(2);
+            const proj1 = modal.find("input")
+            const projectName1 = proj1.element as HTMLInputElement
+            expect(projectName1.value).toBe("proj1")
+        }
+    });
+
     it("shows modal when rename project link is clicked and removes it when cancel is clicked", async () => {
         if (switches.renameProject) {
             const wrapper = getWrapper();


### PR DESCRIPTION
…g project name

## Description

This PR shows project name as default value when a user clicks rename link and copy project.
Adding focus on input upon modal opening has it's own maintenance ticket here https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2219

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
