### PR TITLE
Mrc-2575 Fix erroneous ADR upload file count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.48.1
+
+* Fix erroneous ADR upload file count
+
 # hint 1.48.0
 
 * Use async endpoints for Just-In-time generation of download files from HINT frontend

--- a/src/app/static/src/app/components/downloadResults/UploadModal.vue
+++ b/src/app/static/src/app/components/downloadResults/UploadModal.vue
@@ -41,11 +41,12 @@
                     type="button"
                     class="btn btn-red"
                     :disabled="uploadFilesToAdr.length < 1"
-                    @click.prevent="confirmUpload"
+                    @click.prevent="handleConfirmUpload"
                     v-translate="'ok'"></button>
                 <button
                     type="button"
                     class="btn btn-white"
+                    :disabled="downloadingFiles"
                     @click.prevent="handleCancel"
                     v-translate="'cancel'"></button>
             </template>
@@ -86,6 +87,7 @@
         getUploadMetadata: (id: string) => Promise<void>
         handleDownloadResult: (downloadResults: DownloadResultsDependency) => void,
         stopPolling:(id: number) => void
+        handleConfirmUpload: () => void
     }
 
     interface Computed {
@@ -130,6 +132,11 @@
                 "adrUpload",
                 "uploadFilesToADR"
             ),
+            handleConfirmUpload() {
+                if (!this.downloadingFiles) {
+                    this.confirmUpload()
+                }
+            },
             confirmUpload() {
                 this.uploadFilesToAdr.forEach(value => this.uploadFilesPayload.push(this.uploadFiles[value]));
                 const readyForUpload = this.prepareFilesForUpload();

--- a/src/app/static/src/app/components/downloadResults/UploadModal.vue
+++ b/src/app/static/src/app/components/downloadResults/UploadModal.vue
@@ -41,7 +41,7 @@
                     type="button"
                     class="btn btn-red"
                     :disabled="uploadFilesToAdr.length < 1"
-                    @click.prevent="handleConfirmUpload"
+                    @click.prevent="confirmUpload"
                     v-translate="'ok'"></button>
                 <button
                     type="button"
@@ -87,7 +87,6 @@
         getUploadMetadata: (id: string) => Promise<void>
         handleDownloadResult: (downloadResults: DownloadResultsDependency) => void,
         stopPolling:(id: number) => void
-        handleConfirmUpload: () => void
     }
 
     interface Computed {
@@ -132,13 +131,8 @@
                 "adrUpload",
                 "uploadFilesToADR"
             ),
-            handleConfirmUpload() {
-                if (!this.downloadingFiles) {
-                    this.confirmUpload()
-                }
-            },
             confirmUpload() {
-                this.uploadFilesToAdr.forEach(value => this.uploadFilesPayload.push(this.uploadFiles[value]));
+                this.uploadFilesPayload = this.uploadFilesToAdr.map(value => this.uploadFiles[value]);
                 const readyForUpload = this.prepareFilesForUpload();
 
                 if (readyForUpload) {

--- a/src/app/static/src/app/components/downloadResults/UploadModal.vue
+++ b/src/app/static/src/app/components/downloadResults/UploadModal.vue
@@ -40,7 +40,7 @@
                 <button
                     type="button"
                     class="btn btn-red"
-                    :disabled="uploadFilesToAdr.length < 1"
+                    :disabled="uploadFilesToAdr.length < 1 || downloadingFiles"
                     @click.prevent="confirmUpload"
                     v-translate="'ok'"></button>
                 <button

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.48.0";
+export const currentHintVersion = "1.48.1";

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -512,7 +512,6 @@ describe(`uploadModal `, () => {
         expect(btn.at(1).attributes("disabled")).toBe("disabled");
 
         await btn.at(0).trigger("click")
-        await btn.at(0).trigger("click")
         expect(mockUploadFilesToADR.mock.calls.length).toBe(0)
 
         wrapper.vm.$store.state.downloadResults.spectrum.downloading = false

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -496,18 +496,18 @@ describe(`uploadModal `, () => {
             summary: {downloading: false} as any,
             spectrum: {downloading: true} as any
         }
-        const wrapper = mount(UploadModal, {store: createStore(fakeMetadata, downloadResults)})
-
-        await wrapper.setProps({open: true})
+        const wrapper = mount(UploadModal,
+            {
+                store: createStore(fakeMetadata, downloadResults),
+                propsData: {open: true},
+                data() {
+                    return {
+                        uploadFilesToAdr: ["outputZip", "outputSummary"]
+                    }
+                }
+            })
 
         const btn = wrapper.findAll("button");
-        expect(btn.at(0).attributes("disabled")).toBe("disabled");
-
-        const inputs = wrapper.findAll("input.form-check-input")
-        expect(inputs.length).toBe(2)
-        inputs.at(0).setChecked(true)
-        inputs.at(1).setChecked(true)
-
         expect(btn.at(0).attributes("disabled")).toBeUndefined();
         expect(btn.at(1).attributes("disabled")).toBe("disabled");
 

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -490,4 +490,33 @@ describe(`uploadModal `, () => {
         expect(labels.at(1).attributes("for")).toBe("id-0-1");
         expect(labels.at(2).attributes("for")).toBe("id-1-0");
     });
+
+    it(`does not send upload files to ADR if files are being prepared for upload`, async () => {
+        const downloadResults = {
+            summary: {downloading: false} as any,
+            spectrum: {downloading: true} as any
+        }
+        const wrapper = mount(UploadModal, {store: createStore(fakeMetadata, downloadResults)})
+
+        await wrapper.setProps({open: true})
+
+        const btn = wrapper.findAll("button");
+        expect(btn.at(0).attributes("disabled")).toBe("disabled");
+
+        const inputs = wrapper.findAll("input.form-check-input")
+        expect(inputs.length).toBe(2)
+        inputs.at(0).setChecked(true)
+        inputs.at(1).setChecked(true)
+
+        expect(btn.at(0).attributes("disabled")).toBeUndefined();
+        expect(btn.at(1).attributes("disabled")).toBe("disabled");
+
+        await btn.at(0).trigger("click")
+        await btn.at(0).trigger("click")
+        expect(mockUploadFilesToADR.mock.calls.length).toBe(0)
+
+        wrapper.vm.$store.state.downloadResults.spectrum.downloading = false
+        await Vue.nextTick()
+        expect(btn.at(1).attributes("disabled")).toBeUndefined();
+    });
 })

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -524,4 +524,28 @@ describe(`uploadModal `, () => {
         expect(btn.at(0).attributes("disabled")).toBeUndefined();
         expect(btn.at(1).attributes("disabled")).toBeUndefined();
     });
+
+    it(`does not multiply files when ok button is triggered twice when uploading to ADR`, async () => {
+        const wrapper = mount(UploadModal,
+            {
+                store: createStore(fakeMetadata),
+                propsData: {open: true},
+                data() {
+                    return {
+                        uploadFilesToAdr: ["outputZip", "outputSummary"]
+                    }
+                }
+            })
+
+        const btn = wrapper.findAll("button");
+
+        expect(wrapper.vm.$data.uploadFilesPayload.length).toBe(0)
+
+        expect(btn.at(0).text()).toBe("OK")
+        await btn.at(0).trigger("click")
+        expect(wrapper.vm.$data.uploadFilesPayload.length).toBe(2)
+
+        await btn.at(0).trigger("click")
+        expect(wrapper.vm.$data.uploadFilesPayload.length).toBe(2)
+    });
 })

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -332,21 +332,17 @@ describe(`uploadModal `, () => {
             spectrum: {downloading: true} as any
         }
         const store = createStore(fakeMetadata, downloadResults)
-        const wrapper = mount(UploadModal, {store})
-
-        await wrapper.setProps({open: true})
+        const wrapper = mount(UploadModal, {
+            store,
+            propsData: {open: true}
+        })
 
         const okBtn = wrapper.find("button");
         expect(okBtn.attributes("disabled")).toBe("disabled");
 
         const inputs = wrapper.findAll("input.form-check-input")
         expect(inputs.length).toBe(2)
-        inputs.at(0).setChecked(true)
-        inputs.at(1).setChecked(true)
-
-        expect(okBtn.attributes("disabled")).toBeUndefined();
         expect(okBtn.text()).toBe("OK")
-        await okBtn.trigger("click")
 
         expect(wrapper.find(DownloadProgress).props())
             .toEqual({"downloading": true, "translateKey": "downloadProgressForADR"})
@@ -491,7 +487,7 @@ describe(`uploadModal `, () => {
         expect(labels.at(2).attributes("for")).toBe("id-1-0");
     });
 
-    it(`does not send upload files to ADR if files are being prepared for upload`, async () => {
+    it(`ok and cancel buttons are disabled when upload to ADR is in progress`, async () => {
         const downloadResults = {
             summary: {downloading: false} as any,
             spectrum: {downloading: true} as any
@@ -508,14 +504,24 @@ describe(`uploadModal `, () => {
             })
 
         const btn = wrapper.findAll("button");
-        expect(btn.at(0).attributes("disabled")).toBeUndefined();
+        expect(btn.at(0).attributes("disabled")).toBe("disabled");
         expect(btn.at(1).attributes("disabled")).toBe("disabled");
+    });
 
-        await btn.at(0).trigger("click")
-        expect(mockUploadFilesToADR.mock.calls.length).toBe(0)
+    it(`ok and cancel buttons are enabled when upload to Download/ADR is not in progress`, async () => {
+        const wrapper = mount(UploadModal,
+            {
+                store: createStore(fakeMetadata),
+                propsData: {open: true},
+                data() {
+                    return {
+                        uploadFilesToAdr: ["outputZip", "outputSummary"]
+                    }
+                }
+            })
 
-        wrapper.vm.$store.state.downloadResults.spectrum.downloading = false
-        await Vue.nextTick()
+        const btn = wrapper.findAll("button");
+        expect(btn.at(0).attributes("disabled")).toBeUndefined();
         expect(btn.at(1).attributes("disabled")).toBeUndefined();
     });
 })


### PR DESCRIPTION
This PR fixes erroneous ADR upload counts. 

When an ok button gets triggered multiple times, it multiplies the actual selected files before uploading to ADR. This error could also be reproduced as seen in this ticket https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2575.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
