### PR TITLE
mrc-2583 Add tooltips for indicators in Time series chart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.54.0
+
+* Add tooltips for indicators in Time series chart
+
 # hint 1.53.0
 
 * Remove genericChart dataset when corresponding input file changes

--- a/src/app/static/src/app/components/plots/FilterSelect.vue
+++ b/src/app/static/src/app/components/plots/FilterSelect.vue
@@ -1,6 +1,9 @@
 <template>
     <div>
-        <label :class="'font-weight-bold' + (disabled ? ' disabled-label' : '')" v-translate="label"></label>
+        <label :class="['font-weight-bold', { 'disabled-label': disabled }]" v-translate="label"></label>
+        <span v-if="labelTooltip" v-tooltip="{content: `<dl>${labelTooltip}</dl>`, classes: 'filter-select'}" class="icon-small">
+            <help-circle-icon></help-circle-icon>
+        </span>
         <treeselect id="survey-filters" :multiple=multiple
                     :clearable="false"
                     :options=options
@@ -17,11 +20,12 @@
     import i18next from "i18next";
     import Vue from "vue";
     import Treeselect from '@riophae/vue-treeselect';
-    import {mapStateProp} from "../../utils";
+    import {flattenOptions, mapStateProp} from "../../utils";
     import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
     import {FilterOption} from "../../generated";
-    import {flattenOptions} from "../../utils";
+    import {HelpCircleIcon} from "vue-feather-icons";
+    import {VTooltip} from "v-tooltip";
 
     interface Methods {
         input: (value: string[]) => void
@@ -32,14 +36,15 @@
     interface Computed {
         treeselectValue: string[] | string | null
         currentLanguage: Language
-        placeholder: string
+        placeholder: string,
+        labelTooltip: string
     }
 
     interface Props {
         multiple: boolean,
         label: string,
         disabled: boolean,
-        options: any[],
+        options: FilterOption[],
         value: string[] | string
     }
 
@@ -73,6 +78,12 @@
             placeholder() {
                 const key = this.disabled ? "notUsed" : "select";
                 return i18next.t(key, this.currentLanguage)
+            },
+            labelTooltip() {
+                return this.options.reduce(
+                    (lines, option) => lines.concat(option.description ? `<dt>${option.label}</dt><dd>${option.description}</dd>` : []),
+                    [] as string[]
+                ).join('');
             }
         },
         methods: {
@@ -94,7 +105,13 @@
                 this.$emit("select", this.selectedOptions);
             }
         },
-        components: {Treeselect}
+        components: {
+            Treeselect,
+            HelpCircleIcon
+        },
+        directives: {
+            tooltip: VTooltip
+        }
     });
 </script>
 

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -26,10 +26,12 @@ export interface AncFilters {
   year: {
     label: string;
     id: string;
+    description?: string;
   }[];
   indicators: {
     label: string;
     id: string;
+    description?: string;
   }[];
 }
 export type AncResponseData = {
@@ -88,6 +90,7 @@ export interface BarchartMetadata {
     options: {
       label: string;
       id: string;
+      description?: string;
     }[];
     use_shape_regions?: boolean | null;
   }[];
@@ -149,6 +152,7 @@ export interface CalibratePlotResponse {
         options: {
           label: string;
           id: string;
+          description?: string;
         }[];
         use_shape_regions?: boolean | null;
       }[];
@@ -211,6 +215,7 @@ export interface CalibrateResultResponse {
         options: {
           label: string;
           id: string;
+          description?: string;
         }[];
         use_shape_regions?: boolean | null;
       }[];
@@ -248,6 +253,7 @@ export interface CalibrateResultResponse {
         options: {
           label: string;
           id: string;
+          description?: string;
         }[];
         use_shape_regions?: boolean | null;
       }[];
@@ -327,6 +333,7 @@ export interface ChoroplethMetadata {
     options: {
       label: string;
       id: string;
+      description?: string;
     }[];
     use_shape_regions?: boolean | null;
   }[];
@@ -350,6 +357,7 @@ export interface DownloadStatusResponse {
 export interface DownloadSubmitResponse {
   id: string;
 }
+export type ErrorCode = string;
 export interface Error {
   error: string;
   detail: string | null;
@@ -357,7 +365,6 @@ export interface Error {
   trace?: string[];
   [k: string]: any;
 }
-export type ErrorCode = string;
 export type FileName = string;
 export type FilePath = string | null;
 export interface Filter {
@@ -367,12 +374,14 @@ export interface Filter {
   options: {
     label: string;
     id: string;
+    description?: string;
   }[];
   use_shape_regions?: boolean | null;
 }
 export interface FilterOption {
   label: string;
   id: string;
+  description?: string;
 }
 export interface HintrVersionResponse {
   [k: string]: string;
@@ -697,14 +706,17 @@ export interface ProgrammeFilters {
   age: {
     label: string;
     id: string;
+    description?: string;
   }[];
   calendar_quarter: {
     label: string;
     id: string;
+    description?: string;
   }[];
   indicators: {
     label: string;
     id: string;
+    description?: string;
   }[];
 }
 export type ProgrammeResponseData = {
@@ -781,14 +793,17 @@ export interface SurveyFilters {
   age: {
     label: string;
     id: string;
+    description?: string;
   }[];
   surveys: {
     label: string;
     id: string;
+    description?: string;
   }[];
   indicators: {
     label: string;
     id: string;
+    description?: string;
   }[];
 }
 export type SurveyResponseData = {
@@ -905,14 +920,17 @@ export interface ProgrammeResponse {
     age: {
       label: string;
       id: string;
+      description?: string;
     }[];
     calendar_quarter: {
       label: string;
       id: string;
+      description?: string;
     }[];
     indicators: {
       label: string;
       id: string;
+      description?: string;
     }[];
   };
 }
@@ -939,10 +957,12 @@ export interface AncResponse {
     year: {
       label: string;
       id: string;
+      description?: string;
     }[];
     indicators: {
       label: string;
       id: string;
+      description?: string;
     }[];
   };
 }
@@ -971,14 +991,17 @@ export interface SurveyResponse {
     age: {
       label: string;
       id: string;
+      description?: string;
     }[];
     surveys: {
       label: string;
       id: string;
+      description?: string;
     }[];
     indicators: {
       label: string;
       id: string;
+      description?: string;
     }[];
   };
 }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.53.0";
+export const currentHintVersion = "1.54.0";

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -153,3 +153,8 @@ a.down::after {
     width: 20px;
     vertical-align: sub;
   }
+
+.filter-select .tooltip-inner {
+  text-align: left !important;
+  min-width: 32em;
+}

--- a/src/app/static/src/tests/components/plots/filterSelect.test.ts
+++ b/src/app/static/src/tests/components/plots/filterSelect.test.ts
@@ -4,6 +4,7 @@ import TreeSelect from '@riophae/vue-treeselect';
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
+import {HelpCircleIcon} from "vue-feather-icons";
 
 describe("FilterSelect component", () => {
     const testOptions = [{id: "1", label: "one"}, {id: "2", label: "two"}];
@@ -16,6 +17,30 @@ describe("FilterSelect component", () => {
     it("renders label", () => {
         const wrapper = shallowMount(FilterSelect, {store, propsData: {options: testOptions, label: "testLabel"}});
         expect(wrapper.find("label").text()).toBe("testLabel");
+    });
+
+    it("renders tooltip if any options have descriptions", () => {
+        const tooltip = jest.fn();
+        const wrapper = shallowMount(FilterSelect, {
+            store,
+            propsData: {
+                options: [
+                    ...testOptions,
+                    {id: "3", label: "three", description: "Third option"},
+                    {id: "4", label: "four", description: "Fourth option"}
+                ]
+            },
+            directives: {
+                tooltip
+            }
+        });
+        expect(wrapper.find(HelpCircleIcon).exists()).toBe(true);
+        expect(tooltip.mock.calls[0][1].value.content).toBe("<dl><dt>three</dt><dd>Third option</dd><dt>four</dt><dd>Fourth option</dd></dl>");
+    });
+
+    it("does not render tooltip unless any options have descriptions", () => {
+        const wrapper = shallowMount(FilterSelect, {store, propsData: {options: testOptions, label: "testLabel"}});
+        expect(wrapper.find("span.filter-select").exists()).toBe(false);
     });
 
     it("renders TreeSelect", () => {


### PR DESCRIPTION
## Description

To test:
- Go to _Review inputs_ > _Time series_ chart
- Check that help icon/tooltip appears next to _Plot type_ header
- Observe also that entries in _Plot type_ dropdown are human-readable i.e. "ART count" rather than "art_count"
  - The hintr PR that this PR depends on (mrc-ide/hintr#295) provides not only descriptions (as displayed in the tooltip) but also labels, so although the filter component was previously capable of displaying these, this is the first time they will become visible

## Type of version change

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
