### PR TITLE
Mrc 2669 Getter to filter warnings from hintr

### DIFF
--- a/src/app/static/src/app/components/modelOptions/ModelOptions.vue
+++ b/src/app/static/src/app/components/modelOptions/ModelOptions.vue
@@ -39,11 +39,10 @@
     import {ModelOptionsMutation} from "../../store/modelOptions/mutations";
     import {ModelOptionsState} from "../../store/modelOptions/modelOptions";
     import ResetConfirmation from "../ResetConfirmation.vue";
-    import {RootState, STEPS} from "../../root";
+    import {StepDescription} from "../../store/stepper/stepper";
+    import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
     import ErrorAlert from "../ErrorAlert.vue";
-    import {WarningProps} from "../../types";
-    import {Warning} from "../../generated";
 
     interface Methods {
         fetchOptions: () => void
@@ -53,7 +52,6 @@
         cancelEditing: () => void
         continueEditing: () => void
         confirmEditing: (e: Event) => void
-        warnings: (stepName: String) => WarningProps
     }
 
     interface Computed {
@@ -66,7 +64,6 @@
         selectText: string
         requiredText: string
         validateText: string
-        optionsWarning: Warning[]
     }
 
     interface Data {
@@ -111,9 +108,6 @@
                 set(value: DynamicFormMeta) {
                     this.update(value);
                 }
-            },
-            optionsWarning() {
-                return this.warnings(STEPS.modelOptions).modelOptions
             }
         },
         methods: {
@@ -133,8 +127,7 @@
             update: mapMutationByName(namespace, ModelOptionsMutation.Update),
             unValidate: mapMutationByName(namespace, ModelOptionsMutation.UnValidate),
             fetchOptions: mapActionByName(namespace, "fetchModelRunOptions"),
-            validate: mapActionByName(namespace, "validateModelOptions"),
-            warnings: mapGetterByName(null, "warnings")
+            validate: mapActionByName(namespace, "validateModelOptions")
         },
         components: {
             DynamicForm,

--- a/src/app/static/src/app/components/modelOptions/ModelOptions.vue
+++ b/src/app/static/src/app/components/modelOptions/ModelOptions.vue
@@ -39,10 +39,11 @@
     import {ModelOptionsMutation} from "../../store/modelOptions/mutations";
     import {ModelOptionsState} from "../../store/modelOptions/modelOptions";
     import ResetConfirmation from "../ResetConfirmation.vue";
-    import {StepDescription} from "../../store/stepper/stepper";
-    import {RootState} from "../../root";
+    import {RootState, STEPS} from "../../root";
     import {Language} from "../../store/translations/locales";
     import ErrorAlert from "../ErrorAlert.vue";
+    import {WarningProps} from "../../types";
+    import {Warning} from "../../generated";
 
     interface Methods {
         fetchOptions: () => void
@@ -52,6 +53,7 @@
         cancelEditing: () => void
         continueEditing: () => void
         confirmEditing: (e: Event) => void
+        warnings: (stepName: String) => WarningProps
     }
 
     interface Computed {
@@ -64,6 +66,7 @@
         selectText: string
         requiredText: string
         validateText: string
+        optionsWarning: Warning[]
     }
 
     interface Data {
@@ -108,6 +111,9 @@
                 set(value: DynamicFormMeta) {
                     this.update(value);
                 }
+            },
+            optionsWarning() {
+                return this.warnings(STEPS.modelOptions).modelOptions
             }
         },
         methods: {
@@ -127,7 +133,8 @@
             update: mapMutationByName(namespace, ModelOptionsMutation.Update),
             unValidate: mapMutationByName(namespace, ModelOptionsMutation.UnValidate),
             fetchOptions: mapActionByName(namespace, "fetchModelRunOptions"),
-            validate: mapActionByName(namespace, "validateModelOptions")
+            validate: mapActionByName(namespace, "validateModelOptions"),
+            warnings: mapGetterByName(null, "warnings")
         },
         components: {
             DynamicForm,

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -80,7 +80,7 @@ export interface WarningsState {
 
 export enum STEPS  {
     modelOptions = "model_options",
-    modelFit = "model_fit",
+    modelRun = "model_fit",
     modelCalibrate = "model_calibrate",
     reviewOutput = "review_output",
     downloadResult = "download_results"

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -78,6 +78,14 @@ export interface WarningsState {
     warnings: Warning[]
 }
 
+export enum STEPS  {
+    modelOptions = "model_options",
+    modelFit = "model_fit",
+    modelCalibrate = "model_calibrate",
+    reviewOutput = "review_output",
+    downloadResult = "download_results"
+}
+
 const persistState = (store: Store<RootState>): void => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
         console.log(mutation.type);

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -1,12 +1,32 @@
 import {RootState} from "../../root";
 import {Getter, GetterTree} from "vuex";
+import {Warning} from "../../generated";
 
 interface RootGetters {
     isGuest: Getter<RootState, RootState>
+    warnings: Getter<RootState, RootState>
 }
 
 export const getters: RootGetters & GetterTree<RootState, RootState> = {
     isGuest: (state: RootState, getters: any) => {
         return state.currentUser == "guest";
+    },
+
+    warnings: (getters: any, rootGetters: any, rootState: RootState) => (stepName: string) => {
+
+        const warnings = {
+            modelOptions: rootState.modelOptions.warnings,
+            modelRun: rootState.modelRun.warnings,
+            modelCalibrate: rootState.modelCalibrate.warnings
+        }
+
+        const filterWarnings = (warnings: Warning[], stepName: string) =>
+            warnings.filter(warning => !!warning.locations.find(location => location === stepName))
+
+        return {
+            modelOptions: filterWarnings(warnings.modelOptions, stepName),
+            modelRun: filterWarnings(warnings.modelRun, stepName),
+            modelCalibrate: filterWarnings(warnings.modelCalibrate, stepName)
+        }
     }
 };

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -1,5 +1,5 @@
 import {Payload} from "vuex";
-import {FilterOption, Error, DownloadStatusResponse, DownloadSubmitResponse} from "./generated";
+import {FilterOption, Error, DownloadStatusResponse, DownloadSubmitResponse, Warning} from "./generated";
 
 export interface PayloadWithType<T> extends Payload {
     payload: T
@@ -219,4 +219,10 @@ export interface GenericChartMetadata {
 
 export interface GenericChartMetadataResponse {
     [key: string]: GenericChartMetadata;
+}
+
+export interface WarningProps {
+    modelOptions: Warning[]
+    modelRun: Warning[]
+    modelCalibrate: Warning[]
 }

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -1,0 +1,46 @@
+import {mockModelCalibrateState, mockModelOptionsState, mockModelRunState, mockRootState} from "../mocks";
+import {getters} from "../../app/store/root/getters";
+import {Warning} from "../../app/generated";
+import {STEPS} from "../../app/root";
+
+describe(`root getters`, () => {
+
+    const warning: Warning[] = [
+        {text: "model option test", locations: ["model_options"]},
+        {text: "model calibrate test", locations: ["model_calibrate"]},
+        {text: "model run test", locations: ["model_fit"]}
+    ]
+
+    const testState = () => {
+        return mockRootState({
+            modelOptions: mockModelOptionsState({warnings: warning}),
+            modelRun: mockModelRunState({warnings: warning}),
+            modelCalibrate: mockModelCalibrateState({warnings: warning})
+        })
+    }
+
+    it(`can get model run warnings`, () => {
+        const rootState = testState()
+
+        const warn = getters.warnings(rootState, null, testState() as any, null)
+        const result = warn(STEPS.modelRun).modelRun
+        expect(result).toEqual([{text: "model run test", locations: [STEPS.modelRun]}])
+    })
+
+    it(`can get model calibrate warnings`, () => {
+        const rootState = testState()
+
+        const warn = getters.warnings(rootState, null, testState() as any, null)
+        const result = warn(STEPS.modelCalibrate).modelCalibrate
+        expect(result).toEqual([{text: "model calibrate test", locations: [STEPS.modelCalibrate]}])
+    })
+
+    it(`can get model options warnings`, () => {
+        const rootState = testState()
+
+        const warn = getters.warnings(rootState, null, testState() as any, null)
+        const result = warn(STEPS.modelOptions).modelOptions
+        expect(result).toEqual([{text: "model option test", locations: [STEPS.modelOptions]}])
+    })
+
+})


### PR DESCRIPTION
This PR adds warnings returned from hintr to root getters. 

* warnings getter accepts stepName as parameter, aggregates and returns warnings relating to the given steps.
* warnings can be used in relevant warning UI components.

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
