### PR TITLE
mrc-2752 Expect errors from calibrate endpoint because calibrate id is not valid

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -119,8 +119,8 @@ class HintrApiClientTests
     {
         val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
         val result = sut.getCalibratePlot("1234")
-        assertThat(result.statusCodeValue).isEqualTo(200)
-        JSONValidator().validateSuccess(result.body!!, "CalibratePlotResponse")
+        assertThat(result.statusCodeValue).isEqualTo(400)
+        JSONValidator().validateError(result.body!!, "FAILED_TO_RETRIEVE_RESULT")
     }
 
     @Test

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -61,9 +61,9 @@ describe("model calibrate actions integration", () => {
         await actions.getResult({commit, state, rootState} as any);
 
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]["type"]).toBe("SetError");
-        expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
-        expect(commit.mock.calls[1][0]).toBe("Ready");
+        expect(commit.mock.calls[0][0]).toBe("CalibrationPlotStarted");
+        expect(commit.mock.calls[1][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     });
 
     it("can get calibrate plot", async () => {
@@ -78,9 +78,8 @@ describe("model calibrate actions integration", () => {
         await actions.getCalibratePlot({commit, state, rootState} as any);
 
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]).toBe("CalibrationPlotStarted");
-        expect(commit.mock.calls[1][0]).toBe("SetPlotData");
-        expect(commit.mock.calls[1][1]).toHaveProperty("data");
-        expect(commit.mock.calls[1][1]).toHaveProperty("plottingMetadata.barchart");
+        expect(commit.mock.calls[0][0]).toBe("SetError");
+        expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
+        expect(commit.mock.calls[1][0]).toBe("Ready");
     });
 });

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -61,9 +61,9 @@ describe("model calibrate actions integration", () => {
         await actions.getResult({commit, state, rootState} as any);
 
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]).toBe("CalibrationPlotStarted");
-        expect(commit.mock.calls[1][0]["type"]).toBe("SetError");
-        expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
+        expect(commit.mock.calls[0][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
+        expect(commit.mock.calls[1][0]).toBe("Ready");
     });
 
     it("can get calibrate plot", async () => {
@@ -78,8 +78,8 @@ describe("model calibrate actions integration", () => {
         await actions.getCalibratePlot({commit, state, rootState} as any);
 
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]).toBe("SetError");
-        expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
-        expect(commit.mock.calls[1][0]).toBe("Ready");
+        expect(commit.mock.calls[0][0]).toBe("CalibrationPlotStarted");
+        expect(commit.mock.calls[1][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     });
 });


### PR DESCRIPTION
## Description

I think this build error was due to the dummy calibrate endpoint having been relaxed about accepting any calibrate id. The tests pass a fake calibrate id, and this now causes an error, as it does when fake id is passed for calibrate result. I have updated the tests to be consistent with the calibrate result tests .i.e. pass fake id, and expect an error. It would be good to test the success case if and when we get browser testing added to HINT. 

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
