### PR TITLE
Jest mockImplementation to fix getUserCanUpload test

### DIFF
--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -74,7 +74,7 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
             if (!selectedDataset.organization) {
                 //We may also have to fetch the selected dataset metadata too, if not loaded during this session
                 await getAndSetDatasets(context, selectedDataset.id)
-                selectedDatasetOrgId = (baseline as BaselineState).selectedDataset!.organization.id
+                selectedDatasetOrgId = rootState.baseline.selectedDataset!.organization.id
                 // selectedDatasetOrgId = rootState.baseline.selectedDataset!.organization.id;
                 // selectedDatasetOrgId = selectedDataset.organization!.id;
             } else {

--- a/src/app/static/src/tests/adr/actions.test.ts
+++ b/src/app/static/src/tests/adr/actions.test.ts
@@ -324,7 +324,7 @@ describe("ADR actions", () => {
         //of action which required that state change
         const commit = jest.fn().mockImplementation(mutation => {
             if (mutation === "baseline/SetDataset") {
-                root.baseline.selectedDataset = {organization: {id: "test-org"}} as any
+                root.baseline.selectedDataset = {id: "test-dataset", organization: {id: "test-org"}} as any
             }
         });
 

--- a/src/app/static/src/tests/adr/actions.test.ts
+++ b/src/app/static/src/tests/adr/actions.test.ts
@@ -322,9 +322,9 @@ describe("ADR actions", () => {
 
         //Give commit an implementation so it can really update the state on the SetDataset mutation to allow testing
         //of action which required that state change
-        const commit = jest.fn().mockImplementation(mutation => {
+        const commit = jest.fn().mockImplementation((mutation, payload) => {
             if (mutation === "baseline/SetDataset") {
-                root.baseline.selectedDataset = {id: "test-dataset", organization: {id: "test-org"}} as any
+                root.baseline.selectedDataset = payload
             }
         });
 

--- a/src/app/static/src/tests/adr/actions.test.ts
+++ b/src/app/static/src/tests/adr/actions.test.ts
@@ -312,13 +312,20 @@ describe("ADR actions", () => {
     });
 
     it("getUserCanUpload sets organisation on selectedDataset if necessary", async () => {
-        const commit = jest.fn();
         const root = mockRootState({
             baseline: mockBaselineState({selectedDataset: {id: "test-dataset"}} as any)
         });
         const adr = mockADRState({
             datasets: [{id: "test-dataset", resources: [], organization: {id: "test-org"}}],
             schemas: {baseUrl: "http://test"} as any
+        });
+
+        //Give commit an implementation so it can really update the state on the SetDataset mutation to allow testing
+        //of action which required that state change
+        const commit = jest.fn().mockImplementation(mutation => {
+            if (mutation === "baseline/SetDataset") {
+                root.baseline.selectedDataset = {organization: {id: "test-org"}} as any
+            }
         });
 
         mockAxios.onGet(`adr/orgs?permission=update_dataset`)


### PR DESCRIPTION
Branch to show how to use mockImplementation to stub a required change to baseline state 
- fixed up one of the two failing tests - gave the mock commit an implementation to really set organisation in the baseline when that mutation is commitrd
- This required a change to the action - need to get baseline state from the root state rather than the module - and can't rely on local selectedDataset variable as whole dataset will be overwritten by that mutation
