### PR TITLE
mrc-2521 Upload release to ADR: support creating release in backend

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -32,6 +32,7 @@ interface ADRClient
 {
     fun getInputStream(url: String): BufferedInputStream
     fun get(url: String): ResponseEntity<String>
+    fun post(url: String, params: List<Pair<String, String>>): ResponseEntity<String>
     fun postFile(url: String, parameters: List<Pair<String, Any?>>, file: Pair<String, File>): ResponseEntity<String>
 }
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -30,6 +30,16 @@ abstract class FuelClient(protected val baseUrl: String)
                 .asResponseEntity()
     }
 
+    fun post(url: String, params: List<Pair<String, String>>): ResponseEntity<String>
+    {
+        return "$baseUrl/$url".httpPost(params)
+                .addTimeouts()
+                .header(standardHeaders())
+                .response()
+                .second
+                .asResponseEntity()
+    }
+
     protected fun postJson(url: String, json: String): ResponseEntity<String>
     {
         return "$baseUrl/$url".httpPost()

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -174,6 +174,13 @@ class ADRController(private val encryption: Encryption,
         return saveAndValidate(url, FileType.ANC)
     }
 
+    @PostMapping("/datasets/{id}/releases")
+    fun createRelease(@PathVariable id: String, @RequestParam name: String): ResponseEntity<String>
+    {
+        val adr = adrClientBuilder.build()
+        return adr.post("dataset_version_create", listOf("dataset_id" to id, "name" to name));
+    }
+
     @PostMapping("/datasets/{id}/resource/{resourceType}/{modelCalibrateId}")
     @Suppress("ReturnCount", "LongParameterList", "UnsafeCallOnNullableType")
     fun pushFileToADR(@PathVariable id: String,

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -705,6 +705,32 @@ class ADRControllerTests : HintrControllerTests()
         assertThat(result.body!!).isEqualTo("whatever")
     }
 
+    @Test
+    fun `creates a release`()
+    {
+        val expectedUrl = "dataset_version_create"
+        val mockClient = mock<ADRClient> {
+            on { post(expectedUrl, listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
+                    .ok()
+                    .body("whatever")
+        }
+        val mockBuilder = mock<ADRClientBuilder> {
+            on { build() } doReturn mockClient
+        }
+        val sut = ADRController(
+                mock(),
+                mock(),
+                mockBuilder,
+                objectMapper,
+                mockProperties,
+                mock(),
+                mock(),
+                mockSession,
+                mock())
+        val result = sut.createRelease("dataset-1", "release-1")
+        assertThat(result.body!!).isEqualTo("whatever")
+    }
+
     private fun makeFakeSuccessResponse(): ResponseEntity<String>
     {
         val resultWithResources = mapOf("resources" to listOf(1, 2))


### PR DESCRIPTION
## Description

Notes:
- To test manually:
  - Upload some resources to ADR (e.g. Burundi) from HINT
  - Run this in your browser console: `await fetch("/adr/datasets/burundi-inputs-unaids-estimates-2021/releases", {method: "POST", body: new URLSearchParams({name: "1.1"})})`
    - Replace the dataset name (e.g. `burundi-inputs-unaids-estimates-2021`) with the name of the dataset you actually uploaded to, and set the release name to something not previously used
  - Check the [releases page](https://dev.adr.fjelltopp.org/inputs-unaids-estimates/burundi-inputs-unaids-estimates-2021/releases) (or dropdown from mrc-2519) for new release
- This PR uses the Burundi dataset for ADR integration testing, as this is a dataset in which the test user can create new resources. It uploads a dummy resource and creates a new version on each run of the integration tests. This is because:
  - Creating two releases at the same point in the activity stream isn't allowed
  - Releases can't be deleted via the API
  - Private datasets such as `hint_test` [don't have an activity stream](https://github.com/ckan/ckan/issues/5772) so we can't upload a dummy resource in order to extend the activity stream 
- I'd rather not be hard-coding Burundi (Antarctica would be preferable, if we can give the test user write access to this), but only alternative seems to be making hint_test public or creating a new dataset that is, but this was previously discouraged (understandably). Would be good to keep the relevant test, so please let me know of any other ideas!
- New code in `FuelClient` is used in tests but not tested itself... but I don't think the rest of the code is either. And not sure how we would do it, or potential value of doing so?
- This doesn't support providing notes when creating releases - the mockups don't require this - but would be easy enough to add subsequently

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
