### PR TITLE
mrc-2613 Remove JCenter from Gradle repository list

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -23,7 +23,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
 
-    implementation 'com.github.kittinunf.fuel:fuel:2.2.3'
+    implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/Extensions.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/Extensions.kt
@@ -58,7 +58,7 @@ fun Response.asResponseEntity(logger: Log = LogFactory.getLog(HintExceptionHandl
 
     return try
     {
-        val body = this.body().asString("application/json")
+        val body = this.body().asString(MediaType.APPLICATION_JSON_UTF8_VALUE)
         val json = ObjectMapper().readTree(body)
 
         if (!json.has("status") && !json.has("success"))

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -3,7 +3,9 @@ buildscript {
 
     repositories {
         mavenCentral()
-        jcenter()
+        maven { // required for detekt < v1.17.0
+            url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven"
+        }
     }
 
     dependencies {
@@ -21,7 +23,9 @@ subprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
+        maven { // required for detekt < v1.17.0
+            url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven"
+        }
     }
 
     apply plugin: 'io.spring.dependency-management'

--- a/src/generateDatabaseInterface/build.gradle
+++ b/src/generateDatabaseInterface/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 apply plugin: 'application'
 
 mainClassName = "org.imperial.mrc.hint.generateDatabaseInterface.AppKt"

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.30'
     repositories {
-        // This is needed for gradle-docker
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'se.transmode.gradle:gradle-docker:1.2'


### PR DESCRIPTION
## Description

- Bump fuel to a version whose dependencies are available in Maven Central. Correspondingly parse hintr response as utf-8 - the default in fuel became ASCII. Ideally hintr would express this the content type it sends, but that's a more invasive change (actually a change to porcelain).
- Remove unnecessary reference to Maven Central
- Use JetBrains repo for old version of kotlinx-html, which is required for version of detekt we're using. Upgrading detekt would be a better option - but this would also require a Gradle update, which again is a bigger change for another ticket.

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
