### PR TITLE
mrc-2207 Remove obsolete feature switches

### DIFF
--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -29,42 +29,41 @@
                         ></chevron-down-icon>
                     </button>
                 </div>
-                <div class="col-md-3 project-cell">
+                <div class="col-md-3 project-cell name-cell">
                     <a href="#"
                     @click="loadVersion($event, p.id, p.versions[0].id)">
                     {{ p.name }}
                     </a>
                     <small v-if="p.sharedBy" class="text-muted d-flex" >{{getTranslatedValue("sharedBy")}}: {{p.sharedBy}}</small>
                 </div>
-                <div class="col-md-1 project-cell">
+                <div class="col-md-1 project-cell version-count-cell">
                     <small class="text-muted">{{ versionCountLabel(p) }}</small>
                 </div>
-                <div class="col-md-2 project-cell">
+                <div class="col-md-2 project-cell updated-cell">
                     {{ format(p.versions[0].updated) }}
                 </div>
-                <div class="col-md-1 project-cell"
+                <div class="col-md-1 project-cell load-cell"
                 v-tooltip ="getTranslatedValue('load')">
                     <button class=" btn btn-sm btn-red-icons"
                     @click="loadVersion($event, p.id, p.versions[0].id)">
                     <refresh-cw-icon size="20"></refresh-cw-icon>
                     </button>
                 </div>
-                 <div class="col-md-1 project-cell"
-                v-tooltip ="getTranslatedValue('renameProject')"
-                    v-if="renameProjectIsEnabled">
+                 <div class="col-md-1 project-cell rename-cell"
+                v-tooltip ="getTranslatedValue('renameProject')">
                     <button class="btn btn-sm btn-red-icons"
                             @click="renameProject($event, p.id)">
                         <edit-icon size="20"></edit-icon>
                     </button>
                 </div>
-                <div class="col-md-1 project-cell" 
+                <div class="col-md-1 project-cell delete-cell"
                 v-tooltip ="getTranslatedValue('delete')">
                     <button class=" btn btn-sm btn-red-icons"
                             @click="deleteProject($event, p.id)">
                         <trash-2-icon size="20"></trash-2-icon>
                     </button>
                 </div>
-                <div class="col-md-1 project-cell" v-if="promoteProjectIsEnabled"
+                <div class="col-md-1 project-cell copy-cell"
                      v-tooltip="getTranslatedValue('copyLatestToNewProject')">
                     <button class=" btn btn-sm btn-red-icons"
                             @click="promoteVersion(
@@ -76,7 +75,7 @@
                     </button>
                 </div>
 
-                <div class="col-md-1 project-cell" v-if="shareProjectIsEnabled">
+                <div class="col-md-1 project-cell share-cell">
                     <share-project :project="p"></share-project>
                 </div>
             </div>
@@ -86,31 +85,29 @@
                      :key="v.id"
                      class="row font-italic bg-light py-2">
                     <div class="col-md-4 version-cell"></div>
-                    <div class="col-md-1 version-cell">
+                    <div class="col-md-1 version-cell version-label-cell">
                         {{ versionLabel(v) }}
                     </div>
-                    <div class="col-md-2 version-cell">
+                    <div class="col-md-2 version-cell version-updated-cell">
                         {{ format(v.updated) }}
                     </div>
-                    <div class="col-md-1 version-cell" 
+                    <div class="col-md-1 version-cell load-cell"
                     v-tooltip ="getTranslatedValue('load')">
                         <button class=" btn btn-sm btn-red-icons"
                                 @click="loadVersion($event, p.id, v.id)">
                             <refresh-cw-icon size="20"></refresh-cw-icon>
                         </button>
                     </div>
-                    <div class="col-md-1 version-cell"
-                    v-if="renameProjectIsEnabled">
+                    <div class="col-md-1 version-cell">
                     </div>
-                    <div class="col-md-1 version-cell"
+                    <div class="col-md-1 version-cell delete-cell"
                     v-tooltip ="getTranslatedValue('delete')">
                         <button class=" btn btn-sm btn-red-icons"
                                 @click="deleteVersion($event, p.id, v.id)">
                             <trash-2-icon size="20"></trash-2-icon>
                         </button>
                     </div>
-                    <div class="col-md-1 version-cell"
-                         v-if="promoteProjectIsEnabled"
+                    <div class="col-md-1 version-cell copy-cell"
                          v-tooltip="getTranslatedValue('copyToNewProject')">
                         <button class=" btn btn-sm btn-red-icons"
                                 @click="promoteVersion(
@@ -194,7 +191,6 @@
     import {RootState} from "../../root";
     import ProjectsMixin from "./ProjectsMixin";
     import ShareProject from "./ShareProject.vue";
-    import {switches} from "../../featureSwitches";
     import {VTooltip} from 'v-tooltip';
     import {projects} from "../../store/projects/projects";
 
@@ -208,9 +204,6 @@
         versionToPromote: VersionIds | null;
         newProjectName: string;
         selectedVersionNumber: string;
-        shareProjectIsEnabled: boolean;
-        promoteProjectIsEnabled: boolean;
-        renameProjectIsEnabled: boolean;
     }
 
     interface Computed {
@@ -258,9 +251,6 @@
                 versionToPromote: null,
                 newProjectName: "",
                 selectedVersionNumber: "",
-                shareProjectIsEnabled: switches.shareProject,
-                promoteProjectIsEnabled: switches.promoteProject,
-                renameProjectIsEnabled: switches.renameProject,
                 projectToRename: null,
                 renamedProjectName: ''
             };

--- a/src/app/static/src/app/featureSwitches.ts
+++ b/src/app/static/src/app/featureSwitches.ts
@@ -1,11 +1,5 @@
 const urlParams = new URLSearchParams(window.location.search);
-const shareProject = !urlParams.get('shareProject');
-const promoteProject = !urlParams.get('promoteProject');
-const renameProject = !urlParams.get('renameProject');
 const modelBugReport = !urlParams.get('modelBugReport');
 export const switches = {
-    shareProject: shareProject,
-    promoteProject: promoteProject,
-    renameProject: renameProject,
     modelBugReport: modelBugReport
-}
+};

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -8,7 +8,6 @@ import {emptyState, RootState} from "../../../app/root";
 import {Project} from "../../../app/types";
 import {mockProjectsState} from "../../mocks";
 import {expectTranslated} from "../../testHelpers";
-import {switches} from "../../../app/featureSwitches";
 import ShareProject from "../../../app/components/projects/ShareProject.vue";
 import {Language} from "../../../app/store/translations/locales";
 
@@ -116,15 +115,17 @@ describe("Project history component", () => {
         expect(v.at(1).find("a").text()).toContain(name);
         expect(v.at(2).text()).toBe(versionsCount === 1 ? "1 version" : `${versionsCount} versions`);
         expect(v.at(3).text()).toBe(formatDateTime(updatedIsoDate));
+        expect(v.at(4).classes()).toContain("load-cell");
+        expect(v.at(5).classes()).toContain("rename-cell");
+        expect(v.at(6).classes()).toContain("delete-cell");
+        expect(v.at(7).classes()).toContain("copy-cell");
+        expect(v.at(8).classes()).toContain("share-cell");
 
-        if (switches.shareProject) {
-            expect(wrapper.findAll(ShareProject).length).toBeGreaterThan(0);
-        } else {
-            expect(wrapper.findAll(ShareProject).length).toBe(0);
-        }
+        expect(wrapper.findAll(ShareProject).length).toBeGreaterThan(0);
+
         const versions = wrapper.find(`#versions-${id}`);
-            expect(versions.classes()).toContain("collapse");
-            expect(versions.attributes("style")).toBe("display: none;");
+        expect(versions.classes()).toContain("collapse");
+        expect(versions.attributes("style")).toBe("display: none;");
     };
 
     const testRendersVersion = (row: Wrapper<any>, id: string, updatedIsoDate: string, versionNumber: number,
@@ -134,6 +135,10 @@ describe("Project history component", () => {
         expect(cells.at(0).text()).toBe("");
         expect(cells.at(1).text()).toBe(`v${versionNumber}`);
         expect(cells.at(2).text()).toBe(formatDateTime(updatedIsoDate));
+        expect(cells.at(3).classes()).toContain("load-cell");
+        expect(cells.at(4).isEmpty()).toBe(true);
+        expect(cells.at(5).classes()).toContain("delete-cell");
+        expect(cells.at(6).classes()).toContain("copy-cell");
     };
 
     it("renders as expected ", () => {
@@ -210,10 +215,9 @@ describe("Project history component", () => {
     });
 
     it("shows modal when click delete project link", async () => {
-        if (!switches.renameProject) {
         const wrapper = getWrapper();
         const store = wrapper.vm.$store;
-        const deleteLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
+        const deleteLink = wrapper.find("#p-1").find(".project-cell.delete-cell").find("button");
         deleteLink.trigger("click");
         await Vue.nextTick();
 
@@ -223,14 +227,12 @@ describe("Project history component", () => {
         const buttons = modal.find(".modal-footer").findAll("button");
         expectTranslated(buttons.at(0), "OK", "OK", store);
         expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
-        }
     });
 
     it("shows modal when click delete version link", async () => {
-        if (!switches.renameProject) {
         const wrapper = getWrapper();
         const store = wrapper.vm.$store;
-        const deleteLink = wrapper.find("#v-s11").findAll(".version-cell").at(4).find("button");
+        const deleteLink = wrapper.find("#v-s11").find(".version-cell.delete-cell").find("button");
         deleteLink.trigger("click");
         await Vue.nextTick();
 
@@ -240,13 +242,11 @@ describe("Project history component", () => {
         const buttons = modal.find(".modal-footer").findAll("button");
         expectTranslated(buttons.at(0), "OK", "OK", store);
         expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
-        }
     });
 
     it("invokes deleteProject action when confirm delete", async () => {
-        if (!switches.renameProject) {
         const wrapper = getWrapper(testProjects);
-        const deleteLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
+        const deleteLink = wrapper.find("#p-1").find(".project-cell.delete-cell").find("button");
         deleteLink.trigger("click");
         await Vue.nextTick();
 
@@ -256,13 +256,11 @@ describe("Project history component", () => {
 
         expect(mockDeleteProject.mock.calls.length).toBe(1);
         expect(mockDeleteProject.mock.calls[0][1]).toBe(1);
-        }
     });
 
     it("invokes deleteVersion action when confirm delete", async () => {
-        if (!switches.renameProject) {
         const wrapper = getWrapper(testProjects);
-        const deleteLink = wrapper.find("#v-s11").findAll(".version-cell").at(4).find("button");
+        const deleteLink = wrapper.find("#v-s11").find(".version-cell.delete-cell").find("button");
         deleteLink.trigger("click");
         await Vue.nextTick();
 
@@ -272,13 +270,11 @@ describe("Project history component", () => {
 
         expect(mockDeleteVersion.mock.calls.length).toBe(1);
         expect(mockDeleteVersion.mock.calls[0][1]).toStrictEqual({projectId: 1, versionId: "s11"});
-        }
     });
 
-    it("hides modal and does not invoke action when click cancel", async () => {
-
+    it("hides delete modal and does not invoke action when click cancel", async () => {
         const wrapper = getWrapper(testProjects);
-        const deleteLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
+        const deleteLink = wrapper.find("#v-s11").find(".version-cell.delete-cell").find("button");
         deleteLink.trigger("click");
         await Vue.nextTick();
 
@@ -292,40 +288,36 @@ describe("Project history component", () => {
     }); 
 
     const testLoadVersionLink = async function (elementId: string, projectId: number, versionId: string) {
-        if (!switches.renameProject) {
         const wrapper = getWrapper(testProjects);
         const versionLink = wrapper.find("#versions-1").find("button");
         versionLink.trigger("click");
         await Vue.nextTick();
         expect(mockLoad.mock.calls.length).toBe(1);
         expect(mockLoad.mock.calls[0][1]).toStrictEqual({projectId: 1, versionId: "s11"});
-        }
     };
 
     it("shows modal when rename project link is clicked and removes it when cancel is clicked", async () => {
-        if (switches.renameProject) {
-            const wrapper = getWrapper();
-            const store = wrapper.vm.$store;
-            const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
-            renameLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper();
+        const store = wrapper.vm.$store;
+        const renameLink = wrapper.find("#p-1").find(".project-cell.rename-cell").find("button");
+        renameLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(2);
-            expect(modal.classes()).toContain("show");
-            expectTranslated(modal.find(".modal-body h4"), "Please enter a new name for the project",
-                "Veuillez entrer un nouveau nom pour le projet", store);
+        const modal = wrapper.findAll(".modal").at(2);
+        expect(modal.classes()).toContain("show");
+        expectTranslated(modal.find(".modal-body h4"), "Please enter a new name for the project",
+            "Veuillez entrer un nouveau nom pour le projet", store);
 
-            const input = modal.find("input")
-            expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
-            const buttons = modal.find(".modal-footer").findAll("button");
-            expectTranslated(buttons.at(0), "Rename project", "Renommer le projet", store);
-            expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        const input = modal.find("input")
+        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        const buttons = modal.find(".modal-footer").findAll("button");
+        expectTranslated(buttons.at(0), "Rename project", "Renommer le projet", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
 
-            const cancelButton = buttons.at(1);
-            cancelButton.trigger("click");
-            await Vue.nextTick();
-            expect(modal.classes()).not.toContain("show");
-        }
+        const cancelButton = buttons.at(1);
+        cancelButton.trigger("click");
+        await Vue.nextTick();
+        expect(modal.classes()).not.toContain("show");
     });
 
     it("methods for rename and cancel rename work regardless of feature switch", async () => {
@@ -344,169 +336,157 @@ describe("Project history component", () => {
     });
 
     it("shows modal when copy project link is clicked and removes it when cancel is clicked", async () => {
-        if (switches.promoteProject && !switches.renameProject) {
-            const wrapper = getWrapper();
-            const store = wrapper.vm.$store;
-            const copyLink = wrapper.find("#p-1").findAll(".project-cell").at(6).find("button");
-            copyLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper();
+        const store = wrapper.vm.$store;
+        const copyLink = wrapper.find("#p-1").find(".project-cell.copy-cell").find("button");
+        copyLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(1);
-            expect(modal.classes()).toContain("show");
-            expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
-                "Copie de la version v1 dans un nouveau projet", store);
-            expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
-                "Veuillez entrer un nom pour le nouveau projet", store);
+        const modal = wrapper.findAll(".modal").at(1);
+        expect(modal.classes()).toContain("show");
+        expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
+            "Copie de la version v1 dans un nouveau projet", store);
+        expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
+            "Veuillez entrer un nom pour le nouveau projet", store);
 
-            const input = modal.find("input")
-            expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
-            const buttons = modal.find(".modal-footer").findAll("button");
-            expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
-            expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        const input = modal.find("input")
+        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        const buttons = modal.find(".modal-footer").findAll("button");
+        expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
 
-            const cancelButton = buttons.at(1);
-            cancelButton.trigger("click");
-            await Vue.nextTick();
-            expect(modal.classes()).not.toContain("show");
-        }
+        const cancelButton = buttons.at(1);
+        cancelButton.trigger("click");
+        await Vue.nextTick();
+        expect(modal.classes()).not.toContain("show");
+
     });
 
     it("shows modal when copy version link is clicked and removes it when cancel is clicked", async () => {
-        if (switches.promoteProject && !switches.renameProject) {
-            const wrapper = getWrapper();
-            const store = wrapper.vm.$store;
-            const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
-            copyLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper();
+        const store = wrapper.vm.$store;
+        const copyLink = wrapper.find("#v-s11").find(".version-cell.copy-cell").find("button");
+        copyLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(1);
-            expect(modal.classes()).toContain("show");
-            expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
-                "Copie de la version v1 dans un nouveau projet", store);
-            expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
-                "Veuillez entrer un nom pour le nouveau projet", store);
-            const input = modal.find("input");
-            expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
-            const buttons = modal.find(".modal-footer").findAll("button");
-            expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
-            expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        const modal = wrapper.findAll(".modal").at(1);
+        expect(modal.classes()).toContain("show");
+        expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
+            "Copie de la version v1 dans un nouveau projet", store);
+        expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
+            "Veuillez entrer un nom pour le nouveau projet", store);
+        const input = modal.find("input");
+        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        const buttons = modal.find(".modal-footer").findAll("button");
+        expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
 
-            const cancelButton = buttons.at(1);
-            cancelButton.trigger("click");
-            await Vue.nextTick();
-            expect(modal.classes()).not.toContain("show");
-        }
+        const cancelButton = buttons.at(1);
+        cancelButton.trigger("click");
+        await Vue.nextTick();
+        expect(modal.classes()).not.toContain("show");
     });
 
     it("invokes promoteVersion action when confirm copy", async () => {
-        if (switches.promoteProject && !switches.renameProject) {
-            const wrapper = getWrapper(testProjects);
-            const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
-            copyLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper(testProjects);
+        const copyLink = wrapper.find("#v-s11").find(".version-cell.copy-cell").find("button");
+        copyLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(1);
-            const input = modal.find("input");
-            const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
-            input.setValue("newProject");
-            expect(copyBtn.attributes("disabled")).toBe(undefined);
-            copyBtn.trigger("click");
+        const modal = wrapper.findAll(".modal").at(1);
+        const input = modal.find("input");
+        const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
+        input.setValue("newProject");
+        expect(copyBtn.attributes("disabled")).toBe(undefined);
+        copyBtn.trigger("click");
 
-            await Vue.nextTick();
+        await Vue.nextTick();
 
-            expect(mockPromoteVersion.mock.calls.length).toBe(1);
-            expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
-                {
-                    "name": "newProject",
-                    "version": {
-                        "projectId": 1,
-                        "versionId": "s11",
-                    }
-                });
-        }
+        expect(mockPromoteVersion.mock.calls.length).toBe(1);
+        expect(mockPromoteVersion.mock.calls[0][1]).toStrictEqual(
+            {
+                "name": "newProject",
+                "version": {
+                    "projectId": 1,
+                    "versionId": "s11",
+                }
+            });
     });
 
     it("cannot invoke promoteVersion action when input value is empty", async () => {
-        if (switches.promoteProject) {
-            const wrapper = getWrapper(testProjects);
-            const copyLink = wrapper.find("#v-s11").findAll(".version-cell").at(5).find("button");
-            copyLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper(testProjects);
+        const copyLink = wrapper.find("#v-s11").find(".version-cell.copy-cell").find("button");
+        copyLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(1);
-            const input = modal.find("input");
-            const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
-            input.setValue("");
-            expect(copyBtn.attributes("disabled")).toBe("disabled");
-            copyBtn.trigger("click");
+        const modal = wrapper.findAll(".modal").at(1);
+        const input = modal.find("input");
+        const copyBtn = modal.find(".modal-footer").findAll("button").at(0);
+        input.setValue("");
+        expect(copyBtn.attributes("disabled")).toBe("disabled");
+        copyBtn.trigger("click");
 
-            await Vue.nextTick();
+        await Vue.nextTick();
 
-            expect(mockPromoteVersion.mock.calls.length).toBe(0);
-        }
+        expect(mockPromoteVersion.mock.calls.length).toBe(0);
     });
 
     it("invokes renameProject action when confirm rename", async () => {
-        if (switches.renameProject) {
-            const wrapper = getWrapper(testProjects);
-            const vm = wrapper.vm as any
-            const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(5).find("button");
-            renameLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper(testProjects);
+        const vm = wrapper.vm as any
+        const renameLink = wrapper.find("#p-1").find(".project-cell.rename-cell").find("button");
+        renameLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(2);
-            const input = modal.find("input");
-            const renameBtn = modal.find(".modal-footer").findAll("button").at(0);
-            input.setValue("renamedProject");
-            expect(renameBtn.attributes("disabled")).toBe(undefined);
-            expect(vm.projectToRename).toBe(1);
-            expect(vm.renamedProjectName).toBe("renamedProject");
-            renameBtn.trigger("click");
+        const modal = wrapper.findAll(".modal").at(2);
+        const input = modal.find("input");
+        const renameBtn = modal.find(".modal-footer").findAll("button").at(0);
+        input.setValue("renamedProject");
+        expect(renameBtn.attributes("disabled")).toBe(undefined);
+        expect(vm.projectToRename).toBe(1);
+        expect(vm.renamedProjectName).toBe("renamedProject");
+        renameBtn.trigger("click");
 
-            await Vue.nextTick();
+        await Vue.nextTick();
 
-            expect(mockRenameProject.mock.calls.length).toBe(1);
-            expect(mockRenameProject.mock.calls[0][1]).toStrictEqual(
-                {
-                    "name": "renamedProject",
-                    "projectId": 1
-                });
-            expect(vm.projectToRename).toBe(null);
-            expect(vm.renamedProjectName).toBe("");
-            
-        }
+        expect(mockRenameProject.mock.calls.length).toBe(1);
+        expect(mockRenameProject.mock.calls[0][1]).toStrictEqual(
+            {
+                "name": "renamedProject",
+                "projectId": 1
+            });
+        expect(vm.projectToRename).toBe(null);
+        expect(vm.renamedProjectName).toBe("");
     });
 
     it("cannot invoke renameProject action when input value is empty", async () => {
-        if (switches.renameProject) {
-            const wrapper = getWrapper(testProjects);
-            const renameLink = wrapper.find("#p-1").findAll(".project-cell").at(4).find("button");
-            renameLink.trigger("click");
-            await Vue.nextTick();
+        const wrapper = getWrapper(testProjects);
+        const renameLink = wrapper.find("#p-1").find(".project-cell.rename-cell").find("button");
+        renameLink.trigger("click");
+        await Vue.nextTick();
 
-            const modal = wrapper.findAll(".modal").at(2);
-            const input = modal.find("input");
-            const renameBtn = modal.find(".modal-footer").findAll("button").at(0);
-            input.setValue("");
-            expect(renameBtn.attributes("disabled")).toBe("disabled");
-            renameBtn.trigger("click");
+        const modal = wrapper.findAll(".modal").at(2);
+        const input = modal.find("input");
+        const renameBtn = modal.find(".modal-footer").findAll("button").at(0);
+        input.setValue("");
+        expect(renameBtn.attributes("disabled")).toBe("disabled");
+        renameBtn.trigger("click");
 
-            await Vue.nextTick();
+        await Vue.nextTick();
 
-            expect(mockRenameProject.mock.calls.length).toBe(0);
-        }
+        expect(mockRenameProject.mock.calls.length).toBe(0);
     });
 
     it("cannot invoke confirmRename if no project is selected", async () => {
-            const wrapper = getWrapper(testProjects);
-            wrapper.setData({ projectToRename: null });
-            wrapper.setData({ renamedProjectName: "renamedProject" })
-            const vm = wrapper.vm as any
-            vm.confirmRename("renamedProject");
-            await Vue.nextTick();
-            expect(mockRenameProject.mock.calls.length).toBe(0);
-            expect(vm.projectToRename).toBe(null);
-            expect(vm.renamedProjectName).toBe("renamedProject");
+        const wrapper = getWrapper(testProjects);
+        wrapper.setData({ projectToRename: null });
+        wrapper.setData({ renamedProjectName: "renamedProject" });
+        const vm = wrapper.vm as any
+        vm.confirmRename("renamedProject");
+        await Vue.nextTick();
+        expect(mockRenameProject.mock.calls.length).toBe(0);
+        expect(vm.projectToRename).toBe(null);
+        expect(vm.renamedProjectName).toBe("renamedProject");
     });
 
     it('can render shared by email when project is shared', () => {


### PR DESCRIPTION
## Description

Removes obsolete feature switches for rename, copy and delete project, and all references to them in code and test.

A lot of bother around dealing with these switches in the tests involved them making assumptions about which column index in projectHistory component at which to find elements, which changed depending on switch values. To make these tests more readable and less brittle, I have added meaningful classes to the elements in question and selected on those in the tests. 

I've included checking that these are at the expected indexes in the render test only, so we're still checking these, but only in one place. 

Not updating version as no behaviour changes.

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
