### PR TITLE
mrc-2635 Show correct output table headers in French and Portuguese

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.55.1
+
+* Render filter labels verbatim in output tables, do not attempt to translate
+
 # hint 1.55.0
 
 * Refresh output metadata and options when language changes

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -29,6 +29,7 @@
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <table-view class="col-md-9"
+                                :translate-labels="false"
                                 :tabledata="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="choroplethFilters"
@@ -53,6 +54,7 @@
                     <div class="col-md-3"></div>
                     <table-view class="col-md-9"
                                 :tabledata="chartdata"
+                                :translate-labels="false"
                                 :area-filter-id="areaFilterId"
                                 :filters="barchartFilters"
                                 :countryAreaFilterOption="countryAreaFilterOption"
@@ -77,6 +79,7 @@
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
                     <table-view class="col-md-9"
+                                :translate-labels="false"
                                 :tabledata="chartdata"
                                 :area-filter-id="areaFilterId"
                                 :filters="bubblePlotFilters"

--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -66,6 +66,7 @@
         filters: Filter[],
         countryAreaFilterOption: NestedFilterOption,
         areaFilterId: string
+        translateLabels: boolean
     }
 
     interface DisplayRow {
@@ -115,6 +116,10 @@
         },
         selections: {
             type: Object
+        },
+        translateLabels: {
+            type: Boolean,
+            default: true
         }
     }
 
@@ -203,10 +208,10 @@
                         }
                     }
                     const {value, upper, lower} = current
-                    const { indicator, format, scale, accuracy } = current.indicatorMeta
+                    const {indicator, format, scale, accuracy} = current.indicatorMeta
                     displayRows[key][indicator] = formatOutput(value, format, scale, accuracy);
-                    displayRows[key][`${indicator}_lower`] = lower ? formatOutput(lower, format, scale, accuracy): '';
-                    displayRows[key][`${indicator}_upper`] = upper ? formatOutput(upper, format, scale, accuracy): '';
+                    displayRows[key][`${indicator}_lower`] = lower ? formatOutput(lower, format, scale, accuracy) : '';
+                    displayRows[key][`${indicator}_upper`] = upper ? formatOutput(upper, format, scale, accuracy) : '';
                 });
                 return Object.values(displayRows);
             },
@@ -219,7 +224,9 @@
                 this.filtersToDisplay.map(value => {
                     const field: Dict<any> = {};
                     field.key = value.id
-                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
+                    field.label = this.translateLabels ?
+                        i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage}) :
+                        value.label
                     fields.push(field)
                 })
                 this.indicators.map((value, index) => {

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.56.0";
+export const currentHintVersion = "1.56.1";

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -310,6 +310,7 @@ describe("ModelOutput component", () => {
         expect(table.props().indicators).toStrictEqual(["TEST CHORO INDICATORS"]);
         expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
+        expect(table.props().translateLabels).toBe(false);
     });
 
     it("renders choropleth table with correct indicator props", () => {
@@ -342,6 +343,7 @@ describe("ModelOutput component", () => {
         expect(table.props().indicators).toStrictEqual(["TEST BUBBLE INDICATORS", "TEST BUBBLE INDICATORS"]);
         expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
+        expect(table.props().translateLabels).toBe(false);
     });
 
     it("renders bubble plot table with correct indicator props", () => {
@@ -400,6 +402,7 @@ describe("ModelOutput component", () => {
         });
         expect(table.props().tabledata).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
+        expect(table.props().translateLabels).toBe(false);
     });
 
     it("renders barchart table with correct indicator props", () => {

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -418,7 +418,7 @@ describe('Table from testdata', () => {
         expect(wrapper.findAll('tr').length).toBe(2);
     });
 
-    it('renders correct markup in French', () => {
+    it('renders correct markup in French when translateLabels is true', () => {
         const wrapper = getWrapperFr();
         expect(wrapper.find('th').text()).toBe('Zone (Click to sort Ascending)');
         expect(wrapper.find('td').text()).toBe('4.1 3.1');
@@ -430,6 +430,20 @@ describe('Table from testdata', () => {
         expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
         expect(wrapper.findAll('tr').length).toBe(3);
     });
+
+    it('renders correct markup in French when translateLabels is false', () => {
+        const wrapper = getWrapperFr({translateLabels: false});
+        expect(wrapper.find('th').text()).toBe('Zone (Click to sort Ascending)');
+        expect(wrapper.find('td').text()).toBe('4.1 3.1');
+        expect(wrapper.findAll('th').at(1).text()).toBe('Age (Click to sort Ascending)');
+        expect(wrapper.findAll('td').at(1).text()).toBe('0-15');
+        expect(wrapper.findAll('th').at(2).text()).toBe('Sex (Click to sort Ascending)');
+        expect(wrapper.findAll('td').at(2).text()).toBe('Female');
+        expect(wrapper.findAll('th').at(3).text()).toBe('HIV prevalence (Click to sort Ascending)');
+        expect(wrapper.findAll('td').at(3).text()).toBe('10.00%');
+        expect(wrapper.findAll('tr').length).toBe(3);
+    });
+
     it('renders correct markup when sorting by HIV prevalence ascending', () => {
         const wrapper = getWrapper();
         wrapper.setData({sortBy: 'prevalence'})

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -418,7 +418,7 @@ describe('Table from testdata', () => {
         expect(wrapper.findAll('tr').length).toBe(2);
     });
 
-    it('renders correct markup in French when translateLabels is true', () => {
+    it('renders correct markup in French including translating labels by default', () => {
         const wrapper = getWrapperFr();
         expect(wrapper.find('th').text()).toBe('Zone (Click to sort Ascending)');
         expect(wrapper.find('td').text()).toBe('4.1 3.1');
@@ -431,7 +431,7 @@ describe('Table from testdata', () => {
         expect(wrapper.findAll('tr').length).toBe(3);
     });
 
-    it('renders correct markup in French when translateLabels is false', () => {
+    it('does not translate filter labels when translateLabels is false', () => {
         const wrapper = getWrapperFr({translateLabels: false});
         expect(wrapper.find('th').text()).toBe('Zone (Click to sort Ascending)');
         expect(wrapper.find('td').text()).toBe('4.1 3.1');


### PR DESCRIPTION
## Description

Add a flag to the `Table` component to turn off filter label translations, and turn them off for the output tables.

## Type of version change
Patch

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
