### PR TITLE
mrc-2485_tests Add Portuguese translation tests and missing translations

### DIFF
--- a/src/app/static/src/app/components/modelOptions/ModelOptions.vue
+++ b/src/app/static/src/app/components/modelOptions/ModelOptions.vue
@@ -6,7 +6,7 @@
         </div>
         <dynamic-form v-if="!loading && !hasOptionsError"
                       v-model="modelOptions"
-                      submit-text="Validate"
+                      :submit-text="validateText"
                       @confirm="confirmEditing"
                       @submit="validate"
                       :required-text="requiredText"
@@ -63,6 +63,7 @@
         currentLanguage: Language
         selectText: string
         requiredText: string
+        validateText: string
     }
 
     interface Data {
@@ -95,6 +96,9 @@
             },
             requiredText() {
                 return i18next.t("required", {lng: this.currentLanguage})
+            },
+            validateText() {
+                return i18next.t("validate", {lng: this.currentLanguage})
             },
             editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation"),
             modelOptions: {

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -4,7 +4,7 @@
         <div id="headers" class="row font-weight-bold pt-2">
             <div class="col-md-1 header-cell"></div>
             <div class="col-md-3 header-cell" v-translate="'projectName'"></div>
-            <div class="col-md-1 header-cell">Versions</div>
+            <div class="col-md-1 header-cell" v-translate="'versions'"></div>
             <div class="col-md-2 header-cell" v-translate="'lastUpdated'"></div>
             <div class="col-md-1 header-cell" v-translate="'load'"></div>
             <div class="col-md-1 header-cell" v-translate="'renameProjectHistoryHeader'"></div>

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -377,9 +377,10 @@
             createProject: mapActionByName(namespace, "createProject"),
             getProjects: mapActionByName(namespace, "getProjects"),
             versionCountLabel(project: Project) {
+                const lng = this.currentLanguage;
                 return project.versions.length == 1
-                    ? "1 version"
-                    : `${project.versions.length} versions`;
+                    ? `1 ${i18next.t("versionCountLabelSingle", {lng})}`
+                    : `${project.versions.length} ${i18next.t("versionCountLabelPlural", {lng})}`;
             },
             versionLabel(version: Version) {
                 return versionLabel(version);

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -212,6 +212,7 @@ export interface Translations {
     usernameValidation: string,
     validate: string,
     validating: string,
+    versions: string,
     xAxis: string,
     year: string
 }
@@ -462,6 +463,7 @@ const en: Translations = {
     usernameValidation: "Please enter your username",
     validate: "Validate",
     validating: "Validating...",
+    versions: "Versions",
     xAxis: "X Axis",
     year: "Year"
 };
@@ -708,6 +710,7 @@ const fr: Partial<Translations> = {
     usernameValidation: "Veuillez entrer votre nom d’utilisateur",
     validate: "Valider",
     validating: "Validation en cours...",
+    versions: "Versions",
     xAxis: "Axe X",
     year: "An"
 };
@@ -891,7 +894,7 @@ const pt: Partial<Translations> = {
     projectsHeaderCreate: "Criar um novo projeto",
     projectsHeaderReturn: "regressar ao projeto atual",
     projectsNoSelfShare: "Os projetos não podem ser partilhados com a conta do próprio utilizador",
-    promoteVersionHeader: "A copiar versão {{ versão }} para um novo projeto",
+    promoteVersionHeader: "A copiar versão {{ version }} para um novo projeto",
     refresh: "Atualizar",
     remove: "remover",
     renameProject: "Mudar o nome do projeto",
@@ -911,7 +914,7 @@ const pt: Partial<Translations> = {
     saveVersionConfirm: "Guardar versão e continuar a editar",
     select: "Selecionar...",
     selectADR: "Selecionar conjunto de dados do ADR",
-    selectedDataset: "Conjunto de dados selecionado,",
+    selectedDataset: "Conjunto de dados selecionado:",
     selectNewFile: "Selecionar novo ficheiro",
     sessionExpired: "A sua sessão expirou. Por favor, atualize a página e inicie sessão novamente. Pode guardar o seu trabalho antes de atualizar.",
     sessionExpiredLogin: "A sua sessão expirou. Por favor, inicie sessão novamente.",
@@ -943,7 +946,7 @@ const pt: Partial<Translations> = {
     uploadComplete: "Carregamento concluído",
     uploadFileOutputSummary: "Relatório de síntese",
     uploadFileOutputZip: "Saídas modelo",
-    uploadFileDataset: "Conjunto de dados,",
+    uploadFileDataset: "Conjunto de dados:",
     uploadFileDesc: "Descrição (isto será anexado aos metadados do ficheiro):",
     uploadFileInstruction: "Por favor, selecione os ficheiros novos ou modificados que devem ser carregados",
     uploadFileOverwrite: "Este ficheiro já existe no ADR e será substituído. O ficheiro foi atualizado ",
@@ -953,6 +956,7 @@ const pt: Partial<Translations> = {
     usernameValidation: "Por favor, introduza o seu nome de utilizador",
     validate: "Validar",
     validating: "A validar...",
+    versions: "Versões",
     xAxis: "Eixo X",
     year: "Ano"
 };

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -921,7 +921,7 @@ const pt: Partial<Translations> = {
     sharedBy: "Partilhado por",
     shareProject: "Partilhar projeto",
     shareProjectInstructions: "<p>" +
-        "Isto irá criar uma cópia de {{ projeto }} para os utilizadores em causa." +
+        "Isto irá criar uma cópia de {{ project }} para os utilizadores em causa." +
         "</p>" +
         "<p>" +
         " Por favor, introduza os endereços de e-mail com os quais gostaria de partilhar este projeto. " +

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -212,6 +212,8 @@ export interface Translations {
     usernameValidation: string,
     validate: string,
     validating: string,
+    versionCountLabelPlural: string,
+    versionCountLabelSingle: string,
     versions: string,
     xAxis: string,
     year: string
@@ -463,6 +465,8 @@ const en: Translations = {
     usernameValidation: "Please enter your username",
     validate: "Validate",
     validating: "Validating...",
+    versionCountLabelPlural: "versions",
+    versionCountLabelSingle: "version",
     versions: "Versions",
     xAxis: "X Axis",
     year: "Year"
@@ -710,6 +714,8 @@ const fr: Partial<Translations> = {
     usernameValidation: "Veuillez entrer votre nom d’utilisateur",
     validate: "Valider",
     validating: "Validation en cours...",
+    versionCountLabelPlural: "versions",
+    versionCountLabelSingle: "version",
     versions: "Versions",
     xAxis: "Axe X",
     year: "An"
@@ -956,6 +962,8 @@ const pt: Partial<Translations> = {
     usernameValidation: "Por favor, introduza o seu nome de utilizador",
     validate: "Validar",
     validating: "A validar...",
+    versionCountLabelPlural: "versões",
+    versionCountLabelSingle: "versão",
     versions: "Versões",
     xAxis: "Eixo X",
     year: "Ano"

--- a/src/app/static/src/app/store/translations/registerTranslations.ts
+++ b/src/app/static/src/app/store/translations/registerTranslations.ts
@@ -11,7 +11,8 @@ export default <S extends TranslatableState>(store: Store<S>) => {
         lng: Language.en,
         resources: {
             en: {translation: locales.en},
-            fr: {translation: locales.fr}
+            fr: {translation: locales.fr},
+            pt: {translation: locales.pt}
         },
         fallbackLng: Language.en
     });

--- a/src/app/static/src/scss/partials/files.scss
+++ b/src/app/static/src/scss/partials/files.scss
@@ -22,3 +22,13 @@
     width: 90px;
   }
 }
+
+.pt {
+  .custom-file-label:not(.uploading)::after {
+    content: "Navegar" !important;
+  }
+
+  .custom-file-label.uploading::after {
+    width: 90px;
+  }
+}

--- a/src/app/static/src/scss/partials/files.scss
+++ b/src/app/static/src/scss/partials/files.scss
@@ -27,8 +27,4 @@
   .custom-file-label:not(.uploading)::after {
     content: "Navegar" !important;
   }
-
-  .custom-file-label.uploading::after {
-    width: 90px;
-  }
 }

--- a/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
@@ -129,8 +129,8 @@ describe("adr integration", () => {
         expect(renders.findAll(ADRKey).length).toBe(1);
         const spans = (renders.find("#adr-capacity").findAll("span"))
 
-        expectTranslated(spans.at(0), "ADR access level:", "Niveau d'accès ADR:", store)
-        expectTranslated(spans.at(1), "Read & Write", "Lecture et écriture", store)
+        expectTranslated(spans.at(0), "ADR access level:", "Niveau d'accès ADR:", "Nível de acesso ADR:", store)
+        expectTranslated(spans.at(1), "Read & Write", "Lecture et écriture", "Leitura e Escrita", store)
         expect(mockTooltip.mock.calls[0][1].value).toBe("You have read and write permissions for this dataset and may push output files to ADR");
     });
 
@@ -146,8 +146,8 @@ describe("adr integration", () => {
         expect(renders.findAll(ADRKey).length).toBe(1);
         const spans = (renders.find("#adr-capacity").findAll("span"))
 
-        expectTranslated(spans.at(0), "ADR access level:", "Niveau d'accès ADR:", store)
-        expectTranslated(spans.at(1), "Read only", "Lecture seule", store)
+        expectTranslated(spans.at(0), "ADR access level:", "Niveau d'accès ADR:","Nível de acesso ADR:", store)
+        expectTranslated(spans.at(1), "Read only", "Lecture seule", "Apenas leitura", store)
         expect(mockTooltip.mock.calls[0][1].value).toBe("You do not currently have write permissions for this dataset and will be unable to upload files to ADR");
     });
 

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -220,7 +220,8 @@ describe("select dataset", () => {
     it("renders select dataset button when no dataset is selected", () => {
         let store = getStore()
         const rendered = shallowMount(SelectDataset, {store});
-        expectTranslated(rendered.find("button"), "Select ADR dataset", "Sélectionner l’ensemble de données ADR", store);
+        expectTranslated(rendered.find("button"), "Select ADR dataset",
+            "Sélectionner l’ensemble de données ADR", "Selecionar conjunto de dados do ADR", store);
     });
 
     it("renders edit dataset button when dataset is already selected", () => {
@@ -228,7 +229,7 @@ describe("select dataset", () => {
             selectedDataset: fakeDataset
         })
         const rendered = shallowMount(SelectDataset, {store});
-        expectTranslated(rendered.find("button"), "Edit", "Éditer", store);
+        expectTranslated(rendered.find("button"), "Edit", "Éditer", "Editar", store);
     });
 
     it("does not render refresh button or info icon when no resources are out of date", () => {
@@ -252,8 +253,8 @@ describe("select dataset", () => {
             stubs: ["tree-select"]
         });
         const buttons = rendered.findAll("button");
-        expectTranslated(buttons.at(0), "Refresh", "Rafraîchir", store);
-        expectTranslated(buttons.at(1), "Edit", "Éditer", store);
+        expectTranslated(buttons.at(0), "Refresh", "Rafraîchir", "Atualizar", store);
+        expectTranslated(buttons.at(1), "Edit", "Éditer", "Editar", store);
 
         expect(rendered.findAll(InfoIcon).length).toBe(1);
 
@@ -345,8 +346,10 @@ describe("select dataset", () => {
         expect(modal.props("open")).toBe(true);
         expectTranslated(modal.find("#fetch-error div"),
             "There was an error fetching datasets from ADR",
-            "Une erreur s'est produite lors de la récupération des ensembles de données à partir d'ADR", store);
-        expectTranslated(modal.find("#fetch-error button"), "Try again", "Réessayer", store);
+            "Une erreur s'est produite lors de la récupération des ensembles de données à partir d'ADR",
+            "Ocorreu um erro ao obter conjuntos de dados do ADR", store);
+        expectTranslated(modal.find("#fetch-error button"), "Try again", "Réessayer",
+            "Tente novamente", store);
     });
 
     it("Try again button invokes getDatasets action", async () => {
@@ -423,7 +426,8 @@ describe("select dataset", () => {
             selectedDataset: fakeDataset
         })
         const rendered = shallowMount(SelectDataset, {store});
-        expectTranslated(rendered.find(".font-weight-bold"), "Selected dataset:", "Ensemble de données sélectionné :", store);
+        expectTranslated(rendered.find(".font-weight-bold"), "Selected dataset:",
+            "Ensemble de données sélectionné :", "Conjunto de dados selecionado:", store);
         expect(rendered.find("a").text()).toBe("Some data");
         expect(rendered.find("a").attributes("href")).toBe("www.adr.com/naomi-data/some-data");
     });
@@ -494,7 +498,7 @@ describe("select dataset", () => {
 
         expect(rendered.find("#fetching-datasets").find(LoadingSpinner).attributes("size")).toBe("xs");
         expectTranslated(rendered.find("#fetching-datasets span"),
-            "Loading datasets", "Chargement de vos ensembles de données", store);
+            "Loading datasets", "Chargement de vos ensembles de données", "A carregar conjuntos de dados", store);
     });
 
     it("sets current dataset", async () => {
@@ -511,7 +515,7 @@ describe("select dataset", () => {
         expect(rendered.findAll(TreeSelect).length).toBe(1);
         expect(rendered.find(Modal).findAll("button").length).toBe(2);
         expect(rendered.findAll("p").length).toBe(0);
-        expectTranslated(rendered.find("h4"), "Browse ADR", "Parcourir ADR", store);
+        expectTranslated(rendered.find("h4"), "Browse ADR", "Parcourir ADR", "Procurar no ADR", store);
 
         rendered.setData({newDatasetId: "id2"});
         rendered.find(Modal).find("button").trigger("click");
@@ -527,6 +531,7 @@ describe("select dataset", () => {
         expectTranslated(rendered.find("p"),
             "Importing files - this may take several minutes. Please do not close your browser.",
             "Importation de fichiers - cela peut prendre plusieurs minutes. Veuillez ne pas fermer votre navigateur.",
+            "Importação de ficheiros - isto pode demorar vários minutos. Por favor, não feche o seu navegador.",
             store);
         expect(rendered.findAll("h4").length).toBe(0);
 

--- a/src/app/static/src/tests/components/baseline/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline/baseline.test.ts
@@ -80,7 +80,7 @@ describe("Baseline upload component", () => {
         const store = createSut({country: "Malawi"});
         const wrapper = shallowMount(Baseline, {store, localVue});
         expectTranslated(wrapper.findAll(ManageFile).at(0).find("label"),
-            "Country: Malawi", "Pays: Malawi", store);
+            "Country: Malawi", "Pays: Malawi", "País: Malawi", store);
     });
 
     it("passes pjnz error to file upload", () => {
@@ -116,7 +116,8 @@ describe("Baseline upload component", () => {
         const store = createSut({validating: true});
         const wrapper = shallowMount(Baseline, {store, localVue});
         const validating = wrapper.find("#baseline-validating");
-        expectTranslated(validating.find("span"), "Validating...", "Validation en cours...", store);
+        expectTranslated(validating.find("span"), "Validating...",
+            "Validation en cours...", "A validar...", store);
         expect(validating.findAll(LoadingSpinner).length).toEqual(1)
     });
 

--- a/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
@@ -51,26 +51,27 @@ describe("Download Results component", () => {
 
         const headers = wrapper.findAll("h4");
         expectTranslated(headers.at(0), "Export model outputs for Spectrum",
-            "Exporter des sorties de modèles pour Spectrum", store);
+            "Exporter des sorties de modèles pour Spectrum", "Exportação de saídas modelo para Spectrum", store);
         expectTranslated(headers.at(1), "Download coarse age group outputs",
-            "Télécharger les résultats grossiers du groupe d'âge", store);
+            "Télécharger les résultats grossiers du groupe d'âge",
+            "Descarregar resultados de grupos etários grosseiros", store);
         expectTranslated(headers.at(2), "Download summary report",
-            "Télécharger le rapport de synthèse", store);
+            "Télécharger le rapport de synthèse", "Descarregar relatório de síntese", store);
         expectTranslated(headers.at(3), "Upload to ADR",
-            "Télécharger vers ADR", store);
+            "Télécharger vers ADR", "Carregar para o ADR", store);
 
         const links = wrapper.findAll("a");
         expect(links.length).toBe(3);
-        expectTranslated(links.at(0), "Export", "Exporter", store);
+        expectTranslated(links.at(0), "Export", "Exporter", "Exportação", store);
         expect(links.at(0).attributes().href).toEqual("/download/spectrum/testId");
-        expectTranslated(links.at(1), "Download", "Télécharger", store);
+        expectTranslated(links.at(1), "Download", "Télécharger", "Descarregar", store);
         expect(links.at(1).attributes().href).toEqual("/download/coarse-output/testId");
-        expectTranslated(links.at(2), "Download", "Télécharger", store);
+        expectTranslated(links.at(2), "Download", "Télécharger", "Descarregar", store);
 
         const buttons = wrapper.findAll("button");
         expect(buttons.length).toBe(1);
         expect(buttons.at(0).attributes().href).toEqual("#")
-        expectTranslated(buttons.at(0), "Upload", "Télécharger", store);
+        expectTranslated(buttons.at(0), "Upload", "Télécharger", "Carregar", store);
     });
 
     it(`renders, opens and closes dialog as expected`, async() => {
@@ -130,7 +131,8 @@ describe("Download Results component", () => {
         const statusMessage = wrapper.find("#uploading");
         expect(statusMessage.find("loading-spinner-stub").exists()).toBe(true)
         expectTranslated(statusMessage.find("span"), "Uploading 1 of 2 (this may take a while)",
-            "Téléchargement de 1 sur 2 (cela peut prendre un certain temps)", store);
+            "Téléchargement de 1 sur 2 (cela peut prendre un certain temps)",
+            "A carregar 1 de 2 (este processo poderá demorar um pouco)", store);
 
         const uploadButton = wrapper.find("button");
         expect(uploadButton.attributes("disabled")).toBe("disabled")
@@ -142,7 +144,7 @@ describe("Download Results component", () => {
 
         const statusMessage = wrapper.find("#uploadComplete");
         expectTranslated(statusMessage.find("span"), "Upload complete",
-            "Téléchargement complet", store);
+            "Téléchargement complet", "Carregamento concluído", store);
         expect(statusMessage.find("tick-stub").exists()).toBe(true)
 
         const uploadButton = wrapper.find("button");

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -108,7 +108,7 @@ describe(`uploadModal `, () => {
         const dialog = wrapper.find("#dialog")
         expect(dialog.exists()).toBe(true)
         const text = dialog.find("h4")
-        expectTranslated(text, "Upload to ADR", "Télécharger vers ADR", store)
+        expectTranslated(text, "Upload to ADR", "Télécharger vers ADR", "Carregar para o ADR", store)
     })
 
     it(`renders dataset name as expected`, () => {
@@ -117,7 +117,7 @@ describe(`uploadModal `, () => {
 
         const dataset = wrapper.find("#dialog").find("#dataset-id")
         expectTranslated(dataset, "Dataset: test title",
-            "Base de données: test title", store)
+            "Base de données: test title", "Conjunto de dados: test title", store)
     })
 
     it(`renders instructions text as expected`, () => {
@@ -128,6 +128,7 @@ describe(`uploadModal `, () => {
         expectTranslated(instructions,
             "Please select the new or modified files which should be uploaded",
             "Veuillez sélectionner les fichiers nouveaux ou modifiés qui doivent être téléchargés",
+            "Por favor, selecione os ficheiros novos ou modificados que devem ser carregados",
             store)
     })
 
@@ -139,7 +140,8 @@ describe(`uploadModal `, () => {
         expect(overwriteText.length).toBe(1)
         expectTranslated(overwriteText.at(0), "This file already exists on ADR " +
             "and will be overwritten. File was updated 25/01/2021 06:34:12",
-            "Ce fichier existe déjà sur ADR et sera écrasé. Le fichier a été mis à jour 25/01/2021 06:34:12", store)
+            "Ce fichier existe déjà sur ADR et sera écrasé. Le fichier a été mis à jour 25/01/2021 06:34:12",
+            "Este ficheiro já existe no ADR e será substituído. O ficheiro foi atualizado 25/01/2021 06:34:12", store);
 
         const inputs = wrapper.findAll("input.form-check-input")
         expect(inputs.length).toBe(2)
@@ -151,8 +153,8 @@ describe(`uploadModal `, () => {
         expect(label.at(0).attributes("for")).toBe("id-0-0");
         expect(label.at(1).attributes("for")).toBe("id-0-1");
 
-        expectTranslated(label.at(0), "Model outputs", "Résultats du modèle", store)
-        expectTranslated(label.at(1), "Summary report", "Rapport sommaire", store)
+        expectTranslated(label.at(0), "Model outputs", "Résultats du modèle", "Saídas modelo", store)
+        expectTranslated(label.at(1), "Summary report", "Rapport sommaire", "Relatório de síntese", store)
     })
 
     it(`checkboxes are set by default`, async () => {
@@ -234,8 +236,8 @@ describe(`uploadModal `, () => {
         const wrapper = mount(UploadModal, {store});
         const headers = wrapper.findAll("h5");
         expect(headers.length).toBe(2);
-        expectTranslated(headers.at(0), "Output Files", "Fichiers de sortie", store);
-        expectTranslated(headers.at(1), "Input Files", "Fichiers d'entrée", store);
+        expectTranslated(headers.at(0), "Output Files", "Fichiers de sortie", "Ficheiros de saída", store);
+        expectTranslated(headers.at(1), "Input Files", "Fichiers d'entrée", "Ficheiros de entrada", store);
     });
 
     it("renders input controls as expected when there are input files", () => {

--- a/src/app/static/src/tests/components/files/fileUpload.test.ts
+++ b/src/app/static/src/tests/components/files/fileUpload.test.ts
@@ -71,7 +71,7 @@ describe("File upload component", () => {
             name: "test-name"
         }, undefined, store);
         expectTranslated(wrapper.find(".custom-file-label"), "Select new file",
-            "Sélectionner un nouveau fichier", store);
+            "Sélectionner un nouveau fichier", "Selecionar novo ficheiro", store);
     });
 
     it("calls upload when file is selected", async () => {

--- a/src/app/static/src/tests/components/files/manageFile.test.ts
+++ b/src/app/static/src/tests/components/files/manageFile.test.ts
@@ -87,7 +87,7 @@ describe("Manage file component", () => {
         const wrapper = createSut({
             existingFileName: "existing-name.csv"
         }, undefined, store);
-        expectTranslated(wrapper.find("label.file-name strong"), "File", "Fichier", store);
+        expectTranslated(wrapper.find("label.file-name strong"), "File", "Fichier", "Ficheiro", store);
         expect(wrapper.find("label.file-name").text()).toContain("existing-name.csv");
     });
 
@@ -138,7 +138,7 @@ describe("Manage file component", () => {
         expect(removeLink.text()).toBe("remove");
 
         //should not render File label if no existing filename
-        expectTranslated(wrapper.find(".file-name"), "remove", "supprimer", wrapper.vm.$store);
+        expectTranslated(wrapper.find(".file-name"), "remove", "supprimer", "remover", wrapper.vm.$store);
 
         removeLink.trigger("click");
 

--- a/src/app/static/src/tests/components/header/fileMenu.test.ts
+++ b/src/app/static/src/tests/components/header/fileMenu.test.ts
@@ -103,7 +103,7 @@ describe("File menu", () => {
         expect(wrapper.find(".dropdown-menu").classes()).toStrictEqual(["dropdown-menu", "show"]);
         let link = wrapper.findAll(".dropdown-item").at(0);
         link.trigger("mousedown");
-        expectTranslated(link, "Save", "Sauvegarder", store as any);
+        expectTranslated(link, "Save", "Sauvegarder", "Guardar", store as any);
 
         const hiddenLink = wrapper.find({ref: "save"});
         expect(hiddenLink.attributes("href")).toBe("http://localhost#1234");
@@ -148,7 +148,7 @@ describe("File menu", () => {
         wrapper.find(".dropdown-toggle").trigger("click");
         expect(wrapper.find(".dropdown-menu").classes()).toStrictEqual(["dropdown-menu", "show"]);
         const link = wrapper.findAll(".dropdown-item").at(1);
-        expectTranslated(link, "Load", "Charger", store as any);
+        expectTranslated(link, "Load", "Charger", "Carregar", store as any);
 
         const input = wrapper.find("input").element as HTMLInputElement;
         input.addEventListener("click", function () {
@@ -232,7 +232,7 @@ describe("File menu", () => {
 
         const modal = wrapper.find(Modal);
         modal.find(".btn").trigger("click");
-        expectTranslated(modal.find(".btn"), "OK", "OK", store as any);
+        expectTranslated(modal.find(".btn"), "OK", "OK", "OK", store as any);
         expect(clearErrorMock.mock.calls.length).toBe(1);
     });
 

--- a/src/app/static/src/tests/components/header/languageMenu.test.ts
+++ b/src/app/static/src/tests/components/header/languageMenu.test.ts
@@ -28,11 +28,12 @@ describe("Language menu", () => {
         expect(wrapper.find(DropDown).props("text")).toBe("EN");
     });
 
-    it("changes language", (done) => {
+    it("changes language to French", (done) => {
         const store = createStore();
         const wrapper = mount(LanguageMenu, {
             store
         });
+
         wrapper.findAll(".dropdown-item").at(1).trigger("mousedown");
 
         setTimeout(() => {
@@ -40,6 +41,13 @@ describe("Language menu", () => {
             expect(wrapper.find(DropDown).props("text")).toBe("FR");
             done();
         })
+    });
+
+    it("changes language to Portuguese", (done) => {
+        const store = createStore();
+        const wrapper = mount(LanguageMenu, {
+            store
+        });
 
         wrapper.findAll(".dropdown-item").at(2).trigger("mousedown");
 
@@ -49,6 +57,4 @@ describe("Language menu", () => {
             done();
         })
     });
-
-
 });

--- a/src/app/static/src/tests/components/header/onlineSupportMenu.test.ts
+++ b/src/app/static/src/tests/components/header/onlineSupportMenu.test.ts
@@ -57,7 +57,8 @@ describe("Online support menu", () => {
             .toStrictEqual(["dropdown-menu", "show", "dropdown-menu-right"]);
 
         const link = wrapper.find(".dropdown").find("a");
-        expectTranslated(link, "Online support", "Support en ligne", store as any);
+        expectTranslated(link, "Online support", "Support en ligne",
+            "Apoio online", store as any);
     });
 
     it("renders FAQ menu-item text and link when language is English", () => {
@@ -71,7 +72,7 @@ describe("Online support menu", () => {
         const link = wrapper.findAll(".dropdown-item").at(0);
         expect(link.attributes("href")).toBe("https://mrc-ide.github.io/naomi-troubleshooting/index-en.html");
         expect(link.attributes("target")).toBe("_blank");
-        expectTranslated(link, "FAQ", "FAQ", store as any);
+        expectTranslated(link, "FAQ", "FAQ", "Perguntas Frequentes", store as any);
     });
 
     it("renders FAQ menu-item text and link when lang is French", () => {
@@ -86,7 +87,7 @@ describe("Online support menu", () => {
         const link = wrapper.findAll(".dropdown-item").at(0);
         expect(link.attributes("href")).toBe("https://mrc-ide.github.io/naomi-troubleshooting/index-fr.html");
         expect(link.attributes("target")).toBe("_blank");
-        expectTranslated(link, "FAQ", "FAQ", store as any);
+        expectTranslated(link, "FAQ", "FAQ", "Perguntas Frequentes", store as any);
     });
 
     it("renders Contact menu-item text and link when modelBugReport switch is true", () => {
@@ -106,7 +107,7 @@ describe("Online support menu", () => {
 
         expect(link.attributes("href")).toBe(expectedHref);
         expect(link.attributes("target")).toBe("_blank");
-        expectTranslated(link, "Contact", "Contact", store as any);
+        expectTranslated(link, "Contact", "Contact", "Contacto",  store as any);
 
     });
 
@@ -125,7 +126,7 @@ describe("Online support menu", () => {
 
         expect(link.attributes("href")).toBe(expectedHref);
         expect(link.attributes("target")).toBe("_blank");
-        expectTranslated(link, "Contact", "Contact", store as any);
+        expectTranslated(link, "Contact", "Contact", "Contacto", store as any);
     });
 
     it("renders accessibility menu-item text and link", () => {
@@ -138,6 +139,6 @@ describe("Online support menu", () => {
 
         const link = wrapper.find("router-link-stub");
         expect(link.attributes("to")).toBe("/accessibility");
-        expectTranslated(link, "Accessibility", "Accessibilité", store as any);
+        expectTranslated(link, "Accessibility", "Accessibilité", "Acessibilidade", store as any);
     });
 });

--- a/src/app/static/src/tests/components/header/userHeader.test.ts
+++ b/src/app/static/src/tests/components/header/userHeader.test.ts
@@ -14,16 +14,16 @@ import OnlineSupportMenu from "../../../app/components/header/OnlineSupportMenu.
 
 const localVue = createLocalVue();
 
-const createFrenchStore = () => {
-    const frStore = new Vuex.Store({
+const createLanguageStore = (language: Language) => {
+    const store = new Vuex.Store({
         state: {
             ...emptyState(),
-            language: Language.fr
+            language
         },
         getters: getters
     });
-    registerTranslations(frStore);
-    return frStore;
+    registerTranslations(store);
+    return store;
 };
 
 describe("user header", () => {
@@ -51,7 +51,7 @@ describe("user header", () => {
         const wrapper = getWrapper(currentUser, store);
         const logoutLink = wrapper.find("a[href='/logout']");
         const loginLink = wrapper.findAll("a[href='/login']");
-        expectTranslated(logoutLink, "Logout", "Fermer une session", store);
+        expectTranslated(logoutLink, "Logout", "Fermer une session", "Sair", store);
         expect(loginLink.length).toBe(0);
     });
 
@@ -61,7 +61,7 @@ describe("user header", () => {
         const wrapper = getWrapper(currentUser, store);
         const loginInfo = wrapper.find("span");
         expectTranslated(loginInfo, "Logged in as someone@email.com",
-            "Connecté en tant que someone@email.com", store);
+            "Connecté en tant que someone@email.com", "Sessão iniciada como", store);
     });
 
     it("contains login link if user is guest", () => {
@@ -70,7 +70,7 @@ describe("user header", () => {
         const wrapper = getWrapper(currentUser, store);
         const logoutLink = wrapper.findAll("a[href='/logout']");
         const loginLink = wrapper.find("a[href='/login']");
-        expectTranslated(loginLink, "Log In", "Ouvrir une session", store);
+        expectTranslated(loginLink, "Log In", "Ouvrir une session", "Iniciar Sessão", store);
         expect(logoutLink.length).toBe(0);
     });
 
@@ -93,17 +93,21 @@ describe("user header", () => {
         expect(wrapper.findAll(OnlineSupportMenu).length).toBe(1);
     })
 
-    it("computes language", () => {
+    it("computes help filename", () => {
         const store = createStore()
         const wrapper = shallowMount(UserHeader, {localVue, store, stubs: ["router-link"]});
         const vm = (wrapper as any).vm;
         expect(vm.helpFilename).toStrictEqual("Naomi-basic-instructions.pdf");
 
-        const frStore = createFrenchStore();
+        const frStore = createLanguageStore(Language.fr);
         const frWrapper = shallowMount(UserHeader, {localVue, store: frStore, stubs: ["router-link"]});
         const frVm = (frWrapper as any).vm;
         expect(frVm.helpFilename).toStrictEqual("Naomi-instructions-de-base.pdf");
 
+        const ptStore = createLanguageStore(Language.pt);
+        const ptWrapper = shallowMount(UserHeader, {localVue, store: ptStore, stubs: ["router-link"]});
+        const ptVm = (ptWrapper as any).vm;
+        expect(ptVm.helpFilename).toStrictEqual("Naomi-basic-instructions.pdf");
     });
 
     it("contains Basic steps document links", () => {
@@ -111,9 +115,13 @@ describe("user header", () => {
         const wrapper = shallowMount(UserHeader, {store, stubs: ["router-link"]});
         expect(wrapper.find("a[href='public/resources/Naomi-basic-instructions.pdf']").text()).toBe("Basic steps");
 
-        const frStore = createFrenchStore();
+        const frStore = createLanguageStore(Language.fr);
         const frWrapper = shallowMount(UserHeader, {store: frStore, stubs: ["router-link"]});
         expect(frWrapper.find("a[href='public/resources/Naomi-instructions-de-base.pdf']").text()).toBe("Etapes de base");
+
+        const ptStore = createLanguageStore(Language.pt);
+        const ptWrapper = shallowMount(UserHeader, {store: ptStore, stubs: ["router-link"]});
+        expect(ptWrapper.find("a[href='public/resources/Naomi-basic-instructions.pdf']").text()).toBe("Passos básicos");
     });
 
     it("renders Projects link as expected if user is not guest", () => {
@@ -122,7 +130,7 @@ describe("user header", () => {
 
         const link = wrapper.find("router-link-stub");
         expect(link.attributes("to")).toBe("/projects");
-        expectTranslated(link, "Projects", "Projets", store);
+        expectTranslated(link, "Projects", "Projets", "Projetos", store);
     });
 
     it("does not render Projects link if current user is guest", () => {

--- a/src/app/static/src/tests/components/header/userHeader.test.ts
+++ b/src/app/static/src/tests/components/header/userHeader.test.ts
@@ -61,7 +61,7 @@ describe("user header", () => {
         const wrapper = getWrapper(currentUser, store);
         const loginInfo = wrapper.find("span");
         expectTranslated(loginInfo, "Logged in as someone@email.com",
-            "Connecté en tant que someone@email.com", "Sessão iniciada como", store);
+            "Connecté en tant que someone@email.com", "Sessão iniciada como someone@email.com", store);
     });
 
     it("contains login link if user is guest", () => {

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -62,7 +62,7 @@ describe("Model calibrate component", () => {
         const wrapper = getWrapper(store);
         expect(wrapper.find(LoadingSpinner).exists()).toBe(true);
         expectTranslated(wrapper.find("#loading-message"), "Loading options",
-            "Chargement de vos options.", store);
+            "Chargement de vos options.", "Opções de carregamento", store);
         expect(wrapper.find(DynamicForm).exists()).toBe(false);
         expect(wrapper.find("#calibration-complete").exists()).toBe(false);
         expect(wrapper.find(ErrorAlert).exists()).toBe(false);
@@ -90,7 +90,7 @@ describe("Model calibrate component", () => {
         expect(form.find("h3").text()).toBe("Test Section");
         expect(form.find(".text-muted").text()).toBe("Just a test section");
         expect((form.find("input").element as HTMLInputElement).value).toBe("5");
-        expectTranslated(wrapper.find("button"), "Calibrate", "Calibrer", store);
+        expectTranslated(wrapper.find("button"), "Calibrate", "Calibrer", "Calibrar", store);
         expect(wrapper.find("button").classes()).toContain("btn-submit");
         expect(wrapper.find("button").classes()).not.toContain("btn-secondary");
         expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(false);
@@ -114,7 +114,7 @@ describe("Model calibrate component", () => {
         const wrapper = getWrapper(store);
         expect(wrapper.find("#calibration-complete").find(Tick).exists()).toBe(true);
         expectTranslated(wrapper.find("#calibration-complete h4"), "Calibration complete",
-            "Calibrage du modèle terminé", store);
+            "Calibrage du modèle terminé", "Calibração concluída", store);
     });
 
     it("renders error", () => {
@@ -129,7 +129,7 @@ describe("Model calibrate component", () => {
         const wrapper = getWrapper(store);
         expect(wrapper.find("#calibrating").find(LoadingSpinner).exists()).toBe(true);
         expectTranslated(wrapper.find("#calibrating"), "Calibrating...",
-            "Calibrage en cours...", store);
+            "Calibrage en cours...", "Calibrar...", store);
         expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.find("button").classes()).toContain("btn-secondary");
         expect(wrapper.find("button").classes()).not.toContain("btn-submit");

--- a/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
+++ b/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
@@ -91,7 +91,7 @@ describe("Model options component", () => {
         expect(rendered.findAll(DynamicForm).length).toBe(0);
         expect(rendered.findAll(LoadingSpinner).length).toBe(1);
         expectTranslated(rendered.find("#loading-message"), "Loading options",
-            "Chargement de vos options.", store);
+            "Chargement de vos options.", "Opções de carregamento", store);
     });
 
     it("renders as expected while validating", () => {
@@ -99,14 +99,14 @@ describe("Model options component", () => {
         const rendered = shallowMount(ModelOptions, {store});
         expect(rendered.find("#validating").find(LoadingSpinner).exists()).toBe(true);
         expectTranslated(rendered.find("#validating"), "Validating...",
-            "Validation en cours...", store);
+            "Validation en cours...", "A validar...", store);
     });
 
     it("displays tick and message if valid is true", () => {
         const store = createStore({valid: true});
         const rendered = shallowMount(ModelOptions, {store});
         expectTranslated(rendered.find("h4"), "Options are valid",
-            "Les options sont valides", store);
+            "Les options sont valides", "As opções são válidas", store);
         expect(rendered.findAll(Tick).length).toBe(1);
         expect(rendered.find("#validating").exists()).toBe(false);
     });

--- a/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
+++ b/src/app/static/src/tests/components/modelOptions/modelOptions.test.ts
@@ -74,15 +74,25 @@ describe("Model options component", () => {
         const form = rendered.find(DynamicForm);
         expect(form.props("requiredText")).toBe("required");
         expect(form.props("selectText")).toBe("Select...");
+        expect(form.props("submitText")).toBe("Validate");
         expect(rendered.findAll(LoadingSpinner).length).toBe(0);
         expect(rendered.find("#validating").exists()).toBe(false);
     });
 
-    it("translates required text and select text", () => {
+    it("translates required, select and validate text into French", () => {
         const store = createStore({}, mockMutations, mockActions, {language: Language.fr});
         const wrapper = shallowMount(ModelOptions, {store});
         expect(wrapper.find(DynamicForm).props("requiredText")).toBe("obligatoire");
         expect(wrapper.find(DynamicForm).props("selectText")).toBe("Sélectionner...");
+        expect(wrapper.find(DynamicForm).props("submitText")).toBe("Valider");
+    });
+
+    it("translates required, select and validate text into Portuguese", () => {
+        const store = createStore({}, mockMutations, mockActions, {language: Language.pt});
+        const wrapper = shallowMount(ModelOptions, {store});
+        expect(wrapper.find(DynamicForm).props("requiredText")).toBe("necessário");
+        expect(wrapper.find(DynamicForm).props("selectText")).toBe("Selecionar...");
+        expect(wrapper.find(DynamicForm).props("submitText")).toBe("Validar");
     });
 
     it("displays loading spinner while fetching is true", () => {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -142,7 +142,7 @@ describe("ModelOutput component", () => {
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
         const activeTab = wrapper.find("a.active");
-        expectTranslated(activeTab, "Map", "Carte", store);
+        expectTranslated(activeTab, "Map", "Carte", "Mapa", store);
     });
 
     it("gets selected tab from state", () => {
@@ -150,7 +150,7 @@ describe("ModelOutput component", () => {
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
         const activeTab = wrapper.find("a.active");
-        expectTranslated(activeTab, "Bar", "Barre", store);
+        expectTranslated(activeTab, "Bar", "Barre", "Bar", store);
     });
 
     it("can change tabs", () => {

--- a/src/app/static/src/tests/components/modelRun/modelRun.test.ts
+++ b/src/app/static/src/tests/components/modelRun/modelRun.test.ts
@@ -200,7 +200,8 @@ describe("Model run component", () => {
         const wrapper = mount(ModelRun, {store, localVue});
         expect(wrapper.find(Modal).props().open).toBe(true);
         expectTranslated(wrapper.find(Modal).find("h4"), "Initialising model fitting",
-            "Initialisation de l'ajustement du modèle", store);
+            "Initialisation de l'ajustement du modèle",
+            "Inicialização do ajuste do modelo", store);
         expect(wrapper.find(Modal).findAll(LoadingSpinner).length).toBe(1);
         expect(wrapper.find(Modal).findAll(ProgressBar).length).toBe(0);
     });
@@ -286,7 +287,7 @@ describe("Model run component", () => {
         });
         const wrapper = shallowMount(ModelRun, {store, localVue});
         expectTranslated(wrapper.find("#model-run-complete"), "Model fitting complete",
-            "Ajustement du modèle terminé", store);
+            "Ajustement du modèle terminé", "Ajuste de modelo concluído", store);
         expect(wrapper.findAll(Tick).length).toBe(1);
     });
 

--- a/src/app/static/src/tests/components/password/forgotPassword.test.ts
+++ b/src/app/static/src/tests/components/password/forgotPassword.test.ts
@@ -43,13 +43,13 @@ describe("Forgot password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Forgotten your password?",
-            "Vous avez oublié votre mot de passe ?", store);
+            "Vous avez oublié votre mot de passe ?", "Esqueceu-se da sua palavra-passe?", store);
         expect((wrapper.find("input[type='email']").element as HTMLInputElement).value).toEqual("");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='email']"), "Email address",
-            "Adresse e-mail", store, "placeholder");
+            "Adresse e-mail", "Endereço de e-mail", store, "placeholder");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='submit']"),
             "Request password reset email", "Demande de réinitialisation du mot de passe par e-mail",
-            store, "value");
+            "Solicitar e-mail de reposição de palavra-passe", store, "value");
         expect(wrapper.findAll("error-alert-stub").length).toEqual(0);
         expect(wrapper.findAll(".alert-success").length).toEqual(0);
     });
@@ -64,11 +64,11 @@ describe("Forgot password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Forgotten your password?",
-            "Vous avez oublié votre mot de passe ?", store);
+            "Vous avez oublié votre mot de passe ?", "Esqueceu-se da sua palavra-passe?", store);
         expect((wrapper.find("input[type='email']").element as HTMLInputElement).value).toEqual("");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='submit']"),
             "Request password reset email", "Demande de réinitialisation du mot de passe par e-mail",
-            store, "value");
+            "Solicitar e-mail de reposição de palavra-passe", store, "value");
         expect(wrapper.findAll("error-alert-stub").length).toEqual(1);
         expect(wrapper.find(ErrorAlert).props().error).toBe(error);
         expect(wrapper.findAll(".alert-success").length).toEqual(0);
@@ -83,16 +83,17 @@ describe("Forgot password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Forgotten your password?",
-            "Vous avez oublié votre mot de passe ?", store);
+            "Vous avez oublié votre mot de passe ?", "Esqueceu-se da sua palavra-passe?", store);
         expect((wrapper.find("input[type='email']").element as HTMLInputElement).value).toEqual("");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='submit']"),
             "Request password reset email", "Demande de réinitialisation du mot de passe par e-mail",
-            store, "value");
+            "Solicitar e-mail de reposição de palavra-passe", store, "value");
         expect(wrapper.findAll("error-alert-stub").length).toEqual(0);
         expect(wrapper.findAll(".alert-success").length).toEqual(1);
         expectTranslatedWithStoreType<PasswordState>(wrapper.find(".alert-success"),
             "Thank you. If we have an account registered for this email address, you will receive a password reset link.",
             "Merci. Si un compte est enregistré pour cette adresse e-mail, vous recevrez un lien de réinitialisation du mot de passe.",
+            "Obrigado. Se tivermos uma conta registada para este endereço de e-mail, receberá uma ligação de reposição de palavra-passe.",
             store);
     });
 

--- a/src/app/static/src/tests/components/password/resetPassword.test.ts
+++ b/src/app/static/src/tests/components/password/resetPassword.test.ts
@@ -50,10 +50,10 @@ describe("Reset password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Enter a new password",
-            "Veuillez entrer un nouveau mot de passe", store);
+            "Veuillez entrer un nouveau mot de passe", "Introduzir uma nova palavra-passe", store);
         expect((wrapper.find("input[type='password']").element as HTMLInputElement).value).toEqual("");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='submit']"),
-            "Update password", "Mettre à jour le mot de passe", store, "value");
+            "Update password", "Mettre à jour le mot de passe", "Atualizar palavra-passe", store, "value");
         expect(wrapper.findAll("error-alert-stub").length).toEqual(0);
         expect(wrapper.findAll("#password-was-reset").length).toEqual(0);
     });
@@ -68,17 +68,20 @@ describe("Reset password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Enter a new password",
-            "Veuillez entrer un nouveau mot de passe", store);
+            "Veuillez entrer un nouveau mot de passe", "Introduzir uma nova palavra-passe", store);
         expect((wrapper.find("input[type='password']").element as HTMLInputElement).value).toEqual("");
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("input[type='submit']"),
-            "Update password", "Mettre à jour le mot de passe", store, "value");
+            "Update password", "Mettre à jour le mot de passe","Atualizar palavra-passe", store, "value");
         expect(wrapper.findAll("error-alert-stub").length).toEqual(1);
         expect(wrapper.find("error-alert-stub").props().error).toBe(error);
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("#request-new-link"),
             "This password reset link is not valid. It may have expired or already been used.\n" +
             "Please request another link here.",
             "Ce lien de réinitialisation du mot de passe n'est pas valide. Il peut avoir expiré ou avoir déjà été utilisé. " +
-            "Veuillez cliquer ici pour demander un autre lien.", store);
+            "Veuillez cliquer ici pour demander un autre lien.",
+            "Esta ligação de reposição de palavra-passe não é válida. Pode ter expirado ou já ter sido utilizada. " +
+            "Por favor, solicite outra ligação aqui.",
+            store);
         expect((wrapper.find("#request-new-link a").element as HTMLLinkElement).href)
             .toEqual("http://localhost/password/forgot-password");
         expect(wrapper.findAll("#password-was-reset").length).toEqual(0);
@@ -93,14 +96,15 @@ describe("Reset password component", () => {
         const wrapper = createSut(store);
 
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("h3"), "Enter a new password",
-            "Veuillez entrer un nouveau mot de passe", store);
+            "Veuillez entrer un nouveau mot de passe", "Introduzir uma nova palavra-passe", store);
         expect(wrapper.findAll("input[type='password']").length).toEqual(0);
         expect(wrapper.findAll("input[type='submit']").length).toEqual(0);
         expect(wrapper.findAll("error-alert-stub").length).toEqual(0);
         expect(wrapper.findAll("#password-was-reset").length).toEqual(1);
         expectTranslatedWithStoreType<PasswordState>(wrapper.find("#password-was-reset"),
             "Thank you, your password has been updated. Click here to login.",
-            "Merci, votre mot de passe a été mis à jour. Cliquez ici pour vous connecter.", store);
+            "Merci, votre mot de passe a été mis à jour. Cliquez ici pour vous connecter.",
+            "Obrigado, a sua palavra-passe foi atualizada. Clique aqui para iniciar sessão.", store);
     });
 
     it("invokes resetPassword action", (done) => {

--- a/src/app/static/src/tests/components/plots/mapEmptyFeature.test.ts
+++ b/src/app/static/src/tests/components/plots/mapEmptyFeature.test.ts
@@ -30,7 +30,8 @@ describe("MapEmptyFeature component", () => {
         expect(wrapper.findAll(LControl).length).toBe(1)
         const noMapData = wrapper.find(LControl).find("span")
         expectTranslated(noMapData, "No data are available for the selected combination. Please review the combination of filter values selected.",
-            "Aucune donnée n'est disponible pour la combinaison sélectionnée. Veuillez examiner la combinaison de valeurs de filtre sélectionnée.", store as any)
+            "Aucune donnée n'est disponible pour la combinaison sélectionnée. Veuillez examiner la combinaison de valeurs de filtre sélectionnée.",
+            "Não existem dados disponíveis para a combinação selecionada. Por favor, reveja a combinação dos valores de filtro selecionados.", store as any)
     });
 
 });

--- a/src/app/static/src/tests/components/plots/resetMap.test.ts
+++ b/src/app/static/src/tests/components/plots/resetMap.test.ts
@@ -22,8 +22,10 @@ describe("ResetMap component", () => {
         const wrapper = getWrapper();
         expect(wrapper.findAll(LControl).length).toBe(1)
         const button = wrapper.find(LControl).find('div').find('a')
-        expectTranslated(button, 'Reset view', 'Réinitialiser la vue', store, "aria-label");
-        expectTranslated(button, 'Reset view', 'Réinitialiser la vue', store, "title");
+        expectTranslated(button, 'Reset view', 'Réinitialiser la vue',
+            "Repor vista", store, "aria-label");
+        expectTranslated(button, 'Reset view', 'Réinitialiser la vue',
+            "Repor vista", store, "title");
         
         button.trigger("click")
         expect(wrapper.emitted("reset-view")).toBeTruthy();

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -150,14 +150,14 @@ describe("Project history component", () => {
         const headers = wrapper.find("#headers").findAll(".header-cell");
         expect(headers.length).toBe(9);
         expect(headers.at(0).text()).toBe("");
-        expectTranslated(headers.at(1), "Project name", "Nom du projet", store);
-        expectTranslated(headers.at(2), "Versions", "Versions", store);
-        expectTranslated(headers.at(3), "Last updated", "Dernière mise à jour", store);
-        expectTranslated(headers.at(4), "Load", "Charger", store);
-        expectTranslated(headers.at(5), "Rename", "Renommer le projet", store);
-        expectTranslated(headers.at(6), "Delete", "Supprimer", store);
-        expectTranslated(headers.at(7), "Copy to", "Copier", store);
-        expectTranslated(headers.at(8), "Share", "Partager", store);
+        expectTranslated(headers.at(1), "Project name", "Nom du projet", "Nome do projeto", store);
+        expectTranslated(headers.at(2), "Versions", "Versions","Versões", store);
+        expectTranslated(headers.at(3), "Last updated", "Dernière mise à jour", "Última atualização", store);
+        expectTranslated(headers.at(4), "Load", "Charger", "Carregar", store);
+        expectTranslated(headers.at(5), "Rename", "Renommer le projet", "Mudar o nome", store);
+        expectTranslated(headers.at(6), "Delete", "Supprimer", "Eliminar", store);
+        expectTranslated(headers.at(7), "Copy to", "Copier", "Copiar para", store);
+        expectTranslated(headers.at(8), "Share", "Partager", "Partilhar", store);
 
         testRendersProject(wrapper, 1, "proj1",  isoDates[1], 2);
         const proj1Versions = wrapper.find("#versions-1");
@@ -223,10 +223,10 @@ describe("Project history component", () => {
 
         const modal = wrapper.find(".modal");
         expect(modal.classes()).toContain("show");
-        expectTranslated(modal.find(".modal-body"), "Delete project?", "Supprimer ce projet?", store);
+        expectTranslated(modal.find(".modal-body"), "Delete project?", "Supprimer ce projet?", "Eliminar projeto?", store);
         const buttons = modal.find(".modal-footer").findAll("button");
-        expectTranslated(buttons.at(0), "OK", "OK", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "OK", "OK", "OK", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
     });
 
     it("shows modal when click delete version link", async () => {
@@ -238,10 +238,11 @@ describe("Project history component", () => {
 
         const modal = wrapper.find(".modal");
         expect(modal.classes()).toContain("show");
-        expectTranslated(modal.find(".modal-body"), "Delete version?", "Supprimer cette version?", store);
+        expectTranslated(modal.find(".modal-body"), "Delete version?",
+            "Supprimer cette version?", "Eliminar versão?", store);
         const buttons = modal.find(".modal-footer").findAll("button");
-        expectTranslated(buttons.at(0), "OK", "OK", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "OK", "OK","OK", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
     });
 
     it("invokes deleteProject action when confirm delete", async () => {
@@ -338,13 +339,16 @@ describe("Project history component", () => {
         const modal = wrapper.findAll(".modal").at(2);
         expect(modal.classes()).toContain("show");
         expectTranslated(modal.find(".modal-body h4"), "Please enter a new name for the project",
-            "Veuillez entrer un nouveau nom pour le projet", store);
+            "Veuillez entrer un nouveau nom pour le projet",
+            "Por favor, introduza um novo nome para o projeto", store);
 
         const input = modal.find("input")
-        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        expectTranslated(input, "Project name", "Nom du projet", "Nome do projeto",
+            store, "placeholder");
         const buttons = modal.find(".modal-footer").findAll("button");
-        expectTranslated(buttons.at(0), "Rename project", "Renommer le projet", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "Rename project", "Renommer le projet",
+            "Mudar o nome do projeto", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
 
         const cancelButton = buttons.at(1);
         cancelButton.trigger("click");
@@ -377,15 +381,17 @@ describe("Project history component", () => {
         const modal = wrapper.findAll(".modal").at(1);
         expect(modal.classes()).toContain("show");
         expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
-            "Copie de la version v1 dans un nouveau projet", store);
+            "Copie de la version v1 dans un nouveau projet",
+            "A copiar versão v1 para um novo projeto", store);
         expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
-            "Veuillez entrer un nom pour le nouveau projet", store);
+            "Veuillez entrer un nom pour le nouveau projet",
+            "Por favor, introduza um nome para o novo projecto", store);
 
         const input = modal.find("input")
-        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        expectTranslated(input, "Project name", "Nom du projet","Nome do projeto", store, "placeholder");
         const buttons = modal.find(".modal-footer").findAll("button");
-        expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "Create project", "Créer un projet", "Criar projeto", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
 
         const cancelButton = buttons.at(1);
         cancelButton.trigger("click");
@@ -404,14 +410,16 @@ describe("Project history component", () => {
         const modal = wrapper.findAll(".modal").at(1);
         expect(modal.classes()).toContain("show");
         expectTranslated(modal.find(".modal-body h4"), "Copying version v1 to a new project",
-            "Copie de la version v1 dans un nouveau projet", store);
+            "Copie de la version v1 dans un nouveau projet",
+            "A copiar versão v1 para um novo projeto", store);
         expectTranslated(modal.find(".modal-body h5"), "Please enter a name for the new project",
-            "Veuillez entrer un nom pour le nouveau projet", store);
+            "Veuillez entrer un nom pour le nouveau projet",
+            "Por favor, introduza um nome para o novo projecto", store);
         const input = modal.find("input");
-        expectTranslated(input, "Project name", "Nom du projet", store, "placeholder");
+        expectTranslated(input, "Project name", "Nom du projet", "Nome do projeto", store, "placeholder");
         const buttons = modal.find(".modal-footer").findAll("button");
-        expectTranslated(buttons.at(0), "Create project", "Créer un projet", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "Create project", "Créer un projet", "Criar projeto", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
 
         const cancelButton = buttons.at(1);
         cancelButton.trigger("click");
@@ -630,7 +638,7 @@ describe("Project history component", () => {
         const modal = wrapper.findAll(".modal").at(1);
         const textarea = modal.find("#promoteNote label");
         expectTranslated(textarea, "Notes: (your reason for copying project)",
-            "Notes : (votre motif pour copier le projet)" , store)
+            "Notes : (votre motif pour copier le projet)" , "Notas: (a sua razão para copiar o projeto)", store)
     });
 
 });

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -113,7 +113,11 @@ describe("Project history component", () => {
         expect(svg.at(1).classes()).toContain("when-open");
         expect(svg.at(1).classes()).toContain("feather-chevron-down");
         expect(v.at(1).find("a").text()).toContain(name);
-        expect(v.at(2).text()).toBe(versionsCount === 1 ? "1 version" : `${versionsCount} versions`);
+
+        const versionCountLabel = versionsCount === 1 ? "1 version" : `${versionsCount} versions`;
+        const ptVersionCountLabel = versionsCount === 1 ? "1 versão" : `${versionsCount} versões`;
+        expectTranslated(v.at(2), versionCountLabel, versionCountLabel, ptVersionCountLabel, wrapper.vm.$store);
+
         expect(v.at(3).text()).toBe(formatDateTime(updatedIsoDate));
         expect(v.at(4).classes()).toContain("load-cell");
         expect(v.at(5).classes()).toContain("rename-cell");

--- a/src/app/static/src/tests/components/projects/projects.test.ts
+++ b/src/app/static/src/tests/components/projects/projects.test.ts
@@ -54,13 +54,14 @@ describe("Projects component", () => {
         expect(wrapper.find("#projects-content").exists()).toBe(true);
 
         expectTranslated(wrapper.find("#projects-header"), "Create a new project",
-            "Créer un nouveau projet", store);
+            "Créer un nouveau projet", "Criar um novo projeto", store);
         expectTranslated(wrapper.find("p"), "Your work is organised into projects. Each project contains its own data and settings.",
-            "Votre travail est organisé en projets. Chaque projet contient ses propres données et paramètres.", store);
+            "Votre travail est organisé en projets. Chaque projet contient ses propres données et paramètres.",
+            "O seu trabalho está organizado em projetos. Cada projeto contém os seus próprios dados e definições.", store);
         expectTranslated(wrapper.find("input"), "Project name",
-            "Nom du projet", store, "placeholder");
+            "Nom du projet", "Nome do projeto", store, "placeholder");
         expectTranslated(wrapper.find("button"), "Create project",
-            "Créer un projet", store);
+            "Créer un projet", "Criar projeto", store);
         expect(wrapper.find("button").attributes("disabled")).toBe("disabled");
         expect(wrapper.find(ErrorAlert).exists()).toBe(false);
     });
@@ -70,10 +71,12 @@ describe("Projects component", () => {
         const store = wrapper.vm.$store;
 
         expectTranslated(wrapper.find("p"), "Your work is organised into projects. Each project contains its own data and settings.",
-            "Votre travail est organisé en projets. Chaque projet contient ses propres données et paramètres.", store);
+            "Votre travail est organisé en projets. Chaque projet contient ses propres données et paramètres.",
+            "O seu trabalho está organizado em projetos. Cada projeto contém os seus próprios dados e definições.", store);
         expectTranslated(wrapper.find("#projects-header"),
             "Create a new project or return to current project (existingProject)",
-            "Créer un nouveau projet ou retour au projet actuel (existingProject)", store);
+            "Créer un nouveau projet ou retour au projet actuel (existingProject)",
+            "Criar um novo projeto ou regressar ao projeto atual (existingProject)", store);
         expect(wrapper.find("#projects-header a").exists()).toBe(true);
     });
 

--- a/src/app/static/src/tests/components/projects/shareProject.test.ts
+++ b/src/app/static/src/tests/components/projects/shareProject.test.ts
@@ -94,7 +94,8 @@ describe("ShareProject", () => {
         const text = modal.find(".text-danger")
         expect(text.classes()).not.toContain("d-none");
         expectTranslated(text, "This email address is not registered with Naomi",
-            "Cette adresse e-mail n'est pas enregistrée dans Naomi", store as any)
+            "Cette adresse e-mail n'est pas enregistrée dans Naomi",
+            "Este endereço de e-mail não está registado na Naomi", store as any)
         expect(modal.find("button").attributes("disabled")).toBe("disabled");
         expect(modal.find(".help-text").isVisible()).toBe(true);
     });
@@ -120,7 +121,8 @@ describe("ShareProject", () => {
         const text = modal.find(".text-danger")
         expect(text.classes()).not.toContain("d-none");
         expectTranslated(text, "Projects cannot be shared with the user's own account",
-            "Les projets ne peuvent pas être partagés avec le propre compte de l'utilisateur", store as any)
+            "Les projets ne peuvent pas être partagés avec le propre compte de l'utilisateur",
+            "Os projetos não podem ser partilhados com a conta do próprio utilizador", store as any)
         expect(modal.find("button").attributes("disabled")).toBe("disabled");
         expect(modal.find(".help-text").isVisible()).toBe(true);
     });
@@ -146,7 +148,8 @@ describe("ShareProject", () => {
         const text = modal.find(".text-danger")
         expect(text.classes()).not.toContain("d-none");
         expectTranslated(text, "Projects cannot be shared with the user's own account",
-            "Les projets ne peuvent pas être partagés avec le propre compte de l'utilisateur", store as any)
+            "Les projets ne peuvent pas être partagés avec le propre compte de l'utilisateur",
+            "Os projetos não podem ser partilhados com a conta do próprio utilizador", store as any)
         expect(modal.find("button").attributes("disabled")).toBe("disabled");
         expect(modal.find(".help-text").isVisible()).toBe(true);
     });
@@ -181,7 +184,8 @@ describe("ShareProject", () => {
             const text = modal.find(".text-danger");
             expect(text.classes()).not.toContain("d-none");
             expectTranslated(text, "Please remove duplicate emails from the list",
-                "Veuillez supprimer les e-mails en double de la liste", store as any)
+                "Veuillez supprimer les e-mails en double de la liste",
+                "Por favor, remova os e-mails duplicados da lista", store as any)
             expect(modal.find("button").attributes("disabled")).toBe("disabled");
             expect(modal.find(".help-text").isVisible()).toBe(true);
         });
@@ -217,7 +221,8 @@ describe("ShareProject", () => {
             const text = modal.find(".text-danger");
             expect(text.classes()).not.toContain("d-none");
             expectTranslated(text, "Please remove duplicate emails from the list",
-                "Veuillez supprimer les e-mails en double de la liste", store as any)
+                "Veuillez supprimer les e-mails en double de la liste",
+                "Por favor, remova os e-mails duplicados da lista", store as any)
             expect(modal.find("button").attributes("disabled")).toBe("disabled");
             expect(modal.find(".help-text").isVisible()).toBe(true);
         });
@@ -538,7 +543,8 @@ describe("ShareProject", () => {
 
         const link = wrapper.find("button");
         link.trigger("click");
-        expectTranslated(wrapper.find(Modal).find("h4"), "Share project", "Partager ce project", store);
+        expectTranslated(wrapper.find(Modal).find("h4"), "Share project",
+            "Partager ce project", "Partilhar projeto", store);
     });
 
     it("translates instructions", () => {
@@ -560,7 +566,12 @@ describe("ShareProject", () => {
             "Veuillez entrer les adresses e-mails " +
             "avec lesquelles vous souhaitez partager ce projet. Appuyez sur Enter pour ajouter une autre adresse. Ces adresses e-mails doivent être déjà enregistrées dans Naomi."
 
-        expectTranslated(wrapper.find(Modal).find("#instructions"), expectedEnglish, expectedFrench, store);
+        const expectedPortuguese = "Isto irá criar uma cópia de p1 para os utilizadores em causa." +
+            " Por favor, introduza os endereços de e-mail com os quais gostaria de partilhar este projeto. " +
+            "Prima Enter para adicionar um novo endereço. Estes endereços de e-mail já devem estar registados na Naomi.";
+
+
+        expectTranslated(wrapper.find(Modal).find("#instructions"), expectedEnglish, expectedFrench, expectedPortuguese, store);
     });
 
     it("translates button text", () => {
@@ -576,8 +587,8 @@ describe("ShareProject", () => {
         link.trigger("click");
         const buttons = wrapper.find(Modal).findAll("button");
 
-        expectTranslated(buttons.at(0), "OK", "OK", store);
-        expectTranslated(buttons.at(1), "Cancel", "Annuler", store);
+        expectTranslated(buttons.at(0), "OK", "OK", "OK", store);
+        expectTranslated(buttons.at(1), "Cancel", "Annuler", "Cancelar", store);
     });
 
     it("translates help text", () => {
@@ -594,7 +605,8 @@ describe("ShareProject", () => {
         const helpText = wrapper.find(Modal).find(".help-text");
 
         expectTranslated(helpText, "Please correct or remove invalid email addresses",
-            "Veuillez corriger ou supprimer les adresses e-mails non-valides", store);
+            "Veuillez corriger ou supprimer les adresses e-mails non-valides",
+            "Por favor, corrija ou remova endereços de e-mail inválidos", store);
     });
 
     it("can render tooltips without an error", () => {

--- a/src/app/static/src/tests/components/projects/versionStatus.test.ts
+++ b/src/app/static/src/tests/components/projects/versionStatus.test.ts
@@ -39,10 +39,12 @@ describe("Version status component", () => {
 
         const spans = wrapper.findAll(".float-right");
         const projectLabel = spans.at(0);
-        expectTranslated(projectLabel, "Project: Test Project v2", "Projet: Test Project v2", store);
+        expectTranslated(projectLabel, "Project: Test Project v2", "Projet: Test Project v2",
+            "Projeto: Test Project v2", store);
 
         const savedLabel = spans.at(1);
-        expectTranslated(savedLabel, "Last saved 12:45", "Dernier enregistré 12:45", store);
+        expectTranslated(savedLabel, "Last saved 12:45", "Dernier enregistré 12:45",
+            "Último projeto guardada 12:45", store);
         expect(savedLabel.find(CheckIcon).exists()).toBe(true);
     });
 
@@ -57,6 +59,7 @@ describe("Version status component", () => {
         const spans = wrapper.findAll(".float-right");
         expect(spans.length).toBe(1);
         const projectLabel = spans.at(0);
-        expectTranslated(projectLabel, "Project: Test Project v2", "Projet: Test Project v2", store);
+        expectTranslated(projectLabel, "Project: Test Project v2", "Projet: Test Project v2",
+            "Projeto: Test Project v2", store);
     });
 });

--- a/src/app/static/src/tests/components/resetConfirmation.test.ts
+++ b/src/app/static/src/tests/components/resetConfirmation.test.ts
@@ -58,21 +58,25 @@ describe("Reset confirmation modal", () => {
         });
 
         expectTranslated(rendered.find("h4"), "Have you saved your work?",
-            "Avez-vous sauvegardé votre travail ?", store);
+            "Avez-vous sauvegardé votre travail ?", "Já guardou o seu trabalho?", store);
         expectTranslated(rendered.findAll("p").at(0),
             "Changing this will result in the following steps being discarded:",
-            "Si vous modifiez ce paramètre, les étapes suivantes seront abandonnées :", store);
+            "Si vous modifiez ce paramètre, les étapes suivantes seront abandonnées :",
+            "Ao alterar isto, as etapas seguintes serão descartadas:", store);
         expectTranslated(rendered.findAll("p").at(1),
             "You may want to save your work before continuing.",
-            "Vous devriez peut-être sauvegarder votre travail avant de poursuivre.", store);
+            "Vous devriez peut-être sauvegarder votre travail avant de poursuivre.",
+            "Poderá querer guardar o seu trabalho antes de continuar.", store);
 
         expectRenderedSteps(rendered);
 
         const buttons = rendered.findAll("button");
         expectTranslated(buttons.at(0), "Discard these steps and keep editing",
-            "Ignorer ces étapes et poursuivre la modification", store);
+            "Ignorer ces étapes et poursuivre la modification",
+            "Descartar estas etapas e continuar a editar", store);
         expectTranslated(buttons.at(1), "Cancel editing so I can save my work",
-            "Annuler l'édition pour que je puisse sauvegarder mon travail", store);
+            "Annuler l'édition pour que je puisse sauvegarder mon travail",
+            "Cancelar a edição para que eu possa guardar o meu trabalho", store);
 
         expect(rendered.find(LoadingSpinner).exists()).toBe(false);
     });
@@ -88,21 +92,23 @@ describe("Reset confirmation modal", () => {
         });
 
         expectTranslated(rendered.find("h4"), "Save version?",
-            "Sauvegarder la version?", store);
+            "Sauvegarder la version?", "Guardar versão?", store);
         expectTranslated(rendered.findAll("p").at(0),
             "Changing this will result in the following steps being discarded:",
-            "Si vous modifiez ce paramètre, les étapes suivantes seront abandonnées :", store);
+            "Si vous modifiez ce paramètre, les étapes suivantes seront abandonnées :",
+            "Ao alterar isto, as etapas seguintes serão descartadas:", store);
         expectTranslated(rendered.findAll("p").at(1),
             "These steps will automatically be saved in a version. You will be able to reload this version from the Projects page.",
             "Ces étapes seront automatiquement sauvegardées dans une version. Vous pourrez recharger cette version depuis la page Projets.",
+            "Estas etapas serão automaticamente guardadas numa versão. Poderá voltar a carregar esta versão a partir da página Projetos.",
             store);
 
         expectRenderedSteps(rendered);
 
         const buttons = rendered.findAll("button");
         expectTranslated(buttons.at(0), "Save version and keep editing",
-            "Sauvegarder la version et continuer à modifier", store);
-        expectTranslated(buttons.at(1), "Cancel editing", "Annuler l'édition", store);
+            "Sauvegarder la version et continuer à modifier", "Guardar versão e continuar a editar", store);
+        expectTranslated(buttons.at(1), "Cancel editing", "Annuler l'édition", "Cancelar edição", store);
 
         expect(rendered.find(LoadingSpinner).exists()).toBe(false);
     });
@@ -166,7 +172,8 @@ describe("Reset confirmation modal", () => {
         const store = rendered.vm.$store
         const noteLabel = rendered.find("#noteHeader label")
         expectTranslated(noteLabel, "Notes: (your reason for saving as a new version)",
-            "Notes : (votre motif pour sauvegarder en tant que nouvelle version)", store)
+            "Notes : (votre motif pour sauvegarder en tant que nouvelle version)",
+            "Notas: (a sua razão para guardar como nova versão)", store)
     });
 
     it("can set and get note value", async () => {
@@ -329,11 +336,12 @@ describe("Reset confirmation modal", () => {
         const steps = rendered.findAll("li");
         expect(steps.length).toBe(3);
         expectTranslated(steps.at(0), "Step 2: Upload survey and programme data",
-            "Étape 2: Télécharger les données d'enquête et de programme", store);
+            "Étape 2: Télécharger les données d'enquête et de programme",
+            "Etapa 2: Carregar dados do inquérito e do programa", store);
         expectTranslated(steps.at(1), "Step 3: Model options",
-            "Étape 3: Options des modèles", store);
+            "Étape 3: Options des modèles", "Etapa 3: Opções de modelos", store);
         expectTranslated(steps.at(2), "Step 4: Fit model",
-            "Étape 4: Ajuster le modèle", store);
+            "Étape 4: Ajuster le modèle", "Etapa 4: Ajustar modelo", store);
     };
 
     const expectRenderedModelRunSteps = (rendered: Wrapper<any>) => {
@@ -341,7 +349,7 @@ describe("Reset confirmation modal", () => {
         const steps = rendered.findAll("li");
         expect(steps.length).toBe(1);
         expectTranslated(steps.at(0), "Step 4: Fit model",
-            "Étape 4: Ajuster le modèle", store);
+            "Étape 4: Ajuster le modèle", "Etapa 4: Ajustar modelo", store);
     };
 
 });

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -174,7 +174,7 @@ describe("Stepper component", () => {
         expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
         expect(wrapper.findAll(".content").length).toBe(0);
         expectTranslated(wrapper.find("#loading-message"), "Loading your data",
-            "Chargement de vos données", store);
+            "Chargement de vos données", "A carregar os seus dados", store);
     });
 
     it("renders loading spinner while ready but loadingFromFile", () => {
@@ -191,7 +191,7 @@ describe("Stepper component", () => {
         expect(wrapper.findAll(LoadingSpinner).length).toBe(1);
         expect(wrapper.findAll(".content").length).toBe(0);
         expectTranslated(wrapper.find("#loading-message"), "Loading your data",
-            "Chargement de vos données", store);
+            "Chargement de vos données","A carregar os seus dados", store);
     });
 
     it("does not render loading spinner once states are ready", () => {

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -197,24 +197,25 @@ describe("Survey and programme component", () => {
 
     it("survey tab is enabled when survey data is present", () => {
         expectTabEnabled({survey: mockSurveyResponse(), selectedDataType: DataType.Survey},
-            "Household Survey", "Enquête de ménage", 0);
+            "Household Survey", "Enquête de ménage", "Inquérito aos agregados familiares", 0);
     });
 
     it("programme (ART) tab is enabled when programme data is present", () => {
         expectTabEnabled({program: mockProgramResponse(), selectedDataType: DataType.Survey},
-            "ART", "ART", 1);
+            "ART", "ART", "TARV", 1);
     });
 
     it("ANC tab is enabled when ANC data is present", () => {
         expectTabEnabled({anc: mockAncResponse(), selectedDataType: DataType.Survey},
-            "ANC Testing", "Test de clinique prénatale", 2);
+            "ANC Testing", "Test de clinique prénatale", "Teste da CPN", 2);
     });
 
-    function expectTabEnabled(state: Partial<SurveyAndProgramState>, englishName: string, frenchName: string, index: number) {
+    function expectTabEnabled(state: Partial<SurveyAndProgramState>, englishName: string, frenchName: string,
+                              portugueseName: string, index: number) {
         const store = createStore(state);
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
         expect(wrapper.findAll(".nav-link").at(index).classes()).not.toContain("disabled");
-        expectTranslated(wrapper.findAll(".nav-link").at(index), englishName, frenchName, store);
+        expectTranslated(wrapper.findAll(".nav-link").at(index), englishName, frenchName, portugueseName, store);
         expect(wrapper.findAll(".nav-link.disabled").length).toBe(2);
     }
 

--- a/src/app/static/src/tests/testHelpers.ts
+++ b/src/app/static/src/tests/testHelpers.ts
@@ -67,20 +67,27 @@ export function expectAllMutationsDefined(mutationDefinitions: any, mutationTree
 export function expectTranslatedWithStoreType<T extends TranslatableState>(element: Wrapper<any>,
                                                                            englishText: string,
                                                                            frenchText: string,
+                                                                           portugueseText: string,
                                                                            store: Store<T>,
                                                                            attribute?: string) {
     store.state.language = Language.en;
     registerTranslations(store);
     const value = () => attribute ? element.attributes(attribute) : element.text();
     expect(value()).toBe(englishText);
+
     store.state.language = Language.fr;
     registerTranslations(store);
     expect(value()).toBe(frenchText);
+
+    store.state.language = Language.pt;
+    registerTranslations(store);
+    expect(value()).toBe(portugueseText);
 }
 
 export const expectTranslated = (element: Wrapper<any>,
                                  englishText: string,
                                  frenchText: string,
+                                 portugueseText: string,
                                  store: Store<RootState>,
                                  attribute?: string) =>
-    expectTranslatedWithStoreType<RootState>(element, englishText, frenchText, store, attribute);
+    expectTranslatedWithStoreType<RootState>(element, englishText, frenchText, portugueseText, store, attribute);


### PR DESCRIPTION
## Description

This branch builds on mrc-2485 (https://github.com/mrc-ide/hint/pull/512) (this PR's target branch) which provides all Portuguese translations by:
- adding all tests for Portuguese text (now included in the helper method `expectTranslated`)
- adding a small number of missing translations (commented inline)

I've checked over the app in Portuguese for any odd text wrapping etc, and it all looks OK to me, except there is a fairly ugly wrap in the header for the file upload for Household Survey (the ADR 🗸 gets wrapped onto a new line). I think trying to fix this e.g. by reducing the width of the map, or floating the ADR marker right, wouldn't necessarily be any better, so I'd propose leaving this unless you can think of a good solution. The 'Select new file' text is also partially hidden - but we already live with this for the French text!

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
