### PR TITLE
mrc-2582 Input time series table

### DIFF
--- a/src/app/src/main/resources/metadata/generic-chart.json
+++ b/src/app/src/main/resources/metadata/generic-chart.json
@@ -62,7 +62,32 @@
             "id": "age",
             "source": "data"
           }
-        ]
+        ],
+        "table": {
+          "columns": [
+            {
+              "dataColumn": "area_name",
+              "label": {
+                "type": "string",
+                "value": "Area"
+              }
+            },
+            {
+              "dataColumn": "age_group",
+              "label": {
+                "type": "string",
+                "value": "Age"
+              }
+            },
+            {
+              "dataColumn": "value",
+              "label": {
+                "type": "selectedFilterOption",
+                "filterId": "plot_type"
+              }
+            }
+          ]
+        }
       }
     ],
     "dataSelectors": {

--- a/src/app/src/main/resources/metadata/generic-chart.json
+++ b/src/app/src/main/resources/metadata/generic-chart.json
@@ -44,7 +44,7 @@
             {
               "data": {
                 "columnId": "area_level_label",
-                "labelFilterId": "area_level"
+                "labelFilterId": null
               },
               "header": {
                 "type": "filterLabel",
@@ -117,7 +117,7 @@
             {
               "data": {
                 "columnId": "area_level_label",
-                "labelFilterId": "area_level"
+                "labelFilterId": null
               },
               "header": {
                 "type": "filterLabel",

--- a/src/app/src/main/resources/metadata/generic-chart.json
+++ b/src/app/src/main/resources/metadata/generic-chart.json
@@ -18,7 +18,32 @@
             "id": "time_step",
             "source": "data"
           }
-        ]
+        ],
+        "table": {
+          "columns": [
+            {
+              "dataColumn": "area_name",
+              "label": {
+                "type": "string",
+                "value": "Area"
+              }
+            },
+            {
+              "dataColumn": "time_period",
+              "label": {
+                "type": "string",
+                "value": "Time Period"
+              }
+            },
+            {
+              "dataColumn": "value",
+              "label": {
+                "type": "selectedFilterOption",
+                "filterId": "plot_type"
+              }
+            }
+          ]
+        }
       },
       {
         "id": "anc",

--- a/src/app/src/main/resources/metadata/generic-chart.json
+++ b/src/app/src/main/resources/metadata/generic-chart.json
@@ -22,22 +22,51 @@
         "table": {
           "columns": [
             {
-              "dataColumn": "area_name",
-              "label": {
-                "type": "string",
-                "value": "Area"
+              "data": {
+                "columnId": "area_name",
+                "labelFilterId": null
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "area_name"
               }
             },
             {
-              "dataColumn": "time_period",
-              "label": {
-                "type": "string",
-                "value": "Time Period"
+              "data": {
+                "columnId": "time_period",
+                "labelFilterId": null
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "time_period"
               }
             },
             {
-              "dataColumn": "value",
-              "label": {
+              "data": {
+                "columnId": "area_level_label",
+                "labelFilterId": "area_level"
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "area_level"
+              }
+            },
+            {
+              "data": {
+                "columnId": "time_step",
+                "labelFilterId": "time_step"
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "time_step"
+              }
+            },
+            {
+              "data": {
+                "columnId": "value",
+                "labelFilterId": null
+              },
+              "header": {
                 "type": "selectedFilterOption",
                 "filterId": "plot_type"
               }
@@ -66,22 +95,51 @@
         "table": {
           "columns": [
             {
-              "dataColumn": "area_name",
-              "label": {
-                "type": "string",
-                "value": "Area"
+              "data": {
+                "columnId": "area_name",
+                "labelFilterId": null
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "area_name"
               }
             },
             {
-              "dataColumn": "age_group",
-              "label": {
-                "type": "string",
-                "value": "Age"
+              "data": {
+                "columnId": "time_period",
+                "labelFilterId": null
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "time_period"
               }
             },
             {
-              "dataColumn": "value",
-              "label": {
+              "data": {
+                "columnId": "area_level_label",
+                "labelFilterId": "area_level"
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "area_level"
+              }
+            },
+            {
+              "data": {
+                "columnId": "age_group",
+                "labelFilterId": "age"
+              },
+              "header": {
+                "type": "filterLabel",
+                "filterId": "age"
+              }
+            },
+            {
+              "data": {
+                "columnId": "value",
+                "labelFilterId": null
+              },
+              "header": {
                 "type": "selectedFilterOption",
                 "filterId": "plot_type"
               }

--- a/src/app/static/src/app/components/genericChart/GenericChart.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChart.vue
@@ -24,9 +24,9 @@
                            :layout-data="chartConfigValues.layoutData"
                            :style="{height: chartConfigValues.scrollHeight}"></plotly>
                 </div>
-                <div v-for="dataSource in chartConfigValues.dataSourceConfigValues" :key="dataSource.config.id">
-                    <generic-chart-table v-if="dataSource.tableConfig"
-                                         :table-config="dataSource.tableConfig"
+                <div v-for="dataSource in chartConfigValues.dataSourceConfigValues.filter(ds => ds.tableConfig)"
+                     :key="dataSource.config.id">
+                    <generic-chart-table :table-config="dataSource.tableConfig"
                                          :filtered-data="chartData[dataSource.config.id]"
                                          :filters="dataSource.filters"
                                          :selected-filter-options="dataSource.selections.selectedFilterOptions"

--- a/src/app/static/src/app/components/genericChart/GenericChart.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChart.vue
@@ -28,6 +28,7 @@
                     <generic-chart-table v-if="dataSource.tableConfig"
                                          :table-config="dataSource.tableConfig"
                                          :filtered-data="chartData[dataSource.config.id]"
+                                         :filters="dataSource.filters"
                                          :selected-filter-options="dataSource.selections.selectedFilterOptions"
                     ></generic-chart-table>
                 </div>

--- a/src/app/static/src/app/components/genericChart/GenericChart.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChart.vue
@@ -24,6 +24,13 @@
                            :layout-data="chartConfigValues.layoutData"
                            :style="{height: chartConfigValues.scrollHeight}"></plotly>
                 </div>
+                <div v-for="dataSource in chartConfigValues.dataSourceConfigValues" :key="dataSource.config.id">
+                    <generic-chart-table v-if="dataSource.tableConfig"
+                                         :table-config="dataSource.tableConfig"
+                                         :filtered-data="chartData[dataSource.config.id]"
+                                         :selected-filter-options="dataSource.selections.selectedFilterOptions"
+                    ></generic-chart-table>
+                </div>
             </div>
         </div>
         <div class="row" v-if="!chartData">
@@ -45,7 +52,7 @@
         Dict, DisplayFilter,
         GenericChartDataset,
         GenericChartMetadata,
-        GenericChartMetadataResponse
+        GenericChartMetadataResponse, GenericChartTableConfig
     } from "../../types";
     import DataSource from "./dataSelectors/DataSource.vue";
     import Filters from "../plots/Filters.vue";
@@ -57,12 +64,14 @@
     import {FilterOption} from "../../generated";
     import Plotly from "./Plotly.vue";
     import {filterData} from "./utils";
+    import GenericChartTable from "./GenericChartTable.vue";
 
     interface DataSourceConfigValues {
         selections: DataSourceSelections
         editable: boolean
         config: DataSourceConfig
         filters: DisplayFilter[] | null
+        tableConfig: GenericChartTableConfig | undefined
     }
 
     interface ChartConfigValues {
@@ -116,6 +125,7 @@
             DataSource,
             Filters,
             Plotly,
+            GenericChartTable,
             ErrorAlert,
             LoadingSpinner
         },
@@ -149,7 +159,8 @@
                         selections,
                         editable: dataSourceConfig.type === "editable",
                         config: dataSourceConfig,
-                        filters: this.datasets[selections.datasetId]?.metadata.filters
+                        filters: this.datasets[selections.datasetId]?.metadata.filters,
+                        tableConfig: this.chartMetadata.datasets.find(d => d.id === selections.datasetId)?.table
                     }
                 });
 

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -1,47 +1,17 @@
 <template>
-    <div>
-        <br>
-        <div v-if="filteredData.length > 0">
-            <b-form-group class="mb-0">
-                <b-input-group size="sm">
-                    <b-form-input
-                            v-model="filter"
-                            type="search"
-                            id="filterInput"
-                            :placeholder="translate('typeSearch')"></b-form-input>
-                    <b-input-group-append>
-                        <b-button :disabled="!filter" @click="filter = ''" v-translate="'clearText'"></b-button>
-                    </b-input-group-append>
-                </b-input-group>
-            </b-form-group>
-            <b-table
-                    striped hover
-                    :fields="generatedFields"
-                    :items="friendlyData"
-                    :sort-by.sync="sortBy"
-                    :sort-desc.sync="sortDesc"
-                    :filter="filter"
-                    responsive="sm"
-                    show-empty>
-            </b-table>
-        </div>
-        <div v-else v-translate="'noData'"></div>
-    </div>
+    <table-view :fields="generatedFields" :filtered-data="filteredData">
+    </table-view>
 </template>
 
 <script lang="ts">
     import Vue from "vue";
-    import i18next from "i18next";
     import {FilterOption} from "../../generated";
     import {
         Dict,
         Filter,
         GenericChartTableConfig
     } from "../../types";
-    import {mapStateProp} from "../../utils";
-    import {BButton, BFormGroup, BFormInput, BInputGroup, BInputGroupAppend, BTable} from 'bootstrap-vue';
-    import {RootState} from "../../root";
-    import {Language} from "../../store/translations/locales";
+    import TableView, {Field} from "../plots/table/Table.vue";;
 
     interface Props {
         filteredData: any[],
@@ -50,19 +20,9 @@
         tableConfig: GenericChartTableConfig
     }
 
-    interface Field {
-        key: string,
-        label?: string
-    }
-
-    interface Methods {
-        translator: string
-    }
-
     interface Computed {
         generatedFields: Field[],
-        friendlyData: any[],
-        currentLanguage: Language
+        friendlyData: any[]
     }
 
     const props = {
@@ -78,10 +38,10 @@
         tableConfig: {
             type: Object
         }
-    }
+    };
 
     export default Vue.extend<unknown, unknown, Computed, Props>({
-        name: "table-view",
+        name: "GenericChartTable",
         props: props,
         data() {
             return {
@@ -89,11 +49,6 @@
                 sortDesc: false,
                 filter: null
             }
-        },
-        methods: {
-            translate(word: string) {
-                return i18next.t(word, {lng: this.currentLanguage})
-            },
         },
         computed: {
             generatedFields() {
@@ -129,17 +84,10 @@
                     return friendlyRow;
                 });
                 return result;
-            },
-            currentLanguage: mapStateProp<RootState, Language>(null,
-                (state: RootState) => state.language)
+            }
         },
         components: {
-            BTable,
-            BFormGroup,
-            BFormInput,
-            BInputGroup,
-            BButton,
-            BInputGroupAppend
+            TableView
         }
     });
 </script>

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -11,7 +11,7 @@
         Filter,
         GenericChartTableConfig
     } from "../../types";
-    import TableView, {Field} from "../plots/table/Table.vue";;
+    import TableView, {Field} from "../plots/table/Table.vue";
 
     interface Props {
         filteredData: any[],

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <table-view :fields="generatedFields" :filtered-data="filteredData">
+    <table-view :fields="generatedFields" :filtered-data="labelledData">
     </table-view>
 </template>
 
@@ -22,7 +22,7 @@
 
     interface Computed {
         generatedFields: Field[],
-        friendlyData: any[]
+        labelledData: any[]
     }
 
     const props = {
@@ -43,26 +43,19 @@
     export default Vue.extend<unknown, unknown, Computed, Props>({
         name: "GenericChartTable",
         props: props,
-        data() {
-            return {
-                sortBy: '',
-                sortDesc: false,
-                filter: null
-            }
-        },
         computed: {
             generatedFields() {
-                const fields = this.tableConfig.columns.map(c => {
+                const fields = this.tableConfig.columns.map(column => {
                     let label: string;
-                    if (c.header.type === "filterLabel") {
-                        label = this.filters.find(f => f.id === c.header.filterId)?.label || c.header.filterId;
+                    if (column.header.type === "filterLabel") {
+                        label = this.filters.find(f => f.id === column.header.filterId)?.label || column.header.filterId;
                     } else {
-                        const selectedFilterOption = this.selectedFilterOptions[c.header.filterId][0];
+                        const selectedFilterOption = this.selectedFilterOptions[column.header.filterId][0];
                         label = selectedFilterOption.label;
                     }
 
                     return {
-                        key: c.data.columnId,
+                        key: column.data.columnId,
                         label,
                         sortable: true,
                         sortByFormatted: true
@@ -71,7 +64,7 @@
 
                 return fields
             },
-            friendlyData() {
+            labelledData() {
                 const filtersDict = this.filters.reduce((dict, filter) => ({...dict, [filter.id]: filter}), {} as Dict<Filter>);
                 const result = this.filteredData.map(row => {
                     const friendlyRow = {...row};

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -32,8 +32,7 @@
 <script lang="ts">
     import Vue from "vue";
     import i18next from "i18next";
-    import {findPath, iterateDataValues, formatOutput} from "./utils";
-    import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../generated";
+    import {FilterOption} from "../../generated";
     import {
         Dict,
         Filter,
@@ -41,33 +40,16 @@
         GenericChartTableSelectedFilterOptionLabel,
         GenericChartTableStringLabel
     } from "../../types";
-    import {flattenOptions, flattenToIdSet, mapStateProp} from "../../utils";
+    import {mapStateProp} from "../../utils";
     import {BButton, BFormGroup, BFormInput, BInputGroup, BInputGroupAppend, BTable} from 'bootstrap-vue';
     import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
 
     interface Props {
         filteredData: any[],
-        //filters: Filter[],
         selectedFilterOptions: Dict<FilterOption[]>,
         tableConfig: GenericChartTableConfig
-
-        //tabledata: any[],
-        //indicators: ChoroplethIndicatorMetadata[],
-        //selections: {
-         //   indicatorId: string,
-         //   selectedFilterOptions: Dict<FilterOption[]>,
-          //  detail: number | null
-        //},
-        //filters: Filter[],
-        //countryAreaFilterOption: NestedFilterOption,
-        //areaFilterId: string
     }
-
-    //interface DisplayRow {
-    //    areaLabel: string,
-    //    areaHierarchy: string
-    //}
 
     interface Field {
         key: string,
@@ -79,12 +61,6 @@
     }
 
     interface Computed {
-        //nonAreaFilters: Filter[],
-        //filtersToDisplay: Filter[],
-        //areaFilter: Filter,
-        //flattenedAreas: Dict<NestedFilterOption>,
-        //selectedAreaIds: string[],
-        //selectedAreaFilterOptions: FilterOption[],
         generatedFields: Array<Field>,
         currentLanguage: Language
     }
@@ -118,28 +94,10 @@
         },
         computed: {
             generatedFields() {
-                //const fields: any[] = [];
-                /*fields.push({
-                    key: 'areaLabel',
-                    label: i18next.t('area', {lng: this.currentLanguage})
-                })
-                this.filtersToDisplay.map(value => {
-                    const field: Dict<any> = {};
-                    field.key = value.id
-                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
-                    fields.push(field)
-                })
-                this.indicators.map((value, index) => {
-                    const field: Dict<any> = {};
-                    field.key = value.indicator
-                    field.label = value.name
-                    fields.push(field)
-                })*/
-
                 const fields = this.tableConfig.columns.map(c => {
                     let label: string;
                     if (c.label.type === "string") {
-                        label = (c.label as GenericChartTableStringLabel).value;
+                        label = (c.label as GenericChartTableStringLabel).value; //TODO: should be translation keys, not English label
                     } else {
                         const filterId = (c.label as GenericChartTableSelectedFilterOptionLabel).filterId;
                         const selectedFilterOption = this.selectedFilterOptions[filterId][0];

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -45,7 +45,7 @@
         props: props,
         computed: {
             generatedFields() {
-                const fields = this.tableConfig.columns.map(column => {
+                return this.tableConfig.columns.map(column => {
                     let label: string;
                     if (column.header.type === "filterLabel") {
                         label = this.filters.find(f => f.id === column.header.filterId)?.label || column.header.filterId;
@@ -61,12 +61,10 @@
                         sortByFormatted: true
                     };
                 });
-
-                return fields
             },
             labelledData() {
                 const filtersDict = this.filters.reduce((dict, filter) => ({...dict, [filter.id]: filter}), {} as Dict<Filter>);
-                const result = this.filteredData.map(row => {
+                return this.filteredData.map(row => {
                     const friendlyRow = {...row};
                     this.tableConfig.columns.filter(column => column.data.labelFilterId).forEach(column => {
                         const filter = filtersDict[column.data.labelFilterId!];
@@ -76,7 +74,6 @@
 
                     return friendlyRow;
                 });
-                return result;
             }
         },
         components: {

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -1,0 +1,171 @@
+<template>
+    <div>
+        <br>
+        <div v-if="filteredData.length > 0">
+            <b-form-group class="mb-0">
+                <b-input-group size="sm">
+                    <b-form-input
+                            v-model="filter"
+                            type="search"
+                            id="filterInput"
+                            :placeholder="translate('typeSearch')"></b-form-input>
+                    <b-input-group-append>
+                        <b-button :disabled="!filter" @click="filter = ''" v-translate="'clearText'"></b-button>
+                    </b-input-group-append>
+                </b-input-group>
+            </b-form-group>
+            <b-table
+                    striped hover
+                    :fields="generatedFields"
+                    :items="filteredData"
+                    :sort-by.sync="sortBy"
+                    :sort-desc.sync="sortDesc"
+                    :filter="filter"
+                    responsive="sm"
+                    show-empty>
+            </b-table>
+        </div>
+        <div v-else v-translate="'noData'"></div>
+    </div>
+</template>
+
+<script lang="ts">
+    import Vue from "vue";
+    import i18next from "i18next";
+    import {findPath, iterateDataValues, formatOutput} from "./utils";
+    import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../generated";
+    import {
+        Dict,
+        Filter,
+        GenericChartTableConfig,
+        GenericChartTableSelectedFilterOptionLabel,
+        GenericChartTableStringLabel
+    } from "../../types";
+    import {flattenOptions, flattenToIdSet, mapStateProp} from "../../utils";
+    import {BButton, BFormGroup, BFormInput, BInputGroup, BInputGroupAppend, BTable} from 'bootstrap-vue';
+    import {RootState} from "../../root";
+    import {Language} from "../../store/translations/locales";
+
+    interface Props {
+        filteredData: any[],
+        //filters: Filter[],
+        selectedFilterOptions: Dict<FilterOption[]>,
+        tableConfig: GenericChartTableConfig
+
+        //tabledata: any[],
+        //indicators: ChoroplethIndicatorMetadata[],
+        //selections: {
+         //   indicatorId: string,
+         //   selectedFilterOptions: Dict<FilterOption[]>,
+          //  detail: number | null
+        //},
+        //filters: Filter[],
+        //countryAreaFilterOption: NestedFilterOption,
+        //areaFilterId: string
+    }
+
+    //interface DisplayRow {
+    //    areaLabel: string,
+    //    areaHierarchy: string
+    //}
+
+    interface Field {
+        key: string,
+        label?: string
+    }
+
+    interface Methods {
+        translator: string
+    }
+
+    interface Computed {
+        //nonAreaFilters: Filter[],
+        //filtersToDisplay: Filter[],
+        //areaFilter: Filter,
+        //flattenedAreas: Dict<NestedFilterOption>,
+        //selectedAreaIds: string[],
+        //selectedAreaFilterOptions: FilterOption[],
+        generatedFields: Array<Field>,
+        currentLanguage: Language
+    }
+
+    const props = {
+        filteredData: {
+            type: Array
+        },
+        selectedFilterOptions: {
+            type: Object
+        },
+        tableConfig: {
+            type: Object
+        }
+    }
+
+    export default Vue.extend<unknown, unknown, Computed, Props>({
+        name: "table-view",
+        props: props,
+        data() {
+            return {
+                sortBy: '',
+                sortDesc: false,
+                filter: null
+            }
+        },
+        methods: {
+            translate(word: string) {
+                return i18next.t(word, {lng: this.currentLanguage})
+            },
+        },
+        computed: {
+            generatedFields() {
+                //const fields: any[] = [];
+                /*fields.push({
+                    key: 'areaLabel',
+                    label: i18next.t('area', {lng: this.currentLanguage})
+                })
+                this.filtersToDisplay.map(value => {
+                    const field: Dict<any> = {};
+                    field.key = value.id
+                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
+                    fields.push(field)
+                })
+                this.indicators.map((value, index) => {
+                    const field: Dict<any> = {};
+                    field.key = value.indicator
+                    field.label = value.name
+                    fields.push(field)
+                })*/
+
+                const fields = this.tableConfig.columns.map(c => {
+                    let label: string;
+                    if (c.label.type === "string") {
+                        label = (c.label as GenericChartTableStringLabel).value;
+                    } else {
+                        const filterId = (c.label as GenericChartTableSelectedFilterOptionLabel).filterId;
+                        const selectedFilterOption = this.selectedFilterOptions[filterId][0];
+                        label = selectedFilterOption.label;
+                    }
+
+                    return {
+                        key: c.dataColumn,
+                        label,
+                        sortable: true,
+                        sortByFormatted: true
+                    };
+                });
+
+                return fields
+            },
+            currentLanguage: mapStateProp<RootState, Language>(null,
+                (state: RootState) => state.language)
+        },
+        components: {
+            BTable,
+            BFormGroup,
+            BFormInput,
+            BInputGroup,
+            BButton,
+            BInputGroupAppend
+        }
+    });
+</script>

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -29,7 +29,7 @@
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <area-indicators-table class="col-md-9"
-                                :tabledata="chartdata"
+                                :table-data="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="choroplethFilters"
                                 :countryAreaFilterOption="countryAreaFilterOption"
@@ -52,7 +52,7 @@
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <area-indicators-table class="col-md-9"
-                                :tabledata="chartdata"
+                                :table-data="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="barchartFilters"
                                 :countryAreaFilterOption="countryAreaFilterOption"
@@ -77,7 +77,7 @@
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <area-indicators-table class="col-md-9"
-                                :tabledata="chartdata"
+                                :table-data="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="bubblePlotFilters"
                                 :countryAreaFilterOption="countryAreaFilterOption"

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -28,7 +28,7 @@
                     @update-colour-scales="updateOutputColourScales({payload: $event})"></choropleth>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
-                    <table-view class="col-md-9"
+                    <area-indicators-table class="col-md-9"
                                 :tabledata="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="choroplethFilters"
@@ -37,7 +37,7 @@
                                 :selections="choroplethSelections"
 
                                 :selectedFilterOptions="choroplethSelections.selectedFilterOptions"
-                    ></table-view>
+                    ></area-indicators-table>
                 </div>
             </div>
 
@@ -51,7 +51,7 @@
                     @update="updateBarchartSelections({payload: $event})"></bar-chart-with-filters>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
-                    <table-view class="col-md-9"
+                    <area-indicators-table class="col-md-9"
                                 :tabledata="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="barchartFilters"
@@ -60,7 +60,7 @@
                                 :selections="barchartSelections"
 
                                 :selectedFilterOptions="barchartSelections.selectedFilterOptions"
-                    ></table-view>
+                    ></area-indicators-table>
                 </div>
             </div>
 
@@ -76,7 +76,7 @@
                              @update-size-scales="updateOutputBubbleSizeScales({payload: $event})"></bubble-plot>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
-                    <table-view class="col-md-9"
+                    <area-indicators-table class="col-md-9"
                                 :tabledata="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="bubblePlotFilters"
@@ -85,7 +85,7 @@
                                 :selections="bubblePlotSelections"
 
                                 :selectedFilterOptions="bubblePlotSelections.selectedFilterOptions"
-                    ></table-view>
+                    ></area-indicators-table>
                 </div>
             </div>
         </div>
@@ -97,7 +97,7 @@
     import Vue from "vue";
     import Choropleth from "../plots/choropleth/Choropleth.vue";
     import BubblePlot from "../plots/bubble/BubblePlot.vue";
-    import TableView from "../plots/table/Table.vue";
+    import AreaIndicatorsTable from "../plots/table/AreaIndicatorsTable.vue";
     import {BarchartIndicator, Filter, FilterConfig, FilterOption} from "@reside-ic/vue-charts/src/bar/types";
     import {BarChartWithFilters} from "@reside-ic/vue-charts";
 
@@ -240,7 +240,7 @@
             BarChartWithFilters,
             BubblePlot,
             Choropleth,
-            TableView
+            AreaIndicatorsTable
         }
     })
 </script>

--- a/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
+++ b/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
@@ -86,13 +86,6 @@
     export default Vue.extend<unknown, unknown, Computed, Props>({
         name: "AreaIndicatorsTable",
         props: props,
-        data() {
-            return {
-                sortBy: '',
-                sortDesc: false,
-                filter: null
-            }
-        },
         computed: {
             nonAreaFilters() {
                 return this.filters.filter((f: Filter) => f.id != this.areaFilterId);

--- a/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
+++ b/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
@@ -30,7 +30,7 @@
     import {Language} from "../../../store/translations/locales";
 
     interface Props {
-        tabledata: any[],
+        tableData: any[],
         indicators: ChoroplethIndicatorMetadata[],
         selections: {
             indicatorId: string,
@@ -60,7 +60,7 @@
     }
 
     const props = {
-        tabledata: {
+        tableData: {
             type: Array
         },
         filters: {
@@ -123,7 +123,7 @@
             },
             filteredData() {
                 const filteredValues: any[] = [];
-                iterateDataValues(this.tabledata,
+                iterateDataValues(this.tableData,
                     this.indicators,
                     this.selectedAreaIds,
                     this.nonAreaFilters,
@@ -169,19 +169,19 @@
                     key: 'areaLabel',
                     label: i18next.t('area', {lng: this.currentLanguage})
                 })
-                this.filtersToDisplay.map(value => {
+                this.filtersToDisplay.forEach(value => {
                     const field: Dict<any> = {};
                     field.key = value.id
                     field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
                     fields.push(field)
                 })
-                this.indicators.map((value, index) => {
+                this.indicators.forEach(value => {
                     const field: Dict<any> = {};
                     field.key = value.indicator
                     field.label = value.name
                     fields.push(field)
                 })
-                fields.map(field => {
+                fields.forEach(field => {
                     field.sortable = true
                     field.sortByFormatted = true
                 })

--- a/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
+++ b/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
@@ -1,0 +1,204 @@
+<template>
+   <table-view :filtered-data="filteredData" :fields="generatedFields">
+        <template v-slot:cell(areaLabel)="data">
+            <div>{{ data.item.areaLabel }}</div>
+            <div class="small">{{ data.item.areaHierarchy }}</div>
+        </template>
+        <template v-for="i in indicators" v-slot:[`cell(${i.indicator})`]="data">
+            <div :key="i.indicator">
+                <div class="value">{{ data.item[i.indicator] }}</div>
+                <div class="small" v-if="data.item[`${i.indicator}_lower`]">
+                    ({{ data.item[`${i.indicator}_lower`] }} – {{ data.item[`${i.indicator}_upper`] }})
+                </div>
+            </div>
+        </template>
+        <template v-slot:emptyfiltered>
+            <p class="text-center" v-translate="'noRecords'"></p>
+        </template>
+   </table-view>
+</template>
+
+<script lang="ts">
+    import Vue from "vue";
+    import i18next from "i18next";
+    import TableView, {Field} from "./Table.vue";
+    import {findPath, iterateDataValues, formatOutput} from "../utils";
+    import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../../generated";
+    import {Dict, Filter} from "../../../types";
+    import {flattenOptions, flattenToIdSet, mapStateProp} from "../../../utils";
+    import {RootState} from "../../../root";
+    import {Language} from "../../../store/translations/locales";
+
+    interface Props {
+        tabledata: any[],
+        indicators: ChoroplethIndicatorMetadata[],
+        selections: {
+            indicatorId: string,
+            selectedFilterOptions: Dict<FilterOption[]>,
+            detail: number | null
+        },
+        filters: Filter[],
+        countryAreaFilterOption: NestedFilterOption,
+        areaFilterId: string
+    }
+
+    interface DisplayRow {
+        areaLabel: string,
+        areaHierarchy: string
+    }
+
+    interface Computed {
+        nonAreaFilters: Filter[],
+        filtersToDisplay: Filter[],
+        areaFilter: Filter,
+        filteredData: DisplayRow[],
+        flattenedAreas: Dict<NestedFilterOption>,
+        selectedAreaIds: string[],
+        selectedAreaFilterOptions: FilterOption[],
+        generatedFields: Array<Field>,
+        currentLanguage: Language
+    }
+
+    const props = {
+        tabledata: {
+            type: Array
+        },
+        filters: {
+            type: Array
+        },
+        countryAreaFilterOption: {
+            type: Object
+        },
+        indicators: {
+            type: Array
+        },
+        areaFilterId: {
+            type: String
+        },
+        selectedFilterOptions: {
+            type: Object
+        },
+        selections: {
+            type: Object
+        }
+    }
+
+    export default Vue.extend<unknown, unknown, Computed, Props>({
+        name: "AreaIndicatorsTable",
+        props: props,
+        data() {
+            return {
+                sortBy: '',
+                sortDesc: false,
+                filter: null
+            }
+        },
+        computed: {
+            nonAreaFilters() {
+                return this.filters.filter((f: Filter) => f.id != this.areaFilterId);
+            },
+            areaFilter() {
+                return this.filters.find((f: Filter) => f.id == this.areaFilterId)!;
+            },
+            flattenedAreas() {
+                if (this.selections.detail === 0 || !this.selections.detail) {
+                    return this.areaFilter ? flattenOptions([this.countryAreaFilterOption]) : {};
+                }
+                return this.areaFilter ? flattenOptions(this.areaFilter.options) : {};
+            },
+            selectedAreaIds() {
+                const selectedAreaIdSet =
+                    flattenToIdSet(this.selectedAreaFilterOptions.map(o => o.id), this.flattenedAreas);
+                const areaArray = Array.from(selectedAreaIdSet);
+                if (this.selections.detail === 0) {
+                    return [areaArray[0]]
+                } else if (!this.selections.detail) {
+                    const selectedAreaOptions = this.selections.selectedFilterOptions.area || [];
+                    return selectedAreaOptions.map(row => row.id)
+                } else return areaArray.filter(val => parseInt(val[4]) === this.selections.detail);
+            },
+            selectedAreaFilterOptions() {
+                const selectedOptions = this.selections.selectedFilterOptions[this.areaFilterId];
+                if (this.selections.detail === 0) {
+                    return this.countryAreaFilterOption ? [this.countryAreaFilterOption] : []
+                } else if (selectedOptions && selectedOptions.length > 0) {
+                    return selectedOptions
+                } else return this.areaFilter ? this.areaFilter.options : []; //consider all top level areas to be selected if none are
+            },
+            filtersToDisplay() {
+                return this.nonAreaFilters.filter(f => f.options.length > 0)
+            },
+            filteredData() {
+                const filteredValues: any[] = [];
+                iterateDataValues(this.tabledata,
+                    this.indicators,
+                    this.selectedAreaIds,
+                    this.nonAreaFilters,
+                    this.selections.selectedFilterOptions,
+                    (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number, row: any) => {
+                        const filterValues: Dict<any> = {};
+                        this.filtersToDisplay.forEach(f => {
+                            if (row[f.column_id]) {
+                                filterValues[f.id] = row[f.column_id]
+                            }
+                        });
+                        const {upper, lower} = row
+                        filteredValues.push({areaId, filterValues, indicatorMeta, value, upper, lower});
+                    });
+                const displayRows: Dict<any> = {};
+                filteredValues.forEach(current => {
+                    const key = [current.areaId, ...this.nonAreaFilters.map(f => current.filterValues[f.id])].join("_");
+                    if (!(key in displayRows)) {
+                        const areaLabel = this.flattenedAreas[current.areaId].label;
+                        const areaHierarchy = findPath(current.areaId, this.countryAreaFilterOption.children)
+                        const filterLabels: Dict<string> = {};
+                        Object.keys(current.filterValues).forEach(k => {
+                            const selectedOptions = this.selections.selectedFilterOptions[k];
+                            filterLabels[k] = selectedOptions.filter(o => o.id == current.filterValues[k])[0].label;
+                        });
+                        displayRows[key] = {
+                            areaLabel,
+                            areaHierarchy,
+                            ...filterLabels,
+                        }
+                    }
+                    const {value, upper, lower} = current
+                    const { indicator, format, scale, accuracy } = current.indicatorMeta
+                    displayRows[key][indicator] = formatOutput(value, format, scale, accuracy);
+                    displayRows[key][`${indicator}_lower`] = lower ? formatOutput(lower, format, scale, accuracy): '';
+                    displayRows[key][`${indicator}_upper`] = upper ? formatOutput(upper, format, scale, accuracy): '';
+                });
+                return Object.values(displayRows);
+            },
+            generatedFields() {
+                const fields: any[] = [];
+                fields.push({
+                    key: 'areaLabel',
+                    label: i18next.t('area', {lng: this.currentLanguage})
+                })
+                this.filtersToDisplay.map(value => {
+                    const field: Dict<any> = {};
+                    field.key = value.id
+                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
+                    fields.push(field)
+                })
+                this.indicators.map((value, index) => {
+                    const field: Dict<any> = {};
+                    field.key = value.indicator
+                    field.label = value.name
+                    fields.push(field)
+                })
+                fields.map(field => {
+                    field.sortable = true
+                    field.sortByFormatted = true
+                })
+                return fields
+            },
+            currentLanguage: mapStateProp<RootState, Language>(null,
+                (state: RootState) => state.language)
+        },
+        components: {
+            TableView
+        }
+    });
+</script>

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -23,7 +23,9 @@
                 :filter="filter"
                 responsive="sm"
                 show-empty>
-                <slot></slot>
+                <template v-for="(_, slot) in $scopedSlots" v-slot:[slot]="props">
+                    <slot :name="slot" v-bind="props" />
+                </template>
             </b-table>
         </div>
         <div v-else v-translate="'noData'"></div>
@@ -80,7 +82,6 @@
         },
         methods: {
             translate(word: string) {
-                // TEST
                 return i18next.t(word, {lng: this.currentLanguage})
             },
         },

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -80,6 +80,7 @@
         },
         methods: {
             translate(word: string) {
+                // TEST
                 return i18next.t(word, {lng: this.currentLanguage})
             },
         },

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -24,7 +24,7 @@
                 responsive="sm"
                 show-empty>
                 <template v-for="(_, slot) in $scopedSlots" v-slot:[slot]="props">
-                    <slot :name="slot" v-bind="props" />
+                    <slot :name="slot" v-bind="props" />-
                 </template>
             </b-table>
         </div>
@@ -35,10 +35,7 @@
 <script lang="ts">
     import Vue from "vue";
     import i18next from "i18next";
-    import {findPath, iterateDataValues, formatOutput} from "../utils";
-    import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../../generated";
-    import {Dict, Filter} from "../../../types";
-    import {flattenOptions, flattenToIdSet, mapStateProp} from "../../../utils";
+    import {mapStateProp} from "../../../utils";
     import {BButton, BFormGroup, BFormInput, BInputGroup, BInputGroupAppend, BTable} from 'bootstrap-vue';
     import {RootState} from "../../../root";
     import {Language} from "../../../store/translations/locales";

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -24,7 +24,7 @@
                 responsive="sm"
                 show-empty>
                 <template v-for="(_, slot) in $scopedSlots" v-slot:[slot]="props">
-                    <slot :name="slot" v-bind="props" />-
+                    <slot :name="slot" v-bind="props" />
                 </template>
             </b-table>
         </div>

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -51,6 +51,8 @@
     export interface Field {
         key: string,
         label?: string
+        sortable: boolean,
+        sortByFormatted: boolean
     }
 
     interface Methods {

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -16,28 +16,14 @@
             </b-form-group>
             <b-table
                 striped hover
-                :fields="generatedFields"
+                :fields="fields"
                 :items="filteredData"
                 :sort-by.sync="sortBy"
                 :sort-desc.sync="sortDesc"
                 :filter="filter"
                 responsive="sm"
                 show-empty>
-                <template v-slot:cell(areaLabel)="data">
-                    <div>{{ data.item.areaLabel }}</div>
-                    <div class="small">{{ data.item.areaHierarchy }}</div>
-                </template>
-                <template v-for="i in indicators" v-slot:[`cell(${i.indicator})`]="data">
-                    <div :key="i.indicator">
-                        <div class="value">{{ data.item[i.indicator] }}</div>
-                        <div class="small" v-if="data.item[`${i.indicator}_lower`]">
-                            ({{ data.item[`${i.indicator}_lower`] }} – {{ data.item[`${i.indicator}_upper`] }})
-                        </div>
-                    </div>
-                </template>
-                <template v-slot:emptyfiltered>
-                    <p class="text-center" v-translate="'noRecords'"></p>
-                </template>
+                <slot></slot>
             </b-table>
         </div>
         <div v-else v-translate="'noData'"></div>
@@ -56,24 +42,11 @@
     import {Language} from "../../../store/translations/locales";
 
     interface Props {
-        tabledata: any[],
-        indicators: ChoroplethIndicatorMetadata[],
-        selections: {
-            indicatorId: string,
-            selectedFilterOptions: Dict<FilterOption[]>,
-            detail: number | null
-        },
-        filters: Filter[],
-        countryAreaFilterOption: NestedFilterOption,
-        areaFilterId: string
+        filteredData: any[],
+        fields: Field[]
     }
 
-    interface DisplayRow {
-        areaLabel: string,
-        areaHierarchy: string
-    }
-
-    interface Field {
+    export interface Field {
         key: string,
         label?: string
     }
@@ -83,40 +56,17 @@
     }
 
     interface Computed {
-        nonAreaFilters: Filter[],
-        filtersToDisplay: Filter[],
-        areaFilter: Filter,
-        filteredData: DisplayRow[],
-        flattenedAreas: Dict<NestedFilterOption>,
-        selectedAreaIds: string[],
-        selectedAreaFilterOptions: FilterOption[],
-        generatedFields: Array<Field>,
         currentLanguage: Language
     }
 
     const props = {
-        tabledata: {
+        filteredData: {
             type: Array
         },
-        filters: {
+        fields: {
             type: Array
-        },
-        countryAreaFilterOption: {
-            type: Object
-        },
-        indicators: {
-            type: Array
-        },
-        areaFilterId: {
-            type: String
-        },
-        selectedFilterOptions: {
-            type: Object
-        },
-        selections: {
-            type: Object
         }
-    }
+    };
 
     export default Vue.extend<unknown, unknown, Computed, Props>({
         name: "table-view",
@@ -134,106 +84,6 @@
             },
         },
         computed: {
-            nonAreaFilters() {
-                return this.filters.filter((f: Filter) => f.id != this.areaFilterId);
-            },
-            areaFilter() {
-                return this.filters.find((f: Filter) => f.id == this.areaFilterId)!;
-            },
-            flattenedAreas() {
-                if (this.selections.detail === 0 || !this.selections.detail) {
-                    return this.areaFilter ? flattenOptions([this.countryAreaFilterOption]) : {};
-                }
-                return this.areaFilter ? flattenOptions(this.areaFilter.options) : {};
-            },
-            selectedAreaIds() {
-                const selectedAreaIdSet =
-                    flattenToIdSet(this.selectedAreaFilterOptions.map(o => o.id), this.flattenedAreas);
-                const areaArray = Array.from(selectedAreaIdSet);
-                if (this.selections.detail === 0) {
-                    return [areaArray[0]]
-                } else if (!this.selections.detail) {
-                    const selectedAreaOptions = this.selections.selectedFilterOptions.area || [];
-                    return selectedAreaOptions.map(row => row.id)
-                } else return areaArray.filter(val => parseInt(val[4]) === this.selections.detail);
-            },
-            selectedAreaFilterOptions() {
-                const selectedOptions = this.selections.selectedFilterOptions[this.areaFilterId];
-                if (this.selections.detail === 0) {
-                    return this.countryAreaFilterOption ? [this.countryAreaFilterOption] : []
-                } else if (selectedOptions && selectedOptions.length > 0) {
-                    return selectedOptions
-                } else return this.areaFilter ? this.areaFilter.options : []; //consider all top level areas to be selected if none are
-            },
-            filtersToDisplay() {
-                return this.nonAreaFilters.filter(f => f.options.length > 0)
-            },
-            filteredData() {
-                const filteredValues: any[] = [];
-                iterateDataValues(this.tabledata,
-                    this.indicators,
-                    this.selectedAreaIds,
-                    this.nonAreaFilters,
-                    this.selections.selectedFilterOptions,
-                    (areaId: string, indicatorMeta: ChoroplethIndicatorMetadata, value: number, row: any) => {
-                        const filterValues: Dict<any> = {};
-                        this.filtersToDisplay.forEach(f => {
-                            if (row[f.column_id]) {
-                                filterValues[f.id] = row[f.column_id]
-                            }
-                        });
-                        const {upper, lower} = row
-                        filteredValues.push({areaId, filterValues, indicatorMeta, value, upper, lower});
-                    });
-                const displayRows: Dict<any> = {};
-                filteredValues.forEach(current => {
-                    const key = [current.areaId, ...this.nonAreaFilters.map(f => current.filterValues[f.id])].join("_");
-                    if (!(key in displayRows)) {
-                        const areaLabel = this.flattenedAreas[current.areaId].label;
-                        const areaHierarchy = findPath(current.areaId, this.countryAreaFilterOption.children)
-                        const filterLabels: Dict<string> = {};
-                        Object.keys(current.filterValues).forEach(k => {
-                            const selectedOptions = this.selections.selectedFilterOptions[k];
-                            filterLabels[k] = selectedOptions.filter(o => o.id == current.filterValues[k])[0].label;
-                        });
-                        displayRows[key] = {
-                            areaLabel,
-                            areaHierarchy,
-                            ...filterLabels,
-                        }
-                    }
-                    const {value, upper, lower} = current
-                    const { indicator, format, scale, accuracy } = current.indicatorMeta
-                    displayRows[key][indicator] = formatOutput(value, format, scale, accuracy);
-                    displayRows[key][`${indicator}_lower`] = lower ? formatOutput(lower, format, scale, accuracy): '';
-                    displayRows[key][`${indicator}_upper`] = upper ? formatOutput(upper, format, scale, accuracy): '';
-                });
-                return Object.values(displayRows);
-            },
-            generatedFields() {
-                const fields: any[] = [];
-                fields.push({
-                    key: 'areaLabel',
-                    label: i18next.t('area', {lng: this.currentLanguage})
-                })
-                this.filtersToDisplay.map(value => {
-                    const field: Dict<any> = {};
-                    field.key = value.id
-                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
-                    fields.push(field)
-                })
-                this.indicators.map((value, index) => {
-                    const field: Dict<any> = {};
-                    field.key = value.indicator
-                    field.label = value.name
-                    fields.push(field)
-                })
-                fields.map(field => {
-                    field.sortable = true
-                    field.sortByFormatted = true
-                })
-                return fields
-            },
             currentLanguage: mapStateProp<RootState, Language>(null,
                 (state: RootState) => state.language)
         },

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -46,7 +46,7 @@
                             @update="updateChoroplethSelections({payload: $event})"
                             @update-colour-scales="updateSAPColourScales({payload: [selectedDataType, $event]})"></choropleth>
                 <div>
-                    <area-indicators-table :tabledata="data"
+                    <area-indicators-table :table-data="data"
                                 :area-filter-id="areaFilterId"
                                 :filters="filters"
                                 :countryAreaFilterOption="countryAreaFilterOption"

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -46,14 +46,14 @@
                             @update="updateChoroplethSelections({payload: $event})"
                             @update-colour-scales="updateSAPColourScales({payload: [selectedDataType, $event]})"></choropleth>
                 <div>
-                    <table-view :tabledata="data"
+                    <area-indicators-table :tabledata="data"
                                 :area-filter-id="areaFilterId"
                                 :filters="filters"
                                 :countryAreaFilterOption="countryAreaFilterOption"
                                 :indicators="filterTableIndicators"
                                 :selections="plottingSelections"
                                 :selectedFilterOptions="plottingSelections.selectedFilterOptions"
-                    ></table-view>
+                    ></area-indicators-table>
                 </div>
             </div>
         </div>
@@ -72,7 +72,7 @@
     import i18next from "i18next";
     import {mapGetters, mapMutations, mapState} from "vuex";
     import Choropleth from "../plots/choropleth/Choropleth.vue";
-    import TableView from "../plots/table/Table.vue";
+    import AreaIndicatorsTable from "../plots/table/AreaIndicatorsTable.vue";
     import Filters from "../plots/Filters.vue";
     import {
         Filter,
@@ -208,7 +208,7 @@
         components: {
             Choropleth,
             Filters,
-            TableView,
+            AreaIndicatorsTable,
             TreeSelect,
             GenericChart
         }

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -181,10 +181,28 @@ export interface SelectedADRUploadFiles {
     coarseOutput?: any
 }
 
+export interface GenericChartTableStringLabel {
+    type: "string",
+    value: string
+}
+
+export interface GenericChartTableSelectedFilterOptionLabel {
+    type: "selectedFilterOption",
+    filterId: string
+}
+
+export interface GenericChartTableConfig {
+    columns: {
+        dataColumn: string,
+        label: GenericChartTableStringLabel | GenericChartTableSelectedFilterOptionLabel
+    }[]
+}
+
 export interface DatasetConfig {
     id: string
     label: string
     url: string
+    table?: GenericChartTableConfig
 }
 
 export interface DataSourceConfig {

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -181,20 +181,16 @@ export interface SelectedADRUploadFiles {
     coarseOutput?: any
 }
 
-export interface GenericChartTableStringLabel {
-    type: "string",
-    value: string
-}
-
-export interface GenericChartTableSelectedFilterOptionLabel {
-    type: "selectedFilterOption",
-    filterId: string
-}
-
 export interface GenericChartTableConfig {
     columns: {
-        dataColumn: string,
-        label: GenericChartTableStringLabel | GenericChartTableSelectedFilterOptionLabel
+        data: {
+            columnId: string,
+            labelFilterId: string | null
+        },
+        header: {
+            type: "filterLabel" | "selectedFilterOption",
+            filterId: string
+        }
     }[]
 }
 

--- a/src/app/static/src/tests/components/genericChart/genericChart.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChart.test.ts
@@ -285,7 +285,7 @@ describe("GenericChart component", () => {
         const state = {datasets};
         const reducedMetadata =  {
             "test-chart": {
-                datasets: metadata["test-chart"].datasets[0],
+                datasets: [metadata["test-chart"].datasets[0]],
                 dataSelectors: {
                     dataSources: [
                         {id: "visible1", type: "editable", label: "First", datasetId: "dataset1", showFilters: true, showIndicators: false},

--- a/src/app/static/src/tests/components/genericChart/genericChart.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChart.test.ts
@@ -19,6 +19,7 @@ import {GenericChartMetadataResponse} from "../../../app/types";
 import {actions} from "../../../app/store/genericChart/actions";
 import {mutations} from "../../../app/store/genericChart/mutations";
 import {mockAxios} from "../../mocks";
+import GenericChartTable from "../../../app/components/genericChart/GenericChartTable.vue";
 
 describe("GenericChart component", () => {
 
@@ -459,5 +460,62 @@ describe("GenericChart component", () => {
         const genericChartError = {error: "TEST-ERROR"} as any;
         const wrapper = getWrapper( {datasets, genericChartError});
         expect(wrapper.find(ErrorAlert).props("error")).toBe(genericChartError);
+    });
+
+    it("does not render table if no table config for data source's dataset", () => {
+        const state = {datasets};
+        const wrapper = getWrapper(state);
+
+        setTimeout(() => {
+            expect(wrapper.findAll(GenericChartTable).length).toBe(0);
+        });
+    });
+
+    it("renders table if table config exists for data source's dataset", (done) => {
+        const tableConfig1 = {
+            columns: [
+                {
+                    data: {columnId: "age", labelFilterId: null},
+                    header: {type: "filterLabel", filterId: "age"}
+                }
+            ]
+        };
+        const tableConfig2 = {
+            columns: [
+                {
+                    data: {columnId: "year", labelFilterId: "year"},
+                    header: {type: "filterLabel", filterId: "year"}
+                }
+            ]
+        };
+
+        const customMetadata = {
+            "test-chart": {
+                ...metadata["test-chart"],
+                datasets: [
+                    {...metadata["test-chart"].datasets[0], table: tableConfig1},
+                    {...metadata["test-chart"].datasets[1], table: tableConfig2},
+                    metadata["test-chart"].datasets[2]
+                ] as any
+            }
+        };
+        const state = {datasets};
+        const wrapper = getWrapper(state, customMetadata);
+
+        setTimeout(() => {
+            const tables = wrapper.findAll(GenericChartTable);
+            expect(tables.length).toBe(2);
+            expect(tables.at(0).props("tableConfig")).toBe(tableConfig1);
+            expect(tables.at(0).props("filteredData")).toStrictEqual([{age: "1", year: "2021", value: 2}]);
+            expect(tables.at(0).props("filters")).toBe(datasets.dataset1.metadata.filters);
+            expect(tables.at(0).props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
+
+            expect(tables.at(1).props("tableConfig")).toBe(tableConfig2);
+            expect(tables.at(1).props("filteredData")).toStrictEqual([{age: "10", year: "2020", value: 10}]);
+            expect(tables.at(1).props("filters")).toBe(datasets.dataset2.metadata.filters);
+            expect(tables.at(1).props("selectedFilterOptions")).toStrictEqual(datasets.dataset2.metadata.defaults.selected_filter_options);
+
+            done();
+        });
     });
 });

--- a/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
@@ -1,0 +1,114 @@
+import {shallowMount} from "@vue/test-utils";
+import GenericChartTable from "../../../app/components/genericChart/GenericChartTable.vue";
+import Table from "../../../app/components/plots/table/Table.vue";
+
+describe("GenericChartTable component", () => {
+    const tableConfig = {
+        "columns": [
+            {
+                "data": {
+                    "columnId": "area_name",
+                    "labelFilterId": null
+                },
+                "header": {
+                    "type": "filterLabel",
+                    "filterId": "area_name"
+                }
+            },
+            {
+                "data": {
+                    "columnId": "area_level_id",
+                    "labelFilterId": "area_level"
+                },
+                "header": {
+                    "type": "filterLabel",
+                    "filterId": "area_level"
+                }
+            },
+            {
+                "data": {
+                    "columnId": "age_group",
+                    "labelFilterId": "age"
+                },
+                "header": {
+                    "type": "filterLabel",
+                    "filterId": "age"
+                }
+            },
+            {
+                "data": {
+                    "columnId": "value",
+                    "labelFilterId": null
+                },
+                "header": {
+                    "type": "selectedFilterOption",
+                    "filterId": "plot_type"
+                }
+            }
+        ]
+    };
+
+    const filteredData = [
+        {area_name: "Malawi", area_level_id: 0, age_group: "0:15", plot_type: "prevalence", value: 200},
+        {area_name: "Chitipa", area_level_id: 1, age_group: "15:49", plot_type: "prevalence", value: 100}
+    ];
+
+    const filters = [
+        {
+            id: "area_level",
+            label: "Area level",
+            options: [
+                {id: 0, label: "Country"},
+                {id: 1, label: "Region"}
+            ]
+        },
+        {
+            id: "age",
+            label: "Age",
+            options: [
+                {id: "0:15", label: "0-15"},
+                {id: "15:49", label: "15-49"}
+            ]
+        },
+        {
+            id: "plot_type",
+            label: "Plot type",
+            options: [
+                {id: "prevalence", label: "HIV prevalence"},
+                {id: "plhiv", label: "PLHIV"}
+            ]
+        }
+    ];
+
+    const selectedFilterOptions = {
+        area_level: [{id: "area1", label: "Area One"}],
+        plot_type: [{id: "prevalence", label: "HIV prevalence"}]
+    };
+
+    const getWrapper = () => {
+        const propsData = {tableConfig, filteredData, filters, selectedFilterOptions};
+        return shallowMount(GenericChartTable, {propsData});
+    };
+
+    it("renders table component with expected fields", () => {
+        const wrapper = getWrapper();
+        const table = wrapper.find(Table);
+        const expectedFields = [
+            {key: "area_name", label: "area_name", sortable: true, sortByFormatted: true},
+            {key: "area_level_id", label: "Area level", sortable: true, sortByFormatted: true},
+            {key: "age_group", label: "Age", sortable: true, sortByFormatted: true},
+            {key: "value", label: "HIV prevalence", sortable: true, sortByFormatted: true}
+        ];
+        expect(table.props("fields")).toStrictEqual(expectedFields);
+    });
+
+    it("renders table component with expected labelled data", () => {
+        const wrapper = getWrapper();
+        const table = wrapper.find(Table);
+        const expectedData = [
+            {area_name: "Malawi", area_level_id: "Country", age_group: "0-15", plot_type: "prevalence", value: 200},
+            {area_name: "Chitipa", area_level_id: "Region", age_group: "15-49", plot_type: "prevalence", value: 100}
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedData);
+    });
+});

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -309,7 +309,7 @@ describe("ModelOutput component", () => {
         expect(table.props().filters).toStrictEqual(["TEST CHORO FILTERS"]);
         expect(table.props().selections).toStrictEqual({test: "TEST CHORO SELECTIONS"});
         expect(table.props().indicators).toStrictEqual(["TEST CHORO INDICATORS"]);
-        expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
+        expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
     });
 
@@ -341,7 +341,7 @@ describe("ModelOutput component", () => {
         expect(table.props().filters).toStrictEqual(["TEST BUBBLE FILTERS"]);
         expect(table.props().selections).toStrictEqual({test: "TEST BUBBLE SELECTIONS"});
         expect(table.props().indicators).toStrictEqual(["TEST BUBBLE INDICATORS", "TEST BUBBLE INDICATORS"]);
-        expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
+        expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
     });
 
@@ -399,7 +399,7 @@ describe("ModelOutput component", () => {
                 age: {id: "a1", label: "0-4"}
             }
         });
-        expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
+        expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
     });
 

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -16,6 +16,7 @@ import Choropleth from "../../../app/components/plots/choropleth/Choropleth.vue"
 import BubblePlot from "../../../app/components/plots/bubble/BubblePlot.vue";
 import {expectTranslated} from "../../testHelpers";
 import {BarchartIndicator} from "../../../app/types";
+import AreaIndicatorsTable from "../../../app/components/plots/table/AreaIndicatorsTable.vue";
 
 const localVue = createLocalVue();
 
@@ -303,7 +304,7 @@ describe("ModelOutput component", () => {
         const store = getStore();
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.find("table-view-stub");
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().filters).toStrictEqual(["TEST CHORO FILTERS"]);
         expect(table.props().selections).toStrictEqual({test: "TEST CHORO SELECTIONS"});
@@ -326,7 +327,7 @@ describe("ModelOutput component", () => {
             });
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.find("table-view-stub");
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().selections).toStrictEqual({indicatorId: "art_coverage"});
         expect(table.props().indicators).toStrictEqual([{"indicator": "art_coverage", "indicator_value": "4"}]);
     });
@@ -335,7 +336,7 @@ describe("ModelOutput component", () => {
         const store = getStore({selectedTab: "bubble"});
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll("table-view-stub").at(1);
+        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().filters).toStrictEqual(["TEST BUBBLE FILTERS"]);
         expect(table.props().selections).toStrictEqual({test: "TEST BUBBLE SELECTIONS"});
@@ -363,7 +364,7 @@ describe("ModelOutput component", () => {
             });
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll("table-view-stub").at(1);
+        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
         expect(table.props().selections).toStrictEqual({
             colorIndicatorId: "art_coverage",
             sizeIndicatorId: "current_art"
@@ -386,7 +387,7 @@ describe("ModelOutput component", () => {
         const store = getStore({selectedTab: "bar"});
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.find("table-view-stub");
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().filters).toStrictEqual(["TEST BAR FILTERS"]);
         expect(table.props().selections).toStrictEqual({
@@ -416,7 +417,7 @@ describe("ModelOutput component", () => {
             });
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.find("table-view-stub");
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().selections).toStrictEqual({indicatorId: "art_coverage"});
         expect(table.props().indicators).toStrictEqual(
             [

--- a/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
+++ b/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
@@ -30,7 +30,7 @@ const propsData = {
         "format": "0.00%",
         "scale": 1
     }],
-    tabledata: [
+    tableData: [
         ...testData.chartdata
     ],
     countryAreaFilterOption: {
@@ -350,7 +350,7 @@ describe("areaIndicatorsTable", () => {
         ]
     };
     const tableDataWithCountryValue = [
-        ...propsData.tabledata,
+        ...propsData.tableData,
         {
             area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
         }
@@ -374,7 +374,7 @@ describe("areaIndicatorsTable", () => {
                 ...propsData.selections,
                 detail: 0
             },
-            tabledata: tableDataWithCountryValue,
+            tableData: tableDataWithCountryValue,
             filters: [
                 countryLevelAreaFilter,
                 {...propsData.filters[1]},
@@ -411,7 +411,7 @@ describe("areaIndicatorsTable", () => {
                     ]
                 }
             },
-            tabledata: tableDataWithCountryValue,
+            tableData: tableDataWithCountryValue,
             filters: [
                 countryLevelAreaFilter,
                 {...propsData.filters[1]},
@@ -437,7 +437,7 @@ describe("areaIndicatorsTable", () => {
                     }]
                 }
             },
-            tabledata: tableDataWithCountryValue,
+            tableData: tableDataWithCountryValue,
             filters: [
                 countryLevelAreaFilter,
                 {...propsData.filters[1]},

--- a/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
+++ b/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
@@ -41,7 +41,7 @@ const propsData = {
     }
 };
 
-const createStore = (language: Language) => {
+const createStore = (language: Language = Language.en) => {
     const store = new Vuex.Store({
         state: {language}
     });
@@ -55,6 +55,12 @@ const getWrapper = (customPropsData: any = {}, language: Language = Language.en)
 };
 
 describe("areaIndicatorsTable", () => {
+    it('mount test', () => {
+        const store = createStore();
+        mount(AreaIndicatorsTable, {store, propsData});
+    });
+
+
     it('renders Table with correct fields', () => {
         const wrapper = getWrapper();
         const table = wrapper.find(Table);
@@ -442,4 +448,27 @@ describe("areaIndicatorsTable", () => {
 
         expect(table.props("filteredData")).toStrictEqual(expectedCountryLevelData);
     });
+
+    it('area hierarchy is rendered in child Table component', () => {
+        const store = createStore();
+        const wrapper = mount(AreaIndicatorsTable, {store, propsData});
+
+        expect(wrapper.findAll('td').at(0).findAll("div").at(0).text()).toBe('4.1');
+        expect(wrapper.findAll('td').at(0).find(".small").text()).toBe('3.1');
+    });
+
+    it('uncertainty is rendered in child Table component', () => {
+        const customPropsData = {
+            selections: {
+                ...propsData.selections,
+                detail: 3,
+            }
+        };
+
+        const store = createStore();
+        const wrapper = mount(AreaIndicatorsTable, {store, propsData: {...propsData, ...customPropsData}});
+
+        expect(wrapper.findAll('td').at(3).find(".value").text()).toBe('1.00%');
+        expect(wrapper.findAll('td').at(3).find(".small").text()).toBe('(1.00% – 10.00%)');
+    })
 });

--- a/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
+++ b/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
@@ -1,0 +1,445 @@
+import AreaIndicatorsTable from "../../../../app/components/plots/table/AreaIndicatorsTable.vue";
+import Table from "../../../../app/components/plots/table/Table.vue";
+import {testData} from "../testHelpers";
+import {mount, shallowMount} from "@vue/test-utils";
+import Vuex from "vuex";
+import {Language} from "../../../../app/store/translations/locales";
+import registerTranslations from "../../../../app/store/translations/registerTranslations";
+
+const propsData = {
+    ...testData,
+    selections: {
+        indicatorId: "prevalence",
+        detail: 4,
+        selectedFilterOptions: {
+            age: [{id: "0:15", label: "0-15"}],
+            sex: [{id: "female", label: "Female"}],
+            area: []
+        },
+    },
+    indicators: [{
+        indicator: "prevalence",
+        "value_column": "prevalence",
+        "indicator_column": "",
+        "indicator_value": "",
+        "name": "HIV prevalence",
+        "min": 0,
+        "max": 0.5,
+        "colour": "interpolateMagma",
+        "invert_scale": true,
+        "format": "0.00%",
+        "scale": 1
+    }],
+    tabledata: [
+        ...testData.chartdata
+    ],
+    countryAreaFilterOption: {
+        id: "MWI", label: "Malawi", children: [
+            {"id": "MWI_3_1", "label": "3.1", "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]},
+            {"id": "MWI_3_2", "label": "3.2", "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]}
+        ]
+    }
+};
+
+const createStore = (language: Language) => {
+    const store = new Vuex.Store({
+        state: {language}
+    });
+    registerTranslations(store);
+    return store as any;
+};
+
+const getWrapper = (customPropsData: any = {}, language: Language = Language.en) => {
+    const store = createStore(language);
+    return shallowMount(AreaIndicatorsTable, {store, propsData: {...propsData, ...customPropsData}});
+};
+
+describe("areaIndicatorsTable", () => {
+    it('renders Table with correct fields', () => {
+        const wrapper = getWrapper();
+        const table = wrapper.find(Table);
+
+        const expectedFields = [
+            {key: "areaLabel", label: "Area", sortable: true, sortByFormatted: true},
+            {key: "age", label: "Age", sortable: true, sortByFormatted: true},
+            {key: "sex", label: "Sex", sortable: true, sortByFormatted: true},
+            {key: "prevalence", label: "HIV prevalence", sortable: true, sortByFormatted: true}
+        ];
+        expect(table.props("fields")).toStrictEqual(expectedFields);
+    });
+
+    it('renders Table with correct fields in French', () => {
+        const wrapper = getWrapper({}, Language.fr);
+        const table = wrapper.find(Table);
+
+        const expectedFields = [
+            {key: "areaLabel", label: "Zone", sortable: true, sortByFormatted: true},
+            {key: "age", label: "Âge", sortable: true, sortByFormatted: true},
+            {key: "sex", label: "Sexe", sortable: true, sortByFormatted: true},
+            {key: "prevalence", label: "HIV prevalence", sortable: true, sortByFormatted: true}
+        ];
+        expect(table.props("fields")).toStrictEqual(expectedFields);
+    });
+
+    it('renders Table with correct data', () => {
+        const wrapper = getWrapper();
+        const table = wrapper.find(Table);
+
+        const expectedFilteredData = [
+            {
+                areaLabel: "4.1",
+                areaHierarchy: "3.1",
+                prevalence: "10.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            },
+            {
+                areaLabel: "4.2",
+                areaHierarchy: "3.2",
+                prevalence: "20.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            }
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    it('renders Table with correct data when male selected', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                selectedFilterOptions: {
+                    ...propsData.selections.selectedFilterOptions,
+                    sex: [{id: "male", label: "Male"}]
+                }
+            }
+        });
+        const table = wrapper.find(Table);
+
+        const expectedFilteredData = [
+            {
+                areaLabel: "4.2",
+                areaHierarchy: "3.2",
+                prevalence: "10.00%",
+                age: "0-15",
+                sex: "Male",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            },
+            {
+                areaLabel: "4.1",
+                areaHierarchy: "3.1",
+                prevalence: "90.00%",
+                age: "0-15",
+                sex: "Male",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            }
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    it('renders Table with correct data when detail set to 3', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                detail: 3,
+            }
+        });
+        const table = wrapper.find(Table);
+
+        const expectedFilteredData = [
+            {
+                areaLabel: "3.1",
+                areaHierarchy: "",
+                prevalence: "1.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "1.00%",
+                prevalence_upper: "10.00%"
+            },
+            {
+                areaLabel: "3.2",
+                areaHierarchy: "",
+                prevalence: "0.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            }
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    it('renders Table correctly when no data are available for selected filters', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                selectedFilterOptions: {
+                    age: [{id: "15:30", label: "15-30"}],
+                    sex: [{id: "male", label: "Male"}],
+                    area: []
+                }
+            }
+        });
+        const table = wrapper.find(Table);
+        expect(table.props("filteredData")).toStrictEqual([]);
+    });
+
+    it('renders Table data correctly when plhiv indicator is selected', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                indicatorId: "plhiv"
+            },
+            indicators: [{
+                ...propsData.indicators,
+                indicator: "plhiv", value_column: "plhiv", name: "PLHIV", format: "0,0", scale: 10
+            }]
+        });
+        const expectedFilteredData = [
+            {
+                areaLabel: "4.1",
+                areaHierarchy: "3.1",
+                plhiv: "100",
+                age: "0-15",
+                sex: "Female",
+                plhiv_lower: "",
+                plhiv_upper: ""
+            },
+            {
+                areaLabel: "4.2",
+                areaHierarchy: "3.2",
+                plhiv: "200",
+                age: "0-15",
+                sex: "Female",
+                plhiv_lower: "",
+                plhiv_upper: ""
+            }
+        ];
+        const table = wrapper.find(Table);
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    it('renders Table data correctly when 3.2 is selected only', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                selectedFilterOptions: {
+                    ...propsData.selections.selectedFilterOptions,
+                    area: [{
+                        "id": "MWI_3_2",
+                        "label": "3.2",
+                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                    }]
+                }
+            },
+            filters: [
+                {
+                    ...propsData.filters[0],
+                    options: [
+                        {
+                            "id": "MWI_3_1",
+                            "label": "3.1",
+                            "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
+                        },
+                        {
+                            "id": "MWI_3_2",
+                            "label": "3.2",
+                            "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                        }
+                    ]
+                },
+                {...propsData.filters[1]},
+                {...propsData.filters[2]}
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        const expectedFilteredData = [
+            {
+                areaLabel: "4.2",
+                areaHierarchy: "3.2",
+                prevalence: "20.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            }
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    it('renders Table data correctly when 3.2 is selected only and detail is set to 3', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                detail: 3,
+                selectedFilterOptions: {
+                    ...propsData.selections.selectedFilterOptions,
+                    area: [{
+                        "id": "MWI_3_2",
+                        "label": "3.2",
+                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                    }]
+                }
+            },
+            filters: [
+                {
+                    ...propsData.filters[0],
+                    options: [
+                        {
+                            "id": "MWI_3_1",
+                            "label": "3.1",
+                            "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
+                        },
+                        {
+                            "id": "MWI_3_2",
+                            "label": "3.2",
+                            "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                        }
+                    ]
+                },
+                {...propsData.filters[1]},
+                {...propsData.filters[2]}
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        const expectedFilteredData = [
+            {
+                areaLabel: "3.2",
+                areaHierarchy: "",
+                prevalence: "0.00%",
+                age: "0-15",
+                sex: "Female",
+                prevalence_lower: "",
+                prevalence_upper: ""
+            }
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedFilteredData);
+    });
+
+    const countryLevelAreaFilter = {
+        ...propsData.filters[0],
+        options: [
+            {
+                id: "MWI", label: "Malawi", children: [
+                    {
+                        "id": "MWI_3_1",
+                        "label": "3.1",
+                        "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
+                    },
+                    {
+                        "id": "MWI_3_2",
+                        "label": "3.2",
+                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                    }
+                ]
+            },
+        ]
+    };
+    const tableDataWithCountryValue = [
+        ...propsData.tabledata,
+        {
+            area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
+        }
+    ];
+
+    const expectedCountryLevelData = [
+        {
+            areaLabel: "Malawi",
+            areaHierarchy: undefined,
+            prevalence: "50.00%",
+            age: "0-15",
+            sex: "Female",
+            prevalence_lower: "",
+            prevalence_upper: ""
+        }
+    ];
+
+    it('renders Table data correctly when detail set to 0', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                detail: 0
+            },
+            tabledata: tableDataWithCountryValue,
+            filters: [
+                countryLevelAreaFilter,
+                {...propsData.filters[1]},
+                {...propsData.filters[2]}
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        expect(table.props("filteredData")).toStrictEqual(expectedCountryLevelData);
+    });
+
+    it('renders Table with country level data when detail set to null', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                detail: null,
+                selectedFilterOptions: {
+                    ...propsData.selections.selectedFilterOptions,
+                    area: [
+                        {
+                            id: "MWI", label: "Malawi", children: [
+                                {
+                                    "id": "MWI_3_1",
+                                    "label": "3.1",
+                                    "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
+                                },
+                                {
+                                    "id": "MWI_3_2",
+                                    "label": "3.2",
+                                    "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            tabledata: tableDataWithCountryValue,
+            filters: [
+                countryLevelAreaFilter,
+                {...propsData.filters[1]},
+                {...propsData.filters[2]}
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        expect(table.props("filteredData")).toStrictEqual(expectedCountryLevelData);
+    });
+
+    it('renders Table with country level data when detail set to 0 but 3.2 is selected', () => {
+        const wrapper = getWrapper({
+            selections: {
+                ...propsData.selections,
+                detail: 0,
+                selectedFilterOptions: {
+                    ...propsData.selections.selectedFilterOptions,
+                    area: [{
+                        "id": "MWI_3_2",
+                        "label": "3.2",
+                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
+                    }]
+                }
+            },
+            tabledata: tableDataWithCountryValue,
+            filters: [
+                countryLevelAreaFilter,
+                {...propsData.filters[1]},
+                {...propsData.filters[2]}
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        expect(table.props("filteredData")).toStrictEqual(expectedCountryLevelData);
+    });
+});

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -79,8 +79,6 @@ describe('Table from testdata', () => {
         expect(wrapper.contains('br')).toBe(true);
     });
 
-    //TODO: test for rendering slots
-
     it('renders correct markup', () => {
         const wrapper = getWrapper();
         expectDefaultTableMarkup(wrapper);

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -22,6 +22,24 @@ const createStoreFr = () => {
 };
 
 const propsData = {
+    filteredData: [
+        ...testData.chartdata,
+        {
+            area_id: "MWI_4_1", plhiv: 20, prevalence: 0.8, age: "15:30", sex: "female"
+        },
+        {
+            area_id: "MWI_4_2", plhiv: 20, prevalence: 0.3, age: "0:15", sex: "female"
+        }
+    ],
+    fields: [
+        {key: "area_id", label: "Area"},
+        {key: "age",  label: "Age"},
+        {key: "sex", label: "Sex"},
+        {key: "prevalence", "HIV prevalence"}
+    ]
+};
+
+/*const propsData2 = {
     ...testData,
     selections: {
         indicatorId: "prevalence",
@@ -60,7 +78,7 @@ const propsData = {
             {"id": "MWI_3_2", "label": "3.2", "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]}
         ]
     }
-}
+}*/
 
 const getWrapper = (customPropsData: any = {}) => {
     const store = createStore();
@@ -79,6 +97,7 @@ describe('Table from testdata', () => {
         expect(wrapper.contains('table')).toBe(true);
         expect(wrapper.contains('br')).toBe(true);
     });
+
     it('renders correct markup', () => {
         const wrapper = getWrapper();
         expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
@@ -91,345 +110,15 @@ describe('Table from testdata', () => {
         expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
         expect(wrapper.findAll('tr').length).toBe(3);
     });
-    it('renders correct markup when male selected', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                selectedFilterOptions: {
-                    ...propsData.selections.selectedFilterOptions,
-                    sex: [{id: "male", label: "Male"}]
-                }
-            }
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.2 3.2');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Male');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
-        expect(wrapper.findAll('tr').length).toBe(3);
-    });
-    it('renders correct markup when detail set to 3', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                detail: 3,
-            }
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('3.1');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        const div = wrapper.findAll('td').at(3).findAll("div")
-        expect(div.at(1).text()).toBe('1.00%');
-        expect(div.at(2).text()).toBe('(1.00% – 10.00%)');
-        expect(wrapper.findAll('tr').length).toBe(3);
-    });
+
     it('renders correct markup when no data are available for selected filters', () => {
         const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                selectedFilterOptions: {
-                    age: [{id: "15:30", label: "15-30"}],
-                    sex: [{id: "male", label: "Male"}],
-                    area: []
-                }
-            }
+            filteredData: []
         });
         expect(wrapper.contains('table')).toBe(false);
         expect(wrapper.text()).toContain('No data are available for these selections.')
-    });
-    it('renders correct markup when plhiv indicator is selected', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                indicatorId: "plhiv"
-            },
-            indicators: [{
-                ...propsData.indicators,
-                indicator: "plhiv", value_column: "plhiv", name: "PLHIV", format: "0,0", scale: 10
-            }]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('PLHIV (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('100');
-        expect(wrapper.findAll('tr').length).toBe(3);
-    });
-    it('renders correct markup when 3.2 is selected only', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                selectedFilterOptions: {
-                    ...propsData.selections.selectedFilterOptions,
-                    area: [{
-                        "id": "MWI_3_2",
-                        "label": "3.2",
-                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                    }]
-                }
-            },
-            filters: [
-                {
-                    ...propsData.filters[0],
-                    options: [
-                        {
-                            "id": "MWI_3_1",
-                            "label": "3.1",
-                            "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                        },
-                        {
-                            "id": "MWI_3_2",
-                            "label": "3.2",
-                            "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                        }
-                    ]
-                },
-                {...propsData.filters[1]},
-                {...propsData.filters[2]}
-            ]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.2 3.2');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('30.00%');
-        expect(wrapper.findAll('tr').length).toBe(2);
-    });
-    it('renders correct markup when 3.2 is selected only and detail is set to 3', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                detail: 3,
-                selectedFilterOptions: {
-                    ...propsData.selections.selectedFilterOptions,
-                    area: [{
-                        "id": "MWI_3_2",
-                        "label": "3.2",
-                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                    }]
-                }
-            },
-            filters: [
-                {
-                    ...propsData.filters[0],
-                    options: [
-                        {
-                            "id": "MWI_3_1",
-                            "label": "3.1",
-                            "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                        },
-                        {
-                            "id": "MWI_3_2",
-                            "label": "3.2",
-                            "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                        }
-                    ]
-                },
-                {...propsData.filters[1]},
-                {...propsData.filters[2]}
-            ]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('3.2');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('0.00%');
-        expect(wrapper.findAll('tr').length).toBe(2);
-    });
-    it('renders correct markup when detail set to 0', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                detail: 0
-            },
-            tabledata: [
-                ...propsData.tabledata,
-                {
-                    area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
-                }
-            ],
-            filters: [
-                {
-                    ...propsData.filters[0],
-                    options: [
-                        {
-                            id: "MWI", label: "Malawi", children: [
-                                {
-                                    "id": "MWI_3_1",
-                                    "label": "3.1",
-                                    "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                                },
-                                {
-                                    "id": "MWI_3_2",
-                                    "label": "3.2",
-                                    "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                                }
-                            ]
-                        },
-                    ]
-                },
-                {...propsData.filters[1]},
-                {...propsData.filters[2]}
-            ]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('Malawi');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('50.00%');
-        expect(wrapper.findAll('tr').length).toBe(2);
-    });
-    it('renders correct markup when detail set to null', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                detail: null,
-                selectedFilterOptions: {
-                    ...propsData.selections.selectedFilterOptions,
-                    area: [
-                        {
-                            id: "MWI", label: "Malawi", children: [
-                                {
-                                    "id": "MWI_3_1",
-                                    "label": "3.1",
-                                    "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                                },
-                                {
-                                    "id": "MWI_3_2",
-                                    "label": "3.2",
-                                    "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            tabledata: [
-                ...propsData.tabledata,
-                {
-                    area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
-                }
-            ],
-            filters: [
-                {
-                    ...propsData.filters[0],
-                    options: [
-                        {
-                            id: "MWI", label: "Malawi", children: [
-                                {
-                                    "id": "MWI_3_1",
-                                    "label": "3.1",
-                                    "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                                },
-                                {
-                                    "id": "MWI_3_2",
-                                    "label": "3.2",
-                                    "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                                }
-                            ]
-                        },
-                    ]
-                },
-                {...propsData.filters[1]},
-                {...propsData.filters[2]}
-            ]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('Malawi');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('50.00%');
-        expect(wrapper.findAll('tr').length).toBe(2);
-    });
-    it('renders correct markup when detail set to 0 but 3.2 is selected', () => {
-        const wrapper = getWrapper({
-            selections: {
-                ...propsData.selections,
-                detail: 0,
-                selectedFilterOptions: {
-                    ...propsData.selections.selectedFilterOptions,
-                    area: [{
-                        "id": "MWI_3_2",
-                        "label": "3.2",
-                        "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                    }]
-                }
-            },
-            tabledata: [
-                ...propsData.tabledata,
-                {
-                    area_id: "MWI", plhiv: 25, prevalence: 0.5, age: "0:15", sex: "female"
-                }
-            ],
-            filters: [
-                {
-                    ...propsData.filters[0],
-                    options: [
-                        {
-                            id: "MWI", label: "Malawi", children: [
-                                {
-                                    "id": "MWI_3_1",
-                                    "label": "3.1",
-                                    "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]
-                                },
-                                {
-                                    "id": "MWI_3_2",
-                                    "label": "3.2",
-                                    "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]
-                                }
-                            ]
-                        },
-                    ]
-                },
-                {...propsData.filters[1]},
-                {...propsData.filters[2]}
-            ]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('Malawi');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('50.00%');
-        expect(wrapper.findAll('tr').length).toBe(2);
-    });
+    }); //TODO: this test in Fr
 
-    it('renders correct markup in French', () => {
-        const wrapper = getWrapperFr();
-        expect(wrapper.find('th').text()).toBe('Zone (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Âge (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sexe (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
-        expect(wrapper.findAll('tr').length).toBe(3);
-    });
     it('renders correct markup when sorting by HIV prevalence ascending', () => {
         const wrapper = getWrapper();
         wrapper.setData({sortBy: 'prevalence'})

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -1,8 +1,7 @@
-import {mount} from "@vue/test-utils";
+import {mount, Wrapper} from "@vue/test-utils";
 import Table from "../../../../app/components/plots/table/Table.vue";
 import registerTranslations from "../../../../app/store/translations/registerTranslations";
-import Vuex from "vuex";
-import {testData} from "../testHelpers";
+import Vuex from "vuex";;
 import {Language} from "../../../../app/store/translations/locales";
 
 const createStore = () => {
@@ -23,62 +22,20 @@ const createStoreFr = () => {
 
 const propsData = {
     filteredData: [
-        ...testData.chartdata,
         {
-            area_id: "MWI_4_1", plhiv: 20, prevalence: 0.8, age: "15:30", sex: "female"
+            area_id: "4.1", plhiv: 20, prevalence: "80.00%", age: "0-15", sex: "Female"
         },
         {
-            area_id: "MWI_4_2", plhiv: 20, prevalence: 0.3, age: "0:15", sex: "female"
+            area_id: "4.2", plhiv: 20, prevalence: "30.00%", age: "15-30", sex: "Male"
         }
     ],
     fields: [
-        {key: "area_id", label: "Area"},
-        {key: "age",  label: "Age"},
-        {key: "sex", label: "Sex"},
-        {key: "prevalence", "HIV prevalence"}
+        {key: "area_id", label: "Area", sortable: true, sortByFormatted: true},
+        {key: "age",  label: "Age", sortable: true, sortByFormatted: true},
+        {key: "sex", label: "Sex", sortable: true, sortByFormatted: true},
+        {key: "prevalence", label: "HIV prevalence", sortable: true, sortByFormatted: true}
     ]
 };
-
-/*const propsData2 = {
-    ...testData,
-    selections: {
-        indicatorId: "prevalence",
-        detail: 4,
-        selectedFilterOptions: {
-            age: [{id: "0:15", label: "0-15"}],
-            sex: [{id: "female", label: "Female"}],
-            area: []
-        },
-    },
-    indicators: [{
-        indicator: "prevalence",
-        "value_column": "prevalence",
-        "indicator_column": "",
-        "indicator_value": "",
-        "name": "HIV prevalence",
-        "min": 0,
-        "max": 0.5,
-        "colour": "interpolateMagma",
-        "invert_scale": true,
-        "format": "0.00%",
-        "scale": 1
-    }],
-    tabledata: [
-        ...testData.chartdata,
-        {
-            area_id: "MWI_4_1", plhiv: 20, prevalence: 0.8, age: "15:30", sex: "female"
-        },
-        {
-            area_id: "MWI_4_2", plhiv: 20, prevalence: 0.3, age: "0:15", sex: "female"
-        }
-    ],
-    countryAreaFilterOption: {
-        id: "MWI", label: "Malawi", children: [
-            {"id": "MWI_3_1", "label": "3.1", "children": [{"id": "MWI_4_1", "label": "4.1", "children": []}]},
-            {"id": "MWI_3_2", "label": "3.2", "children": [{"id": "MWI_4_2", "label": "4.2", "children": []}]}
-        ]
-    }
-}*/
 
 const getWrapper = (customPropsData: any = {}) => {
     const store = createStore();
@@ -91,6 +48,30 @@ const getWrapperFr = (customPropsData: any = {}) => {
 };
 
 describe('Table from testdata', () => {
+
+    const expectDefaultTableMarkup = (wrapper: Wrapper<any>) => {
+        const dataRow1 = wrapper.findAll("tr").at(1);
+        const dataRow2 = wrapper.findAll("tr").at(2);
+
+        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
+        expect(dataRow1.find('td').text()).toBe('4.1');
+        expect(dataRow2.find('td').text()).toBe('4.2');
+
+        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
+        expect(dataRow1.findAll('td').at(1).text()).toBe('0-15');
+        expect(dataRow2.findAll('td').at(1).text()).toBe('15-30');
+
+        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
+        expect(dataRow1.findAll('td').at(2).text()).toBe('Female');
+        expect(dataRow2.findAll('td').at(2).text()).toBe('Male');
+
+        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
+        expect(dataRow1.findAll('td').at(3).text()).toBe('80.00%');
+        expect(dataRow2.findAll('td').at(3).text()).toBe('30.00%');
+
+        expect(wrapper.findAll('tr').length).toBe(3);
+    };
+
     it('renders a table', () => {
         const wrapper = getWrapper();
         expect(wrapper.contains('div')).toBe(true);
@@ -98,17 +79,11 @@ describe('Table from testdata', () => {
         expect(wrapper.contains('br')).toBe(true);
     });
 
+    //TODO: test for rendering slots
+
     it('renders correct markup', () => {
         const wrapper = getWrapper();
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
-        expect(wrapper.findAll('tr').length).toBe(3);
+        expectDefaultTableMarkup(wrapper);
     });
 
     it('renders correct markup when no data are available for selected filters', () => {
@@ -117,95 +92,137 @@ describe('Table from testdata', () => {
         });
         expect(wrapper.contains('table')).toBe(false);
         expect(wrapper.text()).toContain('No data are available for these selections.')
-    }); //TODO: this test in Fr
+    });
+
+    it('renders correct markup when no data are available for selected filters in French', () => {
+        const wrapper = getWrapperFr({
+            filteredData: []
+        });
+        expect(wrapper.contains('table')).toBe(false);
+        expect(wrapper.text()).toContain("Aucune donnée n'est disponible pour ces sélections.")
+    });
 
     it('renders correct markup when sorting by HIV prevalence ascending', () => {
         const wrapper = getWrapper();
-        wrapper.setData({sortBy: 'prevalence'})
+        wrapper.setData({sortBy: 'prevalence'});
+
+        const dataRow1 = wrapper.findAll("tr").at(1);
+        const dataRow2 = wrapper.findAll("tr").at(2);
+
         expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
+        expect(dataRow1.find('td').text()).toBe('4.2');
+        expect(dataRow2.find('td').text()).toBe('4.1');
+
         expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
+        expect(dataRow1.findAll('td').at(1).text()).toBe('15-30');
+        expect(dataRow2.findAll('td').at(1).text()).toBe('0-15');
+
+
         expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
+        expect(dataRow1.findAll('td').at(2).text()).toBe('Male');
+        expect(dataRow2.findAll('td').at(2).text()).toBe('Female');
+
+
         expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Descending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
+        expect(dataRow1.findAll('td').at(3).text()).toBe('30.00%');
+        expect(dataRow2.findAll('td').at(3).text()).toBe('80.00%');
+
         expect(wrapper.findAll('tr').length).toBe(3);
+
     });
+
     it('renders correct markup when sorting by HIV prevalence descending', () => {
         const wrapper = getWrapper();
-        wrapper.setData({sortBy: 'prevalence', sortDesc: true})
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.2 3.2');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('30.00%');
-        expect(wrapper.findAll('tr').length).toBe(3);
+        wrapper.setData({sortBy: 'prevalence', sortDesc: true});
+        expectDefaultTableMarkup(wrapper);
     });
+
     it('renders correct markup when filtering by 4.2', () => {
         const wrapper = getWrapper();
         wrapper.setData({filter: '4.2'})
         expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.2 3.2');
+        expect(wrapper.find('td').text()).toBe('4.2');
         expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
+        expect(wrapper.findAll('td').at(1).text()).toBe('15-30');
         expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
+        expect(wrapper.findAll('td').at(2).text()).toBe('Male');
         expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
         expect(wrapper.findAll('td').at(3).text()).toBe('30.00%');
         expect(wrapper.findAll('tr').length).toBe(2);
     });
-    it('clicking clear button clears filter and resets table', () => {
+
+    it('clicking clear button clears filter and resets table', async () => {
         const wrapper = getWrapper();
         wrapper.setData({filter: '4.2'})
         wrapper.find('button').trigger('click')
+        expectDefaultTableMarkup(wrapper);
+    });
+
+    it("scoped slot content is rendered correctly", () => {
+        const store = createStore();
+        const scopedSlots = {
+            "cell(area_id)": `<template v-slot:cell(area_id)="props">
+                    <div class="value">{{ props.item.area_id }}</div>
+                    <div class="small">{{ props.item.area_hierarchy }}</div>
+                </template>`,
+            "cell(prevalence)": `<template v-slot:cell(prevalence)="props">
+                                     <div class="value">{{ props.item.prevalence }}</div>
+                                     <div class="small">({{ props.item.prevalence_lower }} - {{ props.item.prevalence_upper }})</div>
+                                  </template>`
+        } ;
+
+        const filteredDataWithSlotValues = [
+            {
+                area_id: "4.1",
+                area_hierarchy: "3.1",
+                plhiv: 20,
+                prevalence: "80.00%",
+                prevalence_lower: "70.00%",
+                prevalence_upper: "90.00%",
+                age: "0-15",
+                sex: "Female"
+            },
+            {
+                area_id: "4.2",
+                area_hierarchy: "3.2",
+                plhiv: 20,
+                prevalence: "30.00%",
+                prevalence_lower: "20.00%",
+                prevalence_upper: "40.00%",
+                age: "15-30",
+                sex: "Male"
+            }
+        ];
+
+
+        const customPropsData = {...propsData, filteredData: filteredDataWithSlotValues};
+
+        const wrapper = mount(Table, {store, propsData: customPropsData, scopedSlots});
+
+        const dataRow1 = wrapper.findAll("tr").at(1);
+        const dataRow2 = wrapper.findAll("tr").at(2);
+
         expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
+        expect(dataRow1.find('td .value').text()).toBe('4.1');
+        expect(dataRow1.find('td .small').text()).toBe('3.1');
+        expect(dataRow2.find('td .value').text()).toBe('4.2');
+        expect(dataRow2.find('td .small').text()).toBe('3.2');
+
         expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
+        expect(dataRow1.findAll('td').at(1).text()).toBe('0-15');
+        expect(dataRow2.findAll('td').at(1).text()).toBe('15-30');
+
         expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
+        expect(dataRow1.findAll('td').at(2).text()).toBe('Female');
+        expect(dataRow2.findAll('td').at(2).text()).toBe('Male');
+
         expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
+        expect(dataRow1.findAll('td').at(3).find(".value").text()).toBe('80.00%');
+        expect(dataRow1.findAll('td').at(3).find(".small").text()).toBe('(70.00% - 90.00%)');
+        expect(dataRow2.findAll('td').at(3).find(".value").text()).toBe('30.00%');
+        expect(dataRow2.findAll('td').at(3).find(".small").text()).toBe('(20.00% - 40.00%)');
+
         expect(wrapper.findAll('tr').length).toBe(3);
     });
 
-    it('renders correct markup when uncertainty ranges are added', () => {
-        const wrapper = getWrapper({
-            tabledata: [
-                {
-                    ...propsData.tabledata[0], upper: 100, lower: 0
-                },
-                {
-                    ...propsData.tabledata[1], upper: 0.9, lower: 0.01
-                },
-                {
-                    ...propsData.tabledata[2], upper: 98, lower: 2
-                },
-                {
-                    ...propsData.tabledata[3], upper: 97, lower: 3
-                },
-                {
-                    ...propsData.tabledata[4], upper: 96, lower: 4
-                },
-                {
-                    ...propsData.tabledata[5], upper: 95, lower: 5
-                }
-            ],
-            indicators: [{...propsData.indicators[0], error_low_column: "lower", error_high_column: "upper"}]
-        });
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(wrapper.find('td').text()).toBe('4.1 3.1');
-        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
-        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
-        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
-        expect(wrapper.findAll('td').at(3).find(".value").text()).toBe('10.00%');
-        expect(wrapper.findAll('td').at(3).find(".small").text()).toBe('(1.00% – 90.00%)');
-        expect(wrapper.findAll('tr').length).toBe(3);
-    });
-})
+});

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -358,7 +358,7 @@ describe("Survey and programme component", () => {
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
         const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
-        expect(table.props().tabledata).toBe("TEST DATA");
+        expect(table.props().tableData).toBe("TEST DATA");
         expect(table.props().filters[0]).toStrictEqual({
             id: "area",
             column_id: "area_id",

--- a/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
+++ b/src/app/static/src/tests/components/surveyAndProgram/surveyAndProgram.test.ts
@@ -23,7 +23,7 @@ import {expectTranslated} from "../../testHelpers";
 import GenericChart from "../../../app/components/genericChart/GenericChart.vue";
 import {GenericChartState} from "../../../app/store/genericChart/genericChart";
 import Choropleth from "../../../app/components/plots/choropleth/Choropleth.vue";
-import {testUploadComponent} from "../baseline/fileUploads";
+import AreaIndicatorsTable from "../../../app/components/plots/table/AreaIndicatorsTable.vue";
 
 const localVue = createLocalVue();
 
@@ -356,7 +356,7 @@ describe("Survey and programme component", () => {
             } as any,
         });
         const wrapper = shallowMount(SurveyAndProgram, {store, localVue});
-        const table = wrapper.find("table-view-stub");
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().tabledata).toBe("TEST DATA");
         expect(table.props().filters[0]).toStrictEqual({


### PR DESCRIPTION
## Description

Again, apologies for this bloated PR, I will try not to make a habit of it.. 

This branch adds the table associated with the input time series as shown in the [mockup](https://mrc-ide.myjetbrains.com/youtrack/api/files/112-1148?sign=MTYzMjcwMDgwMDAwMHwyNC0xN3wxMTItMTE0OHxyMVo5eUhScWFUUktYbFRDbXRXTVB6YWE0VEp2%0D%0ARDhoYm1NQVZ2bFZsUWgwDQo%0D%0A&updated=1629983996651). Because the input time series chart is defined as a generic chart, its associated table is also defined as part of this configuration. 

Note that some displayed column headers are still 'unfriendly' because we do not yet have label metadata for them, because they are not defined as filters in this chart. This will be resolved in https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2624 The affected columns are `area_name` and `time_period`. The last column, showing the selected plot type as header, is also awaiting friendly labels in this filter. 

The main changes are:

- adds table config to generic chart configuration. This is placed at the dataset level, since columns can differ between datasets. 
- refactors the existing Table component into two separate components:
   - `AreaIndicatorsTable` - which does all the data filtering and labelling data previously done in the Table component, which is geared to the non-generic HINT datasets, with known area filter, and a set of indicators separate from the filters (i.e. a different usage from the input time series). This passes processed data to:
   - `Table` - this is now a much simpler component, which just takes pre-filtered data and fields and renders them into a BTable. It passes through any scoped slot templates from the parent (this is used by `AreaIndicatorsTable` to show area hierarchy and indicator uncertainty ranges).
- adds a `GenericChartTable` component, which takes pre-filtered data along with table config and other generic chart configuration, and renders a `Table` component with labelled data and fields.
- updates `GenericChart` to render a `GenericChartTable` per dataset (there is only one for input time series) where configured. 
 
The table config consists of an array of `columns` where each column specifies:
-  `data`
   -  `columnId` - the column id in the dataset from which table values should be taken for this column
   -  `labelFilterId` - if non-null, the filter whose options should be used to find labels associated with column values, which will be displayed in the table instead of the raw values. e.g. for the age filter, this allows us to render '15-49' instead of 'Y015_049'
- `header`
  -  `type` - the options here are `filterLabel` or `selectedFilterOption`. if `filterLabel`, the label of the filter object specified by `filterId` will be used as the column header e.g. 'Age'. If `selectedFilterOption`, the label of the specified filter's selected option will be used as the column header. This allows us to set the header of the value column to the label of the selected plot type, e.g. 'HIV prevalence'. 
  - `filterId` - the filter from which to take filter label or selected filter option label. 

This configuration is subject to change once https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2624 is implemented, since we will no longer be using 'filter' metadata but 'column' metadata, so it will be appropriate to update the config schema at that point.

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
