### PR TITLE
Mrc 2640 - Endpoint for posting error report to Teams

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ErrorReportController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ErrorReportController.kt
@@ -1,0 +1,29 @@
+package org.imperial.mrc.hint.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.imperial.mrc.hint.models.EmptySuccessResponse
+import org.imperial.mrc.hint.models.ErrorReport
+import org.imperial.mrc.hint.models.asResponseEntity
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+class ErrorReportController(private val objectMapper: ObjectMapper)
+{
+    @PostMapping("/error-report")
+    @ResponseBody
+    fun sendErrorReport(@RequestBody errorReport: ErrorReport): ResponseEntity<String>
+    {
+        val errorReportJson = objectMapper.writeValueAsString(errorReport)
+
+        //post errorReportJson to webhook
+        val postErrorReport = ResponseEntity.ok().build<String>()
+
+        if(postErrorReport.statusCode == HttpStatus.OK){
+            return ResponseEntity.badRequest().build()
+        }
+
+        return EmptySuccessResponse.asResponseEntity()
+    }
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ErrorReportController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ErrorReportController.kt
@@ -4,26 +4,41 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.imperial.mrc.hint.models.EmptySuccessResponse
 import org.imperial.mrc.hint.models.ErrorReport
 import org.imperial.mrc.hint.models.asResponseEntity
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
+import org.springframework.http.*
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.postForEntity
 
 @RestController
 class ErrorReportController(private val objectMapper: ObjectMapper)
 {
     @PostMapping("/error-report")
     @ResponseBody
-    fun sendErrorReport(@RequestBody errorReport: ErrorReport): ResponseEntity<String>
+    fun errorReport(@RequestBody errorReport: ErrorReport): ResponseEntity<String>
     {
-        val errorReportJson = objectMapper.writeValueAsString(errorReport)
+        val response = postErrorReport(errorReport)
 
-        //post errorReportJson to webhook
-        val postErrorReport = ResponseEntity.ok().build<String>()
-
-        if(postErrorReport.statusCode == HttpStatus.OK){
-            return ResponseEntity.badRequest().build()
+        if (response.statusCode != HttpStatus.OK)
+        {
+            return ResponseEntity.status(response.statusCode).build()
         }
 
         return EmptySuccessResponse.asResponseEntity()
+    }
+
+    fun postErrorReport(errorReport: ErrorReport): ResponseEntity<String>
+    {
+        val errorReportJson = objectMapper.writeValueAsString(errorReport)
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        val httpEntity = HttpEntity(errorReportJson, headers)
+        val url = "https://prod-58.westeurope.logic.azure.com:443/workflows/a13847fef9034c6099297b59490f8be2/triggers" +
+                "/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig" +
+                "=cVhgcE7b75SnaFfLsYZBYHaSvBRFHLk4enyZ2H7yMj4"
+
+        val restTemplate = RestTemplate()
+        return restTemplate.postForEntity(url, httpEntity)
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/ErrorReport.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/ErrorReport.kt
@@ -1,0 +1,17 @@
+package org.imperial.mrc.hint.models
+
+import java.time.Instant
+
+data class ErrorReport(
+        val email: String,
+        val country: String? = null,
+        val projectName: String,
+        val section: String,
+        val errors: List<Errors>?,
+        val description: String? = null,
+        val stepsToReproduce: String? = null,
+        val browserAgent: String,
+        val timeStamp: Instant? = Instant.now()
+)
+
+data class Errors(val jobId: String, val errorMessage: String)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/ErrorReport.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/ErrorReport.kt
@@ -7,11 +7,11 @@ data class ErrorReport(
         val country: String? = null,
         val projectName: String,
         val section: String,
-        val errors: List<Errors>?,
+        val errors: List<Errors>,
         val description: String? = null,
         val stepsToReproduce: String? = null,
         val browserAgent: String,
         val timeStamp: Instant? = Instant.now()
 )
 
-data class Errors(val jobId: String, val errorMessage: String)
+data class Errors(val jobId: String? = null, val errorMessage: String? = null)


### PR DESCRIPTION
* This PR creates an endpoint `/error-report` to accept JSON definition of error report, see comments on this ticket for structure https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2643. 
* PR sends body of the `/error-report` endpoint to office365 web hook which was created by this ticket https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2646.
* When post to office365 is successful, a message or messages will appear in Naomi Support Teams channel.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
