### PR TITLE
mrc-2468 Re-fetch Input Time Series data when language changes 

### DIFF
--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -70,6 +70,10 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
             actions.push(dispatch("modelCalibrate/getResult"));
         }
 
+        if (Object.keys(rootState.genericChart.datasets).length > 0) {
+            actions.push(dispatch("genericChart/refreshDatasets"));
+        }
+
         await Promise.all(actions);
         commit({type: RootMutation.SetUpdatingLanguage, payload: false});
     }


### PR DESCRIPTION
## Description

Please describe your changes here

One issue this has highlighted is that selected Review Inputs tab is not retained when the view is reloaded, as happens when the language is updated, but also if return to the step from another, or when refresh page. I've made a separate ticket to persist selected tab: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2659

Another issue is that not all Input Time series metadata is being translated. Ticket for this issue: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2660

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
