### PR TITLE
mrc-2440 Reinstate tests disabled pending ADR fix

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -233,7 +233,8 @@ class ADRTests : SecureIntegrationTests()
             testRestTemplate.postForEntity<String>("/adr/key", getPostEntityWithKey())
             val resultWithResources = testRestTemplate.getForEntity<String>("/adr/datasets?showInaccessible=false")
             val data = ObjectMapper().readTree(resultWithResources.body!!)["data"]
-            val resource = data[0]["resources"].find { it["resource_type"].textValue() == type }
+            val dataset = data.find { it["name"].textValue() == "antarctica-inputs-unaids-estimates-2021" }
+            val resource = dataset!!["resources"].find { it["resource_type"].textValue() == type }
             resource!!["url"].textValue()
         }
         else

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -191,7 +191,7 @@ class ADRTests : SecureIntegrationTests()
         if (isAuthorized == IsAuthorized.TRUE) {
             val modelCalibrationId = waitForModelRunResult()
             testRestTemplate.postForEntity<String>("/adr/key", getPostEntityWithKey())
-            val url = "/adr/datasets/hint_test/resource/${ConfiguredAppProperties().adrOutputZipSchema}/$modelCalibrationId?resourceFileName=output.zip&description=test"
+            val url = "/adr/datasets/hint_test/resource/${ConfiguredAppProperties().adrOutputSummarySchema}/$modelCalibrationId?resourceFileName=output.html&description=test"
             val createResult = testRestTemplate.postForEntity<String>(url)
             assertSuccess(createResult)
             val resourceId = ObjectMapper().readTree(createResult.body!!)["data"]["id"].textValue()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -90,7 +90,6 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
-    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save population from ADR`(isAuthorized: IsAuthorized)
@@ -111,7 +110,6 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
-    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save survey from ADR`(isAuthorized: IsAuthorized)
@@ -124,7 +122,6 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
-    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save ANC from ADR`(isAuthorized: IsAuthorized)
@@ -137,7 +134,6 @@ class ADRTests : SecureIntegrationTests()
         assertSecureWithSuccess(isAuthorized, result, "ValidateInputResponse")
     }
 
-    @Disabled("mrc-2439")
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
     fun `can save programme from ADR`(isAuthorized: IsAuthorized)


### PR DESCRIPTION
## Description

* Re-enable tests disabled in mrc-2439
* Hard-code Antarctica dataset rather than using the first one returned by the API (currently Aruba, which is missing some required resources)
* Test uploading summary report (HTML) rather than zip as this is more fragile at the ADR end

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
