### PR TITLE
mrc-2403 Correctly scope ADR mutations/actions in upload logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.35.1
+
+* Correctly scope ADR mutations/actions in upload logic
+
 # hint 1.35.0
 
 * Roll-back making login email case insensitive (mrc-2210)

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.35.0";
+export const currentHintVersion = "1.35.1";

--- a/src/app/static/src/app/store/adrUpload/actions.ts
+++ b/src/app/static/src/app/store/adrUpload/actions.ts
@@ -6,7 +6,6 @@ import {ADRUploadState} from "./adrUpload";
 import {ADRUploadMutation} from "./mutations";
 import {constructUploadFile} from "../../utils";
 import {Dict, UploadFile} from "../../types";
-import {ADRMutation} from "../adr/mutations";
 
 export interface ADRUploadActions {
     getUploadFiles: (store: ActionContext<ADRUploadState, RootState>) => void;
@@ -20,9 +19,9 @@ export const actions: ActionTree<ADRUploadState, RootState> & ADRUploadActions =
         const project = rootState.projects.currentProject;
 
         if (selectedDataset && project) {
-            context.commit({type: ADRMutation.SetADRError, payload: null});
+            commit({type: ADRUploadMutation.SetADRUploadError, payload: null});
             await api(context)
-                .withError(ADRMutation.SetADRError)
+                .withError(ADRUploadMutation.SetADRUploadError)
                 .ignoreSuccess()
                 .get(`/adr/datasets/${selectedDataset.id}`)
                 .then((response) => {
@@ -91,7 +90,7 @@ export const actions: ActionTree<ADRUploadState, RootState> & ADRUploadActions =
                 break
             }
         }
-        await dispatch("adr/getAndSetDatasets", selectedDatasetId);
-        dispatch("getUploadFiles");
+        await dispatch("adr/getAndSetDatasets", selectedDatasetId, {root: true});
+        await dispatch("getUploadFiles");
     }
 };

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -66,10 +66,10 @@ describe("ADR actions", () => {
 
         await actions.getUploadFiles({commit, state, rootState: root} as any);
 
-        expect(commit.mock.calls[0][0].type).toBe("ADRError");
+        expect(commit.mock.calls[0][0].type).toBe("SetADRUploadError");
         expect(commit.mock.calls[0][0].payload).toBeNull();
 
-        expect(commit.mock.calls[1][0].type).toBe("ADRError");
+        expect(commit.mock.calls[1][0].type).toBe("SetADRUploadError");
         expect(commit.mock.calls[1][0].payload).toStrictEqual(mockError("test error"));
     });
 
@@ -106,7 +106,7 @@ describe("ADR actions", () => {
 
         await actions.getUploadFiles({commit, rootState: root} as any);
 
-        expect(commit.mock.calls[0][0].type).toBe("ADRError");
+        expect(commit.mock.calls[0][0].type).toBe("SetADRUploadError");
         expect(commit.mock.calls[0][0].payload).toBeNull();
 
         expect(commit.mock.calls[1][0].type).toBe("SetUploadFiles");

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -174,15 +174,13 @@ describe("ADR actions", () => {
         ] as UploadFile[]
 
         const success = {response: "success"}
-        const success2 = {response: "success2"}
-        const success3 = {response: "success3", data: {id: "datasetId"}}
 
         mockAxios.onPost(`adr/datasets/datasetId/resource/inputs-unaids-naomi-output-zip/calId`)
-            .reply(200, mockSuccess(success));
+            .reply(200, mockSuccess(null));
         mockAxios.onPost(`adr/datasets/datasetId/resource/inputs-unaids-naomi-report/calId`)
-            .reply(200, mockSuccess(success2));
+            .reply(200, mockSuccess(success));
         mockAxios.onGet(`adr/datasets/datasetId`)
-            .reply(200, mockSuccess(success3));
+            .reply(200, mockSuccess(null));
 
         await actions.uploadFilesToADR({commit, dispatch, rootState: root} as any, uploadFilesPayload);
 
@@ -194,7 +192,7 @@ describe("ADR actions", () => {
         expect(commit.mock.calls[2][0]["type"]).toBe("ADRUploadProgress");
         expect(commit.mock.calls[2][0]["payload"]).toBe(2);
         expect(commit.mock.calls[3][0]["type"]).toBe("ADRUploadCompleted");
-        expect(commit.mock.calls[3][0]["payload"]).toEqual(success2);
+        expect(commit.mock.calls[3][0]["payload"]).toEqual(success);
         expect(dispatch.mock.calls.length).toBe(2);
         expect(dispatch.mock.calls[0][0]).toBe("adr/getAndSetDatasets");
         expect(dispatch.mock.calls[0][1]).toBe("datasetId");

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -12,7 +12,12 @@ import {
     mockSuccess
 } from "../mocks";
 import {actions} from "../../app/store/adrUpload/actions";
+import {mutations} from "../../app/store/adrUpload/mutations";
+import {actions as adrActions} from "../../app/store/adr/actions";
+import {mutations as baselineMutations} from "../../app/store/baseline/mutations";
 import {UploadFile} from "../../app/types";
+import Vuex from "vuex";
+import {RootState} from "../../app/root";
 
 describe("ADR actions", () => {
     const state = mockADRState();
@@ -133,34 +138,6 @@ describe("ADR actions", () => {
     });
 
     it("uploadFilesToADR uploads files sequentially to adr and commits complete on upload of final file", async () => {
-        const commit = jest.fn();
-        const dispatch = jest.fn();
-        const root = mockRootState({
-            adr: mockADRState({
-                datasets: [],
-                schemas: {
-                    baseUrl: "http://test",
-                    outputZip: "inputs-unaids-naomi-output-zip",
-                    outputSummary: "inputs-unaids-naomi-report"
-                } as any
-            }),
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calId"}),
-            modelRun: mockModelRunState(
-                {
-                    result: mockCalibrateResultResponse({
-                        uploadMetadata: {
-                            outputSummary: {description: "summary"},
-                            outputZip: {description: "zip"}
-                        }
-                    })
-                }),
-            baseline: mockBaselineState({
-                selectedDataset: {
-                    id: "datasetId"
-                }
-            } as any)
-        });
-
         const uploadFilesPayload = [
             {
                 resourceType: "inputs-unaids-naomi-output-zip",
@@ -173,36 +150,62 @@ describe("ADR actions", () => {
             }
         ] as UploadFile[]
 
-        const success = {response: "success"}
-
         mockAxios.onPost(`adr/datasets/datasetId/resource/inputs-unaids-naomi-output-zip/calId`)
             .reply(200, mockSuccess(null));
         mockAxios.onPost(`adr/datasets/datasetId/resource/inputs-unaids-naomi-report/calId`)
-            .reply(200, mockSuccess(success));
-        mockAxios.onGet(`adr/datasets/datasetId`)
             .reply(200, mockSuccess(null));
+        mockAxios.onGet(`adr/datasets/datasetId`)
+            .reply(200, mockSuccess({id: "datasetId", resources: [], organization: {id: null}, title: "datasetTitle"}));
 
-        await actions.uploadFilesToADR({commit, dispatch, rootState: root} as any, uploadFilesPayload);
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                modelCalibrate: mockModelCalibrateState({
+                    calibrateId: "calId"
+                }),
+                projects: {
+                    currentProject: {name: "project1"} as any
+                } as any
+            }),
+            modules: {
+                adrUpload: {
+                    namespaced: true,
+                    actions,
+                    mutations
+                },
+                adr: {
+                    namespaced: true,
+                    actions: adrActions,
+                    state: mockADRState({
+                        datasets: [],
+                        schemas: {baseUrl: "whatever"} as any
+                    })
+                },
+                baseline: {
+                    namespaced: true,
+                    mutations: baselineMutations,
+                    state: mockBaselineState({
+                        selectedDataset: {
+                            id: "datasetId"
+                        }
+                    } as any)
+                }
+            }
+        });
 
-        expect(commit.mock.calls.length).toBe(4);
-        expect(commit.mock.calls[0][0]["type"]).toBe("ADRUploadStarted");
-        expect(commit.mock.calls[0][0]["payload"]).toBe(2);
-        expect(commit.mock.calls[1][0]["type"]).toBe("ADRUploadProgress");
-        expect(commit.mock.calls[1][0]["payload"]).toBe(1);
-        expect(commit.mock.calls[2][0]["type"]).toBe("ADRUploadProgress");
-        expect(commit.mock.calls[2][0]["payload"]).toBe(2);
-        expect(commit.mock.calls[3][0]["type"]).toBe("ADRUploadCompleted");
-        expect(commit.mock.calls[3][0]["payload"]).toEqual(success);
-        expect(dispatch.mock.calls.length).toBe(2);
-        expect(dispatch.mock.calls[0][0]).toBe("adr/getAndSetDatasets");
-        expect(dispatch.mock.calls[0][1]).toBe("datasetId");
-        expect(dispatch.mock.calls[0][2]).toEqual({root: true});
-        expect(dispatch.mock.calls[1][0]).toBe("getUploadFiles");
+        expect(store.state.baseline.selectedDataset?.title).toBeUndefined();
+        expect(store.state.adrUpload.uploadFiles).toBeUndefined();
+
+        await store.dispatch("adrUpload/uploadFilesToADR", uploadFilesPayload);
+
+        expect(store.state.adrUpload.uploadComplete).toBe(true);
         expect(mockAxios.history.post.length).toBe(2);
-        expect(mockAxios.history.post[0]["data"]).toBe("resourceFileName=file1&resourceId=id1&description=zip");
         expect(mockAxios.history.post[0]["url"]).toBe("/adr/datasets/datasetId/resource/inputs-unaids-naomi-output-zip/calId");
-        expect(mockAxios.history.post[1]["data"]).toBe("resourceFileName=file2&description=summary");
         expect(mockAxios.history.post[1]["url"]).toBe("/adr/datasets/datasetId/resource/inputs-unaids-naomi-report/calId");
+        // adr/getAndSetDatasets
+        expect(store.state.baseline.selectedDataset?.title).toEqual("datasetTitle");
+        // getUploadFiles
+        expect(store.state.adrUpload.uploadFiles).toHaveProperty("outputSummary.resourceFilename", "project1_naomi_summary.html");
+        expect(store.state.adrUpload.uploadFiles).toHaveProperty("outputZip.resourceFilename", "project1_naomi_outputs.zip");
     });
 
     it("uploadFilesToADR sets upload failure and prevents subsequent uploads", async () => {

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -197,6 +197,8 @@ describe("ADR actions", () => {
         expect(commit.mock.calls[3][0]["payload"]).toEqual(success2);
         expect(dispatch.mock.calls.length).toBe(2);
         expect(dispatch.mock.calls[0][0]).toBe("adr/getAndSetDatasets");
+        expect(dispatch.mock.calls[0][1]).toBe("datasetId");
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true});
         expect(dispatch.mock.calls[1][0]).toBe("getUploadFiles");
         expect(mockAxios.history.post.length).toBe(2);
         expect(mockAxios.history.post[0]["data"]).toBe("resourceFileName=file1&resourceId=id1&description=zip");


### PR DESCRIPTION
## Description

* Fix error handling and dataset reload functionality that was broken by splitting ADR state.
* Set `ADRUploadError` rather than `ADRError`, as the former is scoped to (and displayed on) the upload page
* Easiest way to test is to observe (lack of) browser console messages when landing on upload page (when `ADRUploadError` is cleared via mutation), and after uploading (when `adr/getAndSetDatasets` is invoked).
* This could have been spotted via tests if it was checked that `getAndSetDatasets` in particular was actually executed (rather than the action being invoked on the mock). Or if we had an in-browser end-to-end test that checked for JS errors. But any practical suggestions very welcome here - I'm short on ideas.
* Decrease in coverage looks like a false positive related to removal of code

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
