### PR TITLE
mrc-2209 Check if user has permission to upload to ADR dataset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.22.0
+
+* Check if user has ADR upload permission
+
 # hint 1.21.0
 
 * Backend support for ADR uploads

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -124,7 +124,7 @@ class ADRController(private val encryption: Encryption,
     }
 
     @GetMapping("/orgs")
-    fun getOrgsWithPermsission(@RequestParam permission: String): ResponseEntity<String>
+    fun getOrgsWithPermission(@RequestParam permission: String): ResponseEntity<String>
     {
         val adr = adrClientBuilder.build()
         return adr.get("organization_list_for_user?permission=${permission}")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -123,6 +123,13 @@ class ADRController(private val encryption: Encryption,
                         "outputSummary" to appProperties.adrOutputSummarySchema)).asResponseEntity()
     }
 
+    @GetMapping("/orgs")
+    fun getOrgsWithPermsission(@RequestParam permission: String): ResponseEntity<String>
+    {
+        val adr = adrClientBuilder.build()
+        return adr.get("organization_list_for_user?permission=${permission}")
+    }
+
     @PostMapping("/pjnz")
     fun importPJNZ(@RequestParam url: String): ResponseEntity<String>
     {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -65,6 +65,23 @@ class ADRTests : SecureIntegrationTests()
 
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
+    fun `can get orgs with permission`(isAuthorized: IsAuthorized)
+    {
+        testRestTemplate.postForEntity<String>("/adr/key", getPostEntityWithKey())
+        val result = testRestTemplate.getForEntity<String>("/adr/orgs?permission=update_dataset")
+
+        assertSecureWithSuccess(isAuthorized, result, null)
+
+        if (isAuthorized == IsAuthorized.TRUE)
+        {
+            val data = ObjectMapper().readTree(result.body!!)["data"]
+            assertThat(data.count()).isEqualTo(1)
+            assertThat(data[0]["name"].textValue()).isEqualTo("naomi-development-team")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
     fun `can save pjnz from ADR`(isAuthorized: IsAuthorized)
     {
         val pjnz = extractUrl(isAuthorized, "inputs-unaids-spectrum-file")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -425,7 +425,7 @@ class ADRControllerTests : HintrControllerTests()
                 mock(),
                 mockSession,
                 mock())
-        val result = sut.getOrgsWithPermsission("test_perm")
+        val result = sut.getOrgsWithPermission("test_perm")
         assertThat(result.body!!).isEqualTo("whatever")
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -403,6 +403,32 @@ class ADRControllerTests : HintrControllerTests()
         assertThat(result.body!!).isEqualTo("Bad Gateway")
     }
 
+    @Test
+    fun `gets orgs with permission`()
+    {
+        val expectedUrl = "organization_list_for_user?permission=test_perm"
+        val mockClient = mock<ADRClient> {
+            on { get(expectedUrl) } doReturn ResponseEntity
+                    .ok()
+                    .body("whatever")
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties,
+                mock(),
+                mock(),
+                mockSession,
+                mock())
+        val result = sut.getOrgsWithPermsission("test_perm")
+        assertThat(result.body!!).isEqualTo("whatever")
+    }
+
     private fun makeFakeSuccessResponse(): ResponseEntity<String>
     {
         val resultWithResources = mapOf("resources" to listOf(1, 2))

--- a/src/app/static/src/app/components/adr/SelectDataset.vue
+++ b/src/app/static/src/app/components/adr/SelectDataset.vue
@@ -77,7 +77,7 @@
     import {Language} from "../../store/translations/locales";
     import Vue from "vue";
     import TreeSelect from "@riophae/vue-treeselect";
-    import {findResource, mapActionByName, mapMutationByName, mapStateProp} from "../../utils";
+    import {datasetFromMetadata, findResource, mapActionByName, mapMutationByName, mapStateProp} from "../../utils";
     import {RootState} from "../../root";
     import Modal from "../Modal.vue";
     import {BaselineMutation} from "../../store/baseline/mutations";
@@ -116,7 +116,6 @@
         fetchingDatasets: boolean
         datasetOptions: any[]
         selectedDataset: Dataset | null
-        newDataset: Dataset
         selectText: string,
         outOfDateMessage: string,
         outOfDateResources: { [k in keyof DatasetResourceSet]?: true }
@@ -186,25 +185,6 @@
                         </div>`,
                 }));
             },
-            newDataset() {
-                const fullMetaData = this.datasets.find(d => d.id == this.newDatasetId);
-                return fullMetaData && {
-                    id: fullMetaData.id,
-                    title: fullMetaData.title,
-                    url: `${this.schemas.baseUrl}${fullMetaData.type}/${fullMetaData.name}`,
-                    resources: {
-                        pjnz: findResource(fullMetaData, this.schemas.pjnz),
-                        shape: findResource(fullMetaData, this.schemas.shape),
-                        pop: findResource(fullMetaData, this.schemas.population),
-                        survey: findResource(fullMetaData, this.schemas.survey),
-                        program: findResource(fullMetaData, this.schemas.programme),
-                        anc: findResource(fullMetaData, this.schemas.anc)
-                    },
-                    organization: {
-                        id: fullMetaData.organization.id
-                    }
-                }
-            },
             selectText() {
                 if (this.selectedDataset) {
                     return i18next.t('editBtn', {lng: this.currentLanguage})
@@ -253,9 +233,10 @@
             async importDataset() {
                 if (this.newDatasetId) {
                     this.loading = true;
-                    this.setDataset(this.newDataset);
+                    const newDataset = datasetFromMetadata(this.newDatasetId, this.datasets, this.schemas);
+                    this.setDataset(newDataset);
 
-                    const {pjnz, pop, shape, survey, program, anc} = this.newDataset.resources
+                    const {pjnz, pop, shape, survey, program, anc} = newDataset.resources
 
                     await Promise.all([
                         pjnz && this.importPJNZ(pjnz.url),

--- a/src/app/static/src/app/components/adr/SelectDataset.vue
+++ b/src/app/static/src/app/components/adr/SelectDataset.vue
@@ -199,6 +199,9 @@
                         survey: findResource(fullMetaData, this.schemas.survey),
                         program: findResource(fullMetaData, this.schemas.programme),
                         anc: findResource(fullMetaData, this.schemas.anc)
+                    },
+                    organization: {
+                        id: fullMetaData.organization.id
                     }
                 }
             },

--- a/src/app/static/src/app/components/downloadResults/DownloadResults.vue
+++ b/src/app/static/src/app/components/downloadResults/DownloadResults.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {mapStateProps} from "../../utils";
+    import {mapActionByName, mapStateProps} from "../../utils";
     import {ModelCalibrateState} from "../../store/modelCalibrate/modelCalibrate";
     import {DownloadIcon} from "vue-feather-icons";
 
@@ -33,7 +33,11 @@
         summaryReportUrl: string
     }
 
-    export default Vue.extend<unknown, unknown, Computed>({
+    interface Methods {
+        getUserCanUpload: () => void;
+    }
+
+    export default Vue.extend<unknown, Methods, Computed>({
         name: "downloadResults",
         computed: {
             ...mapStateProps<ModelCalibrateState, keyof Computed>("modelCalibrate", {
@@ -48,6 +52,12 @@
             summaryReportUrl: function () {
                 return `/download/summary/${this.modelCalibrateId}`
             }
+        },
+        methods: {
+          getUserCanUpload: mapActionByName("adr", "getUserCanUpload")
+        },
+        mounted() {
+            this.getUserCanUpload();
         },
         components: {
             DownloadIcon

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,3 +1,3 @@
 
 
-export const currentHintVersion = "1.20.0";
+export const currentHintVersion = "1.22.0";

--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -97,7 +97,7 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
                 .then(async (response) => {
                     if (response) {
                         const updateableOrgs = response.data as Organization[];
-;                       const canUpload = updateableOrgs.some(org => org.id === selectedDatasetOrgId);
+                        const canUpload = updateableOrgs.some(org => org.id === selectedDatasetOrgId);
                         commit({type: ADRMutation.SetUserCanUpload, payload: canUpload});
                     }
                 })

--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -75,9 +75,6 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
                         //organisation id for projects which are reloaded
                         let selectedDatasetOrgId: string;
                         if (!selectedDataset.organization) {
-                            console.log("regenning dataset");
-                            console.log("dataset count: " + state.datasets.length.toString());
-
                             //We may also have to fetch the selected dataset metadata too, if not loaded during this session
                             let datasets = state.datasets;
                             if (!datasets.length) {
@@ -94,7 +91,6 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
                             }
 
                             const regenDataset = datasetFromMetadata(selectedDataset.id, datasets, state.schemas!);
-                            console.log("regenned dataset: " + JSON.stringify(regenDataset));
                             commit(`baseline/${BaselineMutation.SetDataset}`, regenDataset, {root: true});
                             selectedDatasetOrgId = regenDataset.organization.id;
                         } else {
@@ -104,7 +100,6 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
                         const updateableOrgs = response.data as Organization[];
 ;                       const canUpload = updateableOrgs.some(org => org.id === selectedDatasetOrgId);
                         commit({type: ADRMutation.SetUserCanUpload, payload: canUpload});
-                        console.log("setting userCanUpload " + JSON.stringify(canUpload));
                     }
                 })
         }

--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -4,7 +4,7 @@ import {api} from "../../apiService";
 import qs from "qs";
 import {ADRState} from "./adr";
 import {ADRMutation} from "./mutations";
-import {constructUploadFile, findResource} from "../../utils";
+import {constructUploadFile, datasetFromMetadata, findResource} from "../../utils";
 import {Organization} from "../../types";
 
 export interface ADRActions {
@@ -70,6 +70,12 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
                 .get("/adr/orgs?permission=update_dataset")
                 .then((response) => {
                     if (response) {
+                        //For backward compatibility, we may have to regenerate the dataset metadata to provide the
+                        //organisation id
+                        if (!selectedDataset.organization) {
+                            const regenDataset = datasetFromMetadata(selectedDataset.id, state.datasets, state.schemas!);
+                            //TODO: set in the state
+                        }
 
                         //NB if this project was created before this feature was added, the selected dataset
                         //will not have organisation recorded  - need to re-fetch. (HOW?)

--- a/src/app/static/src/app/store/adr/adr.ts
+++ b/src/app/static/src/app/store/adr/adr.ts
@@ -12,6 +12,7 @@ export interface ADRState {
     keyError: Error | null,
     adrError: Error | null,
     schemas: ADRSchemas | null,
+    userCanUpload: boolean,
     uploadFiles: Dict<UploadFile> | null
 }
 
@@ -23,6 +24,7 @@ export const initialADRState = (): ADRState => {
         adrError: null,
         schemas: null,
         fetchingDatasets: false,
+        userCanUpload: false,
         uploadFiles: null
     }
 };

--- a/src/app/static/src/app/store/adr/mutations.ts
+++ b/src/app/static/src/app/store/adr/mutations.ts
@@ -10,7 +10,8 @@ export enum ADRMutation {
     SetDatasets = "SetDatasets",
     SetFetchingDatasets = "SetFetchingDatasets",
     SetSchemas = "SetSchemas",
-    SetUploadFiles = "SetUploadFiles"
+    SetUploadFiles = "SetUploadFiles",
+    SetUserCanUpload = "SetUserCanUpload"
 }
 
 export const mutations: MutationTree<ADRState> = {
@@ -40,5 +41,9 @@ export const mutations: MutationTree<ADRState> = {
 
     [ADRMutation.SetUploadFiles](state: ADRState, action: PayloadWithType<Dict<UploadFile>>) {
         state.uploadFiles = action.payload;
-    }
+    },
+
+    [ADRMutation.SetUserCanUpload](state: ADRState, action: PayloadWithType<boolean>) {
+        state.userCanUpload = action.payload;
+    },
 };

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -73,7 +73,6 @@ export const mutations: MutationTree<BaselineState> = {
     },
 
     [BaselineMutation.SetDataset](state: BaselineState, payload: Dataset) {
-        console.log("Setting dataset: " + JSON.stringify(payload))
         state.selectedDataset = payload;
     },
 

--- a/src/app/static/src/app/store/baseline/mutations.ts
+++ b/src/app/static/src/app/store/baseline/mutations.ts
@@ -73,6 +73,7 @@ export const mutations: MutationTree<BaselineState> = {
     },
 
     [BaselineMutation.SetDataset](state: BaselineState, payload: Dataset) {
+        console.log("Setting dataset: " + JSON.stringify(payload))
         state.selectedDataset = payload;
     },
 

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -122,6 +122,11 @@ export interface Dataset {
     title: string
     url: string,
     resources: DatasetResourceSet
+    organization: Organization
+}
+
+export interface Organization {
+    id: string
 }
 
 export interface ADRSchemas {

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -1,9 +1,9 @@
 import * as CryptoJS from 'crypto-js';
 import {ActionMethod, CustomVue, mapActions, mapGetters, mapMutations, mapState, MutationMethod} from "vuex";
-import {DatasetResource, Dict, Version} from "./types";
+import {ADRSchemas, DatasetResource, Dict, Version} from "./types";
 import {Error, FilterOption, NestedFilterOption, Response} from "./generated";
 import moment from 'moment';
-import {DynamicControlGroup, DynamicControlSection, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {DynamicControlGroup, DynamicControlSection, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";;
 
 export type ComputedWithType<T> = () => T;
 
@@ -171,6 +171,26 @@ export const findResource = (datasetWithResources: any, resourceType: string): D
         lastModified: metadata.last_modified,
         metadataModified: metadata.metadata_modified,
         outOfDate: false} : null
+};
+
+export const datasetFromMetadata = (id: string, datasets: any[], schemas: ADRSchemas) => {
+    const fullMetaData = datasets.find(d => d.id == id);
+    return fullMetaData && {
+        id: fullMetaData.id,
+        title: fullMetaData.title,
+        url: `${schemas.baseUrl}${fullMetaData.type}/${fullMetaData.name}`,
+        resources: {
+            pjnz: findResource(fullMetaData, schemas.pjnz),
+            shape: findResource(fullMetaData, schemas.shape),
+            pop: findResource(fullMetaData, schemas.population),
+            survey: findResource(fullMetaData, schemas.survey),
+            program: findResource(fullMetaData, schemas.programme),
+            anc: findResource(fullMetaData, schemas.anc)
+        },
+        organization: {
+            id: fullMetaData.organization.id
+        }
+    }
 };
 
 export const constructUploadFile = (datasetWithResources: any, index: number, resourceType: string,

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -3,7 +3,7 @@ import {ActionMethod, CustomVue, mapActions, mapGetters, mapMutations, mapState,
 import {ADRSchemas, DatasetResource, Dict, Version} from "./types";
 import {Error, FilterOption, NestedFilterOption, Response} from "./generated";
 import moment from 'moment';
-import {DynamicControlGroup, DynamicControlSection, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";;
+import {DynamicControlGroup, DynamicControlSection, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 export type ComputedWithType<T> = () => T;
 

--- a/src/app/static/src/tests/adr/actions.test.ts
+++ b/src/app/static/src/tests/adr/actions.test.ts
@@ -231,4 +231,109 @@ describe("ADR actions", () => {
             }
         });
     });
+
+    it("getUserCanUpload does nothing if no selected dataset", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState()
+        });
+
+        await actions.getUserCanUpload({commit, state, rootState: root} as any);
+
+        expect(commit.mock.calls.length).toBe(0);
+        expect(mockAxios.history.get.length).toBe(0);
+    });
+
+    it("getUserCanUpload fetches updateable dataset and commits when user can upload", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState({selectedDataset: {organization: {id: "test-org"}} as any})
+        });
+        const updateableOrgs = [{id: "other-org"}, {id: "test-org"}];
+        mockAxios.onGet(`adr/orgs?permission=update_dataset`)
+            .reply(200, mockSuccess(updateableOrgs));
+
+        await actions.getUserCanUpload({commit, state, rootState: root} as any);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: "SetUserCanUpload", payload: true});
+    });
+
+    it("getUserCanUpload fetches updateable dataset and commits when user cannot upload", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState({selectedDataset: {organization: {id: "test-org"}} as any})
+        });
+        const updateableOrgs = [{id: "other-org"}, {id: "other-org-2"}];
+        mockAxios.onGet(`adr/orgs?permission=update_dataset`)
+            .reply(200, mockSuccess(updateableOrgs));
+
+        await actions.getUserCanUpload({commit, state, rootState: root} as any);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: "SetUserCanUpload", payload: false});
+    });
+
+    it("getUserCanUpload commits error", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState({selectedDataset: {organization: {id: "test-org"}} as any})
+        });
+        mockAxios.onGet(`adr/orgs?permission=update_dataset`)
+            .reply(500, mockFailure("test-error"));
+
+        await actions.getUserCanUpload({commit, state, rootState: root} as any);
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0].type).toBe("ADRError");
+        expect(commit.mock.calls[0][0].payload).toStrictEqual(mockError("test-error"));
+    });
+
+    it("getUserCanUpload sets organisation on selectedDataset if necessary", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState({selectedDataset: {id: "test-dataset"}} as any)
+        });
+        const adr = mockADRState({
+            datasets: [{id: "test-dataset", resources: [], organization: {id: "test-org"}}],
+            schemas: {baseUrl: "http://test"} as any
+        });
+
+        mockAxios.onGet(`adr/orgs?permission=update_dataset`)
+            .reply(200, mockSuccess([{id: "test-org"}]));
+
+        await actions.getUserCanUpload({commit, state: adr, rootState: root} as any);
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]).toBe("baseline/SetDataset");
+        expect(commit.mock.calls[0][1].id).toBe("test-dataset");
+        expect(commit.mock.calls[0][1].organization).toStrictEqual({id: "test-org"});
+        expect(commit.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: "SetUserCanUpload", payload: true});
+    });
+
+    it("getUserCanUpload fetches dataset metadata to get organization if necessary", async () => {
+        const commit = jest.fn();
+        const root = mockRootState({
+            baseline: mockBaselineState({selectedDataset: {id: "test-dataset"}} as any)
+        });
+        const adr = mockADRState({
+            datasets: [],
+            schemas: {baseUrl: "http://test"} as any
+        });
+
+        const datasetResponse = {id: "test-dataset", resources: [], organization: {id: "test-org"}}
+        mockAxios.onGet(`adr/datasets/test-dataset`)
+            .reply(200, mockSuccess(datasetResponse));
+        mockAxios.onGet(`adr/orgs?permission=update_dataset`)
+            .reply(200, mockSuccess([{id: "test-org"}]));
+
+        await actions.getUserCanUpload({commit, state: adr, rootState: root} as any);
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]).toBe("baseline/SetDataset");
+        expect(commit.mock.calls[0][1].id).toBe("test-dataset");
+        expect(commit.mock.calls[0][1].organization).toStrictEqual({id: "test-org"});
+        expect(commit.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: "SetUserCanUpload", payload: true});
+    });
 });

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -79,7 +79,7 @@ describe("select dataset", () => {
         {
             id: "id1",
             title: "Some data",
-            organization: {title: "org"},
+            organization: {title: "org", id: "org-id"},
             name: "some-data",
             type: "naomi-data",
             resources: []
@@ -87,7 +87,7 @@ describe("select dataset", () => {
         {
             id: "id2",
             title: "Some data 2",
-            organization: {title: "org"},
+            organization: {title: "org", id: "org-id"},
             name: "some-data",
             type: "naomi-data",
             resources: []
@@ -98,6 +98,7 @@ describe("select dataset", () => {
         id: "id1",
         title: "Some data",
         url: "www.adr.com/naomi-data/some-data",
+        organization: {id: "org-id"},
         resources: {
             pjnz: null,
             program: null,
@@ -116,6 +117,7 @@ describe("select dataset", () => {
         id: "id2",
         title: "Some data 2",
         url: "www.adr.com/naomi-data/some-data",
+        organization: {id: "org-id"},
         resources: {
             pjnz: null,
             program: null,

--- a/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
@@ -10,13 +10,19 @@ const localVue = createLocalVue();
 
 describe("Download Results component", () => {
 
-    const createStore = () => {
+    const createStore = (getUserCanUpload = jest.fn()) => {
         const store = new Vuex.Store({
             state: emptyState(),
             modules: {
                 modelCalibrate: {
                     namespaced: true,
                     state: mockModelCalibrateState({calibrateId: "testId"})
+                },
+                adr: {
+                    namespaced: true,
+                    actions: {
+                        getUserCanUpload
+                    }
                 }
             }
         });
@@ -44,5 +50,12 @@ describe("Download Results component", () => {
         expect(links.at(1).attributes().href).toEqual("/download/coarse-output/testId");
         expectTranslated(links.at(2), "Download", "Télécharger", store);
         expect(links.at(2).attributes().href).toEqual("/download/summary/testId")
+    });
+
+    it("invokes getUserCanUpload on mounted", async () => {
+        const mockGetUserCanUpload = jest.fn();
+        const store = createStore(mockGetUserCanUpload);
+        shallowMount(DownloadResults, {store});
+        expect(mockGetUserCanUpload.mock.calls.length).toBe(1);
     });
 });

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -15,13 +15,11 @@ import {mockADRState} from "../mocks";
 describe("ADR dataset-related actions", () => {
     const schemas = {
         baseUrl: "adr.com",
-            pjnz: "pjnz",
-            population: "pop",
-            shape: "shape",
-            survey: "survey",
-            programme: "program",
-            anc: "anc"
-    } as any;
+        pjnz: "pjnz",
+        population: "pop",
+        shape: "shape",
+        survey: "survey",
+    };
 
     beforeAll(async () => {
         await login();
@@ -92,7 +90,7 @@ describe("ADR dataset-related actions", () => {
                 }
             }
         };
-        const adr = mockADRState({ schemas, datasets }); //include datasets in adr state
+        const adr = { schemas, datasets }; //include datasets in adr state
         await adrActions.getUserCanUpload({commit, rootState: root, state: adr} as any);
         expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetUserCanUpload);
         expect(commit.mock.calls[0][0].payload).toBe(true);
@@ -120,10 +118,11 @@ describe("ADR dataset-related actions", () => {
                 }
             }
         };
-        const adr = mockADRState({ schemas }); //do not include datasets in adr state, the action will fetch them
+        const adr = { schemas, datasets: [] }; //do not include datasets in adr state, the action will fetch them
         await adrActions.getUserCanUpload({commit, rootState: root, state: adr} as any);
-        expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetUserCanUpload);
-        expect(commit.mock.calls[0][0].payload).toBe(true);
+        expect(commit.mock.calls[0][0]).toBe(`baseline/${BaselineMutation.SetDataset}`);
+        expect(commit.mock.calls[1][0].type).toBe(ADRMutation.SetUserCanUpload);
+        expect(commit.mock.calls[1][0].payload).toBe(true);
     });
 
     it("can import PJNZ file", async () => {

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -6,12 +6,22 @@ import {actions as adrActions} from "../../app/store/adr/actions";
 import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
 import {getFormData} from "./helpers";
 import {ADRMutation} from "../../app/store/adr/mutations";
+import {mockADRState} from "../mocks";
 
 // this suite tests all endpoints that talk to the ADR
 // we put them in a suite of their own so that we can run
 // them as a separate CI step and easily spot when test failures
 // are related to ADR flakiness
 describe("ADR dataset-related actions", () => {
+    const schemas = {
+        baseUrl: "adr.com",
+            pjnz: "pjnz",
+            population: "pop",
+            shape: "shape",
+            survey: "survey",
+            programme: "program",
+            anc: "anc"
+    } as any;
 
     beforeAll(async () => {
         await login();
@@ -44,17 +54,7 @@ describe("ADR dataset-related actions", () => {
         const dispatch = jest.fn();
         const rootStateWithSchemas = {
             ...rootState,
-            adr: {
-                schemas: {
-                    baseUrl: "adr.com",
-                    pjnz: "pjnz",
-                    population: "pop",
-                    shape: "shape",
-                    survey: "survey",
-                    programme: "program",
-                    anc: "anc"
-                }
-            }
+            adr: { schemas }
         };
 
         await adrActions.getDatasets({commit, rootState} as any);
@@ -67,6 +67,63 @@ describe("ADR dataset-related actions", () => {
 
         await baselineActions.refreshDatasetMetadata({commit, state, dispatch, rootState: rootStateWithSchemas} as any);
         expect(commit.mock.calls[3][0]).toBe(BaselineMutation.UpdateDatasetResources);
+    });
+
+    it("can get userCanUpload when selected dataset organisation is set", async () => {
+        const commit = jest.fn();
+
+        // 1. get datasets
+        await adrActions.getDatasets({commit, rootState} as any);
+
+        // 2. select a naomi dev dataset
+        expect(commit.mock.calls[1][0].type).toStrictEqual(ADRMutation.SetDatasets);
+        const datasets = commit.mock.calls[1][0]["payload"];
+        const dataset = datasets[1];
+        expect(dataset.organization.name).toBe("naomi-development-team");
+
+        // 3. check can upload
+        commit.mockClear();
+        const root = {
+            ...rootState,
+            baseline: {
+                selectedDataset: {
+                    id: dataset.id,
+                    organization: {id: dataset.organization.id}
+                }
+            }
+        };
+        const adr = mockADRState({ schemas, datasets }); //include datasets in adr state
+        await adrActions.getUserCanUpload({commit, rootState: root, state: adr} as any);
+        expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetUserCanUpload);
+        expect(commit.mock.calls[0][0].payload).toBe(true);
+    });
+
+    it("can get dataset details on get userCanUpload when selected dataset organisation is not set", async () => {
+        const commit = jest.fn();
+
+        // 1. get datasets
+        await adrActions.getDatasets({commit, rootState} as any);
+
+        // 2. select a naomi dev dataset
+        expect(commit.mock.calls[1][0].type).toStrictEqual(ADRMutation.SetDatasets);
+        const datasets = commit.mock.calls[1][0]["payload"];
+        const dataset = datasets[1];
+        expect(dataset.organization.name).toBe("naomi-development-team");
+
+        // 3. check can upload
+        commit.mockClear();
+        const root = {
+            ...rootState,
+            baseline: {
+                selectedDataset: {
+                    id: dataset.id
+                }
+            }
+        };
+        const adr = mockADRState({ schemas }); //do not include datasets in adr state, the action will fetch them
+        await adrActions.getUserCanUpload({commit, rootState: root, state: adr} as any);
+        expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetUserCanUpload);
+        expect(commit.mock.calls[0][0].payload).toBe(true);
     });
 
     it("can import PJNZ file", async () => {

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -368,6 +368,9 @@ export const mockDataset = (props: Partial<Dataset> = {}): Dataset => {
             shape: null,
             anc: null
         },
+        organization: {
+          id: "456"
+        },
         ...props
     }
 };


### PR DESCRIPTION
## Description

Back end and front end to check if the user has permission to upload to the ADR dataset. Permissions are at organization level, so we use the organization id associated with the dataset. 

Front end: Adds a new action, invoked when the Download component (final step) loads. This gets the orgs with `update_dataset` permission and sets `userCanUpload` in ADR state if the selected dataset's org is one of these. 

Back end: Adds a new `adr/orgs` endpoint which takes a query parm for the permission to check for, returning all the orgs for which the user has that permission. This could have been a more specific endpoint e.g. userCanUpload but most other endpoints follow this pattern of the backend just passing through ADR responses, which the front end interprets.

The branch adds organization id to the data retained in selectedDataset in the baseline state. However for backward compatibility, we allow for this not being available if we're loading a project saved before this feature was added. In this case we might be able to get the organization out of `datasets` in ADR state, but more likely we'll need to reload dataset details from the backend (these are not persisted when state is saved as they are bulky and go stale).

## Type of version change

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
