### PR TITLE
mrc-2223 add enter key event to create project input field 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hint 1.37.0
+
+* User can create a new project when enter key event is pressed
 
 # hint 1.36.0
 

--- a/src/app/static/src/app/components/projects/Projects.vue
+++ b/src/app/static/src/app/components/projects/Projects.vue
@@ -13,6 +13,7 @@
             <div class="my-3 col-6 clearfix">
                 <input type="text" class="form-control"
                        v-translate:placeholder="'projectName'"
+                       @keyup.enter="createProject(newProjectName)"
                        v-model="newProjectName">
                 <div class="invalid-feedback d-inline"
                      v-translate="'uniqueProjectName'"

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.36.0";
+export const currentHintVersion = "1.37.0";

--- a/src/app/static/src/tests/components/projects/projects.test.ts
+++ b/src/app/static/src/tests/components/projects/projects.test.ts
@@ -84,6 +84,19 @@ describe("Projects component", () => {
         expect(wrapper.findAll(".invalid-feedback").length).toBe(0);
     });
 
+    it("can create a new project when enter key is pressed", () => {
+        const mockCreateProject = jest.fn();
+        const wrapper = createSut({}, mockCreateProject);
+        const input = wrapper.find("input")
+
+        input.setValue("newProject with enter key");
+        expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
+        input.trigger("keyup.enter")
+
+        expect(mockCreateProject.mock.calls.length).toBe(1);
+        expect(mockCreateProject.mock.calls[0][1]).toBe("newProject with enter key");
+    });
+
     it("shows invalid feedback if name is non unique", () => {
         const wrapper = createSut({previousProjects: [{name: "p1", id: 123, versions: []}]});
         wrapper.find("input").setValue("p1");


### PR DESCRIPTION
Adds enter event to create project field. A user can create a new project when he/she press enter button.

Please describe your changes here

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
