### PR TITLE
mrc-2266 Set resource_type when pushing to ADR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.26.0
+
+* Set resource_type when pushing to ADR
+
 # hint 1.25.0
 
 * add upload button and dialog box for result outputs to ADR

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -202,7 +202,8 @@ class ADRController(private val encryption: Encryption,
         // 4. Checksum file and upload with metadata to ADR
         val filePart = Pair("upload", file)
         val commonParameters =
-                listOf("name" to resourceFileName, "description" to artefact.second, "hash" to file.md5sum())
+                listOf("name" to resourceFileName, "description" to artefact.second, "hash" to file.md5sum(),
+                        "resource_type" to resourceType)
         val adr = adrClientBuilder.build()
         return try
         {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/ProjectRepositoryTests.kt
@@ -132,9 +132,8 @@ class ProjectRepositoryTests
     fun `getProjectFromVersionId throws project exception if project does not belong to user`()
     {
         val uid = setupUser()
-        val projectId = sut.saveNewProject(uid, "testProjectRepo")
         assertThatThrownBy {
-            sut.getProjectFromVersionId("v1", "testProjectRepo")
+            sut.getProjectFromVersionId("v1", uid)
         }.isInstanceOf(ProjectException::class.java)
                 .hasMessageContaining("projectDoesNotExist")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -327,7 +327,7 @@ class ADRControllerTests : HintrControllerTests()
         val mockAPIClient: HintrAPIClient = mock {
             on { downloadSummary("model1") } doReturn ResponseEntity.ok().body(StreamingResponseBody { it.write("".toByteArray()) })
         }
-        val mockClient: ADRClient = mock(verboseLogging = true) {
+        val mockClient: ADRClient = mock {
             on { postFile(eq("resource_create"), eq(listOf("name" to "output1.html", "description" to "Naomi summary report", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "resource_type" to "adr-output-summary", "package_id" to "dataset1")), any()) } doReturn ResponseEntity.ok().body("whatever")
         }
         val mockBuilder: ADRClientBuilder = mock {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -43,8 +43,6 @@ class ADRControllerTests : HintrControllerTests()
         on { adrOutputSummarySchema } doReturn "adr-output-summary"
     }
 
-    private val mockFileManager = mock<FileManager>()
-
     private val objectMapper = ObjectMapper()
 
     private val mockUserRepo = mock<UserRepository>() {
@@ -311,7 +309,7 @@ class ADRControllerTests : HintrControllerTests()
             on { downloadSpectrum("model1") } doReturn ResponseEntity.ok().body(StreamingResponseBody { it.write("".toByteArray()) })
         }
         val mockClient: ADRClient = mock {
-            on { postFile(eq("resource_create"), eq(listOf("name" to "output1.zip", "description" to "Naomi model outputs", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "package_id" to "dataset1")), any()) } doReturn ResponseEntity.ok().body("whatever")
+            on { postFile(eq("resource_create"), eq(listOf("name" to "output1.zip", "description" to "Naomi model outputs", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "resource_type" to "adr-output-zip", "package_id" to "dataset1")), any()) } doReturn ResponseEntity.ok().body("whatever")
         }
         val mockBuilder: ADRClientBuilder = mock {
             on { build() } doReturn mockClient
@@ -329,8 +327,8 @@ class ADRControllerTests : HintrControllerTests()
         val mockAPIClient: HintrAPIClient = mock {
             on { downloadSummary("model1") } doReturn ResponseEntity.ok().body(StreamingResponseBody { it.write("".toByteArray()) })
         }
-        val mockClient: ADRClient = mock {
-            on { postFile(eq("resource_create"), eq(listOf("name" to "output1.html", "description" to "Naomi summary report", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "package_id" to "dataset1")), any()) } doReturn ResponseEntity.ok().body("whatever")
+        val mockClient: ADRClient = mock(verboseLogging = true) {
+            on { postFile(eq("resource_create"), eq(listOf("name" to "output1.html", "description" to "Naomi summary report", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "resource_type" to "adr-output-summary", "package_id" to "dataset1")), any()) } doReturn ResponseEntity.ok().body("whatever")
         }
         val mockBuilder: ADRClientBuilder = mock {
             on { build() } doReturn mockClient
@@ -349,7 +347,7 @@ class ADRControllerTests : HintrControllerTests()
             on { downloadSpectrum("model1") } doReturn ResponseEntity.ok().body(StreamingResponseBody { it.write("".toByteArray()) })
         }
         val mockClient: ADRClient = mock {
-            on { postFile(eq("resource_patch"), eq(listOf("name" to "output1.zip", "description" to "Naomi model outputs", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "id" to "resource1")), any()) } doReturn ResponseEntity.ok().body("whatever")
+            on { postFile(eq("resource_patch"), eq(listOf("name" to "output1.zip", "description" to "Naomi model outputs", "hash" to "D41D8CD98F00B204E9800998ECF8427E", "resource_type" to "adr-output-zip", "id" to "resource1")), any()) } doReturn ResponseEntity.ok().body("whatever")
         }
         val mockBuilder: ADRClientBuilder = mock {
             on { build() } doReturn mockClient

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,1 @@
-export const currentHintVersion = "1.25.0";
-
+export const currentHintVersion = "1.26.0";

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -82,8 +82,8 @@ describe("ADR dataset-related actions", () => {
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
         const datasets = commit.mock.calls[2][0]["payload"];
-        const dataset = datasets[0];
-        expect(dataset.organization.name).toBe("naomi-development-team");
+        const dataset = datasets.find((dataset: any) => dataset.organization.name === "naomi-development-team");
+        expect(dataset).not.toBeNull()
 
         // 3. check can upload
         commit.mockClear();
@@ -111,8 +111,8 @@ describe("ADR dataset-related actions", () => {
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
         const datasets = commit.mock.calls[2][0]["payload"];
-        const dataset = datasets[0];
-        expect(dataset.organization.name).toBe("naomi-development-team");
+        const dataset = datasets.find((dataset: any) => dataset.organization.name === "naomi-development-team");
+        expect(dataset).not.toBeNull()
 
         // 3. check can upload
         commit.mockClear();

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -82,7 +82,7 @@ describe("ADR dataset-related actions", () => {
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
         const datasets = commit.mock.calls[2][0]["payload"];
-        const dataset = datasets[1];
+        const dataset = datasets[0];
         expect(dataset.organization.name).toBe("naomi-development-team");
 
         // 3. check can upload
@@ -111,7 +111,7 @@ describe("ADR dataset-related actions", () => {
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
         const datasets = commit.mock.calls[2][0]["payload"];
-        const dataset = datasets[1];
+        const dataset = datasets[0];
         expect(dataset.organization.name).toBe("naomi-development-team");
 
         // 3. check can upload


### PR DESCRIPTION
## Description

Set resource_type when pushing to ADR. Also fix various compiler warnings and test failures (reflecting new datasets mirrored from prod ADR).

## Type of version change

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
