### PR TITLE
mrc-2424 Remove usage of old calibrate endpoing

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -26,7 +26,6 @@ interface HintrAPIClient
     fun submit(data: Map<String, VersionFileWithPath>, modelRunOptions: ModelOptions): ResponseEntity<String>
     fun getStatus(id: String): ResponseEntity<String>
     fun getResult(id: String): ResponseEntity<String>
-    fun calibrate(id: String, calibrationOptions: ModelOptions): ResponseEntity<String>
     fun getPlottingMetadata(iso3: String): ResponseEntity<String>
     fun downloadSpectrum(id: String): ResponseEntity<StreamingResponseBody>
     fun downloadCoarseOutput(id: String): ResponseEntity<StreamingResponseBody>
@@ -119,12 +118,6 @@ class HintrFuelAPIClient(
     override fun getResult(id: String): ResponseEntity<String>
     {
         return get("model/result/${id}")
-    }
-
-    override fun calibrate(id: String, calibrationOptions: ModelOptions): ResponseEntity<String>
-    {
-        val json = objectMapper.writeValueAsString(calibrationOptions)
-        return postJson("model/calibrate/${id}", json)
     }
 
     override fun calibrateSubmit(runId: String, calibrationOptions: ModelOptions): ResponseEntity<String>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
@@ -49,14 +49,6 @@ class ModelRunController(val fileManager: FileManager, val apiClient: HintrAPICl
         return apiClient.cancelModelRun(id)
     }
 
-    @PostMapping("/calibrate/{id}")
-    @ResponseBody
-    fun calibrate(@PathVariable("id") id: String, @RequestBody calibrationOptions: ModelOptions)
-            : ResponseEntity<String>
-    {
-        return apiClient.calibrate(id, calibrationOptions)
-    }
-
     @GetMapping("/options/")
     @ResponseBody
     fun options(): ResponseEntity<String>

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
@@ -73,7 +73,7 @@ class ModelRunTests : SecureIntegrationTests()
     fun `can submit calibrate`()
     {
         val entity = getModelRunEntity()
-        val responseEntity = testRestTemplate.postForEntity<String>("/model/calibrate/1234", entity)
+        val responseEntity = testRestTemplate.postForEntity<String>("/model/calibrate/submit/1234", entity)
         assertError(responseEntity,
                 HttpStatus.BAD_REQUEST,
                 "FAILED_TO_RETRIEVE_RESULT", "Failed to fetch result")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -89,15 +89,6 @@ class HintrApiClientTests
     }
 
     @Test
-    fun `can calibrate`()
-    {
-        val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val result = sut.calibrate("1234", ModelOptions(emptyMap(), versionInfo))
-        assertThat(result.statusCodeValue).isEqualTo(400)
-        JSONValidator().validateError(result.body!!, "FAILED_TO_RETRIEVE_RESULT")
-    }
-
-    @Test
     fun `can submit calibrate`()
     {
         val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
@@ -83,20 +83,6 @@ class ModelRunControllerTests
     }
 
     @Test
-    fun `can calibrate`()
-    {
-        val modelCalibrationOptions = ModelOptions(mapOf(), mapOf())
-        val mockAPIClient = mock<HintrAPIClient> {
-            on { calibrate("testId", modelCalibrationOptions) } doReturn mockResponse
-        }
-        val sut = ModelRunController(mock(), mockAPIClient)
-
-        val result = sut.calibrate("testId", modelCalibrationOptions)
-        assertThat(result).isSameAs(mockResponse)
-
-    }
-
-    @Test
     fun `can submit calibrate`()
     {
         val modelCalibrationOptions = ModelOptions(mapOf(), mapOf())


### PR DESCRIPTION
## Description

The old `/calibrate` endpoint has been removed from hintr and, while we weren't using it in the app any more, we did still have an method in the api client, and an old endpoint and controller method which used it, so the tests for these are now failing. Remove all references to these. Version not updated as no app behaviour changes. 

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
