### PR TITLE
mrc-2300 Improve performance of ADR uploads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.30.0
+
+* Improve performance of ADR uploads
+
 # hint 1.29.0
 
 * Progress feedback on uploading files to ADR

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hint 1.30.0
+# hint 1.29.1
 
 * Improve performance of ADR uploads
 

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -23,9 +23,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
 
-    implementation 'com.github.kittinunf.fuel:fuel:2.1.0'
-    implementation 'com.github.kittinunf.fuel:fuel-json:2.1.0'
-    implementation 'com.github.kittinunf.fuel:fuel-coroutines:2.1.0'
+    implementation 'com.github.kittinunf.fuel:fuel:2.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.httpUpload
 import org.imperial.mrc.hint.asResponseEntity
 import org.springframework.http.ResponseEntity
 import java.io.File
+import java.time.Instant
 
 abstract class FuelClient(protected val baseUrl: String)
 {
@@ -60,12 +61,29 @@ abstract class FuelClient(protected val baseUrl: String)
 
     fun postFile(url: String, parameters: Parameters, file: Pair<String, File>): ResponseEntity<String>
     {
-        return "$baseUrl/$url".httpUpload(parameters)
+        println("""
+            > postFile
+            ${Instant.now()}
+            $baseUrl/$url
+            parameters: $parameters
+            file: $file
+            header: ${standardHeaders()}
+        """.trimIndent())
+//        val response = "https://paste.c-net.org/".httpUpload(parameters)
+//        val response = "https://hookb.in/1gjdyBNoZqfj002yk3kl".httpUpload(parameters)
+        val response = "$baseUrl/$url".httpUpload(parameters)
                 .add(FileDataPart(file.second, file.first))
                 .addTimeouts()
                 .header(standardHeaders())
                 .response()
                 .second
                 .asResponseEntity()
+        println("""
+            < postFile
+            ${Instant.now()}
+            response code: ${response.statusCodeValue}
+            response body: ${response.body}
+        """.trimIndent())
+        return response
     }
 }

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -8,6 +8,7 @@ adr_output_zip_schema=inputs-unaids-naomi-output-zip
 adr_output_summary_schema=inputs-unaids-naomi-report
 adr_schema=inputs-unaids-estimates
 adr_url=https://dev.adr.fjelltopp.org/
+#adr_url=http://localhost:9876/
 application_title=Naomi
 application_url=http://localhost:8080
 email_mode=disk

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.30.0";
+export const currentHintVersion = "1.29.1";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.29.0";
+export const currentHintVersion = "1.30.0";

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.32'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Description

Update Fuel to version [2.2.x](https://github.com/kittinunf/fuel/releases/tag/2.2.1) to incorporate fix for kittinunf/fuel#667

Also remove redundant dependencies

To test: upload Burundi model output zip before and after applying this patch. On my machine it reduces from ~10 mins to ~1 min.

## Type of version change

Patch

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
