### PR TITLE
Disable failing tests pending ADR fix

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -90,6 +90,7 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
+    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save population from ADR`(isAuthorized: IsAuthorized)
@@ -110,6 +111,7 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
+    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save survey from ADR`(isAuthorized: IsAuthorized)
@@ -122,6 +124,7 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
+    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save ANC from ADR`(isAuthorized: IsAuthorized)
@@ -134,6 +137,7 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
+    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save programme from ADR`(isAuthorized: IsAuthorized)


### PR DESCRIPTION
## Description

Temporarily disable failing tests (4 of 6). Switching dataset from Antarctica to e.g. hard-coding Burundi doesn't work as it has similar problems.

Tests to be reinstated in mrc-2440.

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
