### PR TITLE
mrc-2661 set error report section to projects if on projects page

### DIFF
--- a/src/app/static/src/app/components/ErrorReport.vue
+++ b/src/app/static/src/app/components/ErrorReport.vue
@@ -72,7 +72,7 @@
 </template>
 <script lang="ts">
     import Vue from "vue"
-    import {mapGetterByName, mapStateProp, mapActionByName} from "../utils";
+    import {mapActionByName, mapGetterByName, mapStateProp} from "../utils";
     import {StepDescription, StepperState} from "../store/stepper/stepper";
     import {ProjectsState} from "../store/projects/projects"
     import Modal from "./Modal.vue";
@@ -148,6 +148,15 @@
                 this.stepsToReproduce = "";
                 this.section = "";
                 this.email = "";
+            }
+        },
+        watch: {
+            open (newVal) {
+                if (newVal === true) {
+                    if (this.$route.path.indexOf("projects") > -1) {
+                        this.section = "projects"
+                    }
+                }
             }
         }
     })

--- a/src/app/static/src/tests/components/errorReport.test.ts
+++ b/src/app/static/src/tests/components/errorReport.test.ts
@@ -1,4 +1,4 @@
-import {shallowMount, mount} from '@vue/test-utils';
+import {shallowMount, mount, createLocalVue} from '@vue/test-utils';
 import ErrorReport from "../../app/components/ErrorReport.vue";
 import Modal from "../../app/components/Modal.vue";
 import Vuex from "vuex";
@@ -7,6 +7,7 @@ import registerTranslations from "../../app/store/translations/registerTranslati
 import {StepperState} from "../../app/store/stepper/stepper";
 import {ProjectsState} from "../../app/store/projects/projects";
 import {expectTranslated} from "../testHelpers";
+import VueRouter from "vue-router";
 
 describe("Error report component", () => {
 
@@ -440,5 +441,34 @@ describe("Error report component", () => {
 
         expect(generateErrorReport.mock.calls.length).toBe(0);
     });
+
+    it("sets section to 'projects' if opened on project page", () => {
+        const localVue = createLocalVue()
+        localVue.use(VueRouter)
+        const routes = [
+            {
+                path: '/',
+                component: ErrorReport
+            },
+            {
+                path: '/projects',
+                component: ErrorReport
+            }
+        ]
+        const router = new VueRouter({
+            routes
+        })
+
+        const wrapper = mount(ErrorReport, { localVue, router, store: createStore() })
+        expect(wrapper.vm.$route.path).toBe("/");
+        wrapper.setProps({open: true});
+        expect((wrapper.find("#section").element as HTMLSelectElement).value).toBe("uploadInputs");
+
+        wrapper.setProps({open: false});
+        router.push("/projects");
+        wrapper.setProps({open: true});
+        expect((wrapper.find("#section").element as HTMLSelectElement).value).toBe("projects")
+    });
+
 
 });


### PR DESCRIPTION
## Description

Rather than the current step, if user is on the projects page when submitting an error report, the "section" field in the error report form should initialise to "projects".

## Type of version change
None - part of epic

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
