### PR TITLE
mrc-2735 Use default language in root state if undefined in localStorage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.64.3
+
+* Fix language bug on reload
+
 # hint 1.64.2
 
 * add default placeholder to some error report data

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
-export const currentHintVersion = "1.64.2";
+export const currentHintVersion = "1.64.3";
 

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -164,7 +164,7 @@ export const emptyState = (): RootState => {
 const existingState = localStorageManager.getState();
 
 export const storeOptions: StoreOptions<RootState> = {
-    state: {...emptyState(), ...existingState && {language: existingState.language}},
+    state: {...emptyState(), ...existingState},
     modules: {
         adr,
         genericChart,


### PR DESCRIPTION
## Description

See ticket for description of bug on prod - language menu not available, and error logged in console, when loading a project. 

I think this is because language was not previously being stored in local storage, so when a user who has used HINT previously loads from local storage, that language is undefined, and the code was using that undefined language as long as the previous state existed at all. 

To reproduce the error locally: load the application running on master branch, edit the local storage value for hintAppState to remove the 'language' key, and reload the page. You should see the problems described in the bug. Try again in this branch, and the language menu should not disappear. Selected language should still persist on reload.

One thing that confuses me is that the hintAppState is now unique per version, so I'm a bit surprised than an old version without language could be reloaded at all. Any ideas?

## Type of version change
_Delete as appropriate_

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
