### PR TITLE
mrc-2704 stop modal text from being white

### DIFF
--- a/src/app/static/src/app/components/header/UserHeader.vue
+++ b/src/app/static/src/app/components/header/UserHeader.vue
@@ -9,7 +9,7 @@
                              v-translate="'projects'"
                              style="flex:none"></router-link>
                 <file-menu :title="title"></file-menu>
-                <span v-if="!isGuest" class="pr-2 mr-2 border-right">
+                <span v-if="!isGuest" class="pr-2 mr-2 border-right text-white">
                     <span v-translate="'loggedInAs'"></span> {{ user }}
                 </span>
                 <hintr-version-menu class="pr-2 mr-2 border-right"/>

--- a/src/app/static/src/scss/partials/header.scss
+++ b/src/app/static/src/scss/partials/header.scss
@@ -8,7 +8,6 @@
 }
 
 header {
-  color: white;
 
   a {
     color: white;


### PR DESCRIPTION
## Description

The error report modal is technically nested in the `header` element, which had a style rule of white text applied. This removes that rule and instead applies `text-white` as needed more locally.

## Type of version change
None (part of epic)

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
