### PR TITLE
mrc-2617 Fix warnings emitted during tests

### DIFF
--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -28,7 +28,6 @@ import {expectTranslated} from "../../testHelpers";
 import {ADRState} from "../../../app/store/adr/adr";
 import {getters as rootGetters} from "../../../app/store/root/getters";
 import ResetConfirmation from "../../../app/components/ResetConfirmation.vue";
-import {actions as projectsActions} from "../../../app/store/projects/actions"
 import Mock = jest.Mock;
 
 describe("select dataset", () => {
@@ -224,7 +223,9 @@ describe("select dataset", () => {
                 projects: {
                     namespaced: true,
                     state: mockProjectsState({currentProject: {id: 1, name: "v1", versions: []}, currentVersion}),
-                    actions: projectsActions
+                    actions: {
+                        newVersion: jest.fn()
+                    }
                 },
                 surveyAndProgram: {
                     namespaced: true,

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -76,12 +76,18 @@ describe("Stepper component", () => {
                     namespaced: true,
                     state: mockBaselineState(baselineState),
                     getters: baselineGetters,
+                    actions: {
+                        deleteAll: jest.fn()
+                    },
                     mutations
                 },
                 surveyAndProgram: {
                     namespaced: true,
                     state: mockSurveyAndProgramState(surveyAndProgramState),
                     getters: surveyAndProgramGetters,
+                    actions: {
+                        deleteAll: jest.fn()
+                    },
                     mutations: surveyAndProgramMutations
                 },
                 modelRun: {
@@ -416,7 +422,7 @@ describe("Stepper component", () => {
     it("active step only becomes active once state becomes ready", async () => {
 
         const wrapper = createSut(completedBaselineState,
-            {},
+            completedSurveyAndProgramState,
             {plottingMetadata: mockPlottingMetadataResponse()},
             {ready: true},
             {activeStep: 2});
@@ -679,10 +685,17 @@ describe("Stepper component", () => {
     it("complete step only becomes active/complete once state becomes ready", async () => {
 
         const wrapper = createSut(completedBaselineState,
-            {},
+            completedSurveyAndProgramState,
             {plottingMetadata: mockPlottingMetadataResponse()},
-            {ready: true},
-            {activeStep: 7});
+            {ready: true, status: {success: true} as any, result: {complete: true} as any},
+            {activeStep: 7},
+            {},
+            {},
+            jest.fn(),
+            {},
+            {valid: true},
+            {complete: true}
+            );
 
         let steps = wrapper.findAll(Step);
         expect(steps.filter(s => s.props().active).length).toBe(0);

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -21,10 +21,15 @@ const actions = {
     getADRSchemas: jest.fn()
 }
 
+const genericChartActions = {
+    getGenericChartMetadata: jest.fn()
+}
+
 storeOptions.modules!!.baseline!!.actions = baselineActions;
 storeOptions.modules!!.surveyAndProgram!!.actions = surveyAndProgramActions;
 storeOptions.modules!!.modelRun!!.actions = modelRunActions;
 storeOptions.modules!!.projects!!.actions = projectActions;
+storeOptions.modules!!.genericChart!!.actions = genericChartActions;
 storeOptions.actions = actions
 
 console.error = jest.fn();


### PR DESCRIPTION
## Description

Two warnings were being emitted during run of full test suite, both due to missing actions:
- First was inconsequential, but now fixed (`selectDataset.test.ts`)
- Second appears slightly more serious - missing action seems to mask two test failures. The first of these was (I think) due to test being out of date in relation to merger of steps 1 and 2 of stepper. Second seemed to be flat-out wrong: there's no way to get to step 7 without mocking a lot more of the wizard state. Both now fixed.

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
