### PR TITLE
mrc-2604 Fix ADR integration test failure

### DIFF
--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -78,11 +78,10 @@ describe("ADR dataset-related actions", () => {
         const commit = jest.fn();
 
         await adrActions.getDatasets({commit, rootState} as any);
-        const datasetId = commit.mock.calls[2][0]["payload"].find((dataset: Dataset) => dataset.title.includes("Antarctica")).id;
 
         jest.resetAllMocks();
         
-        await adrActions.getReleases({commit, rootState} as any, datasetId);
+        await adrActions.getReleases({commit, rootState} as any, "antarctica-inputs-unaids-estimates-2021");
         expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetReleases)
         expect(commit.mock.calls[0][0].payload.length).toBeGreaterThan(0);
         expect(commit.mock.calls[0][0].payload[0].name).toBeTruthy();


### PR DESCRIPTION
## Description

Current test is vulnerable to addition of (or newly acquired access to) datasets whose name starts with "Antarctica" but don't have a release ([example](https://dev.adr.fjelltopp.org/country-estimates-22/antarctica-country-estimates-2022)). So follow the lead of releases test in [ADRTests.kt](https://github.com/mrc-ide/hint/blob/master/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt#L97) and hard-code dataset ID. This will itself be fragile to annual updates but will be more robust otherwise.

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
