### PR TITLE
mrc-2234 Fix Codecov paths

### DIFF
--- a/buildkite/test-front-end.dockerfile
+++ b/buildkite/test-front-end.dockerfile
@@ -7,5 +7,5 @@ ENV CODECOV_TOKEN=$CODECOV_TOKEN
 CMD npm run lint --prefix=app/static -- --quiet && \
     npm test --prefix=app/static && \
     npm run integration-test-docker --prefix=app/static && \
-    codecov -f app/static/coverage/*.json && \
-    codecov -f app/static/coverage/integration/*.json
+    codecov -p .. -f app/static/coverage/*.json && \
+    codecov -p .. -f app/static/coverage/integration/*.json

--- a/buildkite/test.dockerfile
+++ b/buildkite/test.dockerfile
@@ -8,4 +8,4 @@ ENV CODECOV_TOKEN=$CODECOV_TOKEN
 
 # Test app
 CMD ./gradlew :app:detektMain -PexcludeADR=true :app:test :userCLI:test :app:jacocoTestReport && \
-    codecov -f app/coverage/test/*.xml
+    codecov -p .. -f app/coverage/test/*.xml


### PR DESCRIPTION
## Description

Trying to view the coverage for files in PRs prior to this one doesn't work e.g. from the "Files" tab on [this page](https://app.codecov.io/gh/mrc-ide/hint/compare/474)

Telling Codecov that the project root is `src` rather than the current folder fixes this - see "Files" on [this page](https://app.codecov.io/gh/mrc-ide/hint/compare/475)

This could also be fixed by modifying `codecov.yml`, but doing it in the buildkite scripts seems more sensible as it's a problem specific to that build environment.

This isn't an issue in OW because the codecov script is run within a git checkout, so it automatically detects the root folder. And it isn't an issue for MINT because Codecov is currently disabled there (mrc-1935).

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
