### PR TITLE
mrc-2736 data exploration mode prototyping

### DIFF
--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -1,13 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="io.ktor" withSubpackages="true" static="false" />
-        </value>
-      </option>
       <option name="LBRACE_ON_NEXT_LINE" value="true" />
     </JetCodeStyleSettings>
     <VueCodeStyleSettings>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
@@ -34,6 +34,16 @@ class HomeController(
         return "index"
     }
 
+    @GetMapping(value = ["/explore"])
+    fun explore(model: Model): String
+    {
+        val userProfile = session.getUserProfile()
+        versionRepository.saveVersion(session.getVersionId(), null)
+        model["title"] = "Naomi Data Exploration"
+        model["user"] = userProfile.id
+        return "data-exploration"
+    }
+
     @GetMapping("/metrics", produces = ["text/plain"])
     fun metrics(): ResponseEntity<String>
     {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
@@ -28,6 +28,11 @@ class HomeController(
     fun index(model: Model): String
     {
         val userProfile = session.getUserProfile()
+        val mode = session.getMode()
+        if (mode == "explore"){
+            session.setMode(null)
+            session.setVersionId(null)
+        }
         versionRepository.saveVersion(session.getVersionId(), null)
         model["title"] = appProperties.applicationTitle
         model["user"] = userProfile.id
@@ -38,6 +43,11 @@ class HomeController(
     fun explore(model: Model): String
     {
         val userProfile = session.getUserProfile()
+        val mode = session.getMode()
+        if (mode != "explore"){
+            session.setMode("explore")
+            session.setVersionId(null)
+        }
         versionRepository.saveVersion(session.getVersionId(), null)
         model["title"] = "Naomi Data Exploration"
         model["user"] = userProfile.id

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -46,6 +46,7 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
     companion object
     {
         private const val VERSION_ID = "version_id"
+        private const val APP_MODE = "app_mode"
     }
 
     fun getUserProfile(): CommonProfile
@@ -77,6 +78,16 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
     fun setVersionId(value: String?)
     {
         pac4jConfig.sessionStore.set(webContext, VERSION_ID, value)
+    }
+
+    fun getMode(): String?
+    {
+        return pac4jConfig.sessionStore.get(webContext, APP_MODE) as String?
+    }
+
+    fun setMode(value: String?)
+    {
+        pac4jConfig.sessionStore.set(webContext, APP_MODE, value)
     }
 
     fun generateVersionId(): String

--- a/src/app/static/src/app/components/DataExploration.vue
+++ b/src/app/static/src/app/components/DataExploration.vue
@@ -1,0 +1,38 @@
+<template>
+    <div class="content">
+        <div class="pt-4">
+            <adr-integration></adr-integration>
+            <baseline v-if="step === 1"></baseline>
+            <survey-and-program v-if="step === 2"></survey-and-program>
+            <button @click="back">Back</button>
+            <button @click="next">Next</button>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+    import Vue from "vue";
+    import AdrIntegration from "./adr/ADRIntegration.vue";
+    import Baseline from "./baseline/Baseline.vue";
+    import SurveyAndProgram from "./surveyAndProgram/SurveyAndProgram.vue";
+
+    export default Vue.extend({
+        data() {
+            return {
+                step: 1
+            }
+        },
+        methods: {
+            next() {
+                this.step = 2;
+            },
+            back() {
+                this.step = 1;
+            }
+        },
+        components: {
+            AdrIntegration,
+            Baseline,
+            SurveyAndProgram
+        }
+    })
+</script>

--- a/src/app/static/src/app/components/ErrorReport.vue
+++ b/src/app/static/src/app/components/ErrorReport.vue
@@ -86,7 +86,7 @@
     import {StepDescription, StepperState} from "../store/stepper/stepper";
     import {ProjectsState} from "../store/projects/projects"
     import Modal from "./Modal.vue";
-    import {ErrorReportManualDetails} from "../store/root/actions";
+    import {ErrorReportManualDetails} from "../types";
     import {VTooltip} from 'v-tooltip';
     import i18next from "i18next";
     import {RootState} from "../root";

--- a/src/app/static/src/app/components/adr/SelectDataset.vue
+++ b/src/app/static/src/app/components/adr/SelectDataset.vue
@@ -83,7 +83,7 @@
             </template>
         </modal>
         <reset-confirmation
-            v-if="showConfirmation"
+            v-if="!dataExplorationMode && showConfirmation"
             :continue-editing="continueEditing"
             :cancel-editing="cancelEditing"
             :open="showConfirmation">
@@ -99,7 +99,7 @@
         mapActionByName,
         mapMutationByName,
         mapStateProp,
-        mapGetterByName,
+        mapGetterByName, mapStatePropByName,
     } from "../../utils";
     import {RootState} from "../../root";
     import Modal from "../Modal.vue";
@@ -144,6 +144,7 @@
     }
 
     interface Computed {
+        dataExplorationMode: boolean;
         datasets: any[];
         selectedRelease: Release | null;
         releaseName: string | null;
@@ -205,10 +206,13 @@
         },
         directives: {tooltip: VTooltip},
         computed: {
-            editsRequireConfirmation: mapGetterByName(
-                "stepper",
-                "editsRequireConfirmation"
-            ),
+            dataExplorationMode: mapStatePropByName(null, "dataExplorationMode"),
+            editsRequireConfirmation() {
+                if (this.dataExplorationMode){
+                    return false
+                }
+                return this.$store.getters["stepper/editsRequireConfirmation"]
+            },
             hasShapeFile: mapStateProp<BaselineState, boolean>(
                 "baseline",
                 (state: BaselineState) => !!state.shape

--- a/src/app/static/src/app/components/files/FileUpload.vue
+++ b/src/app/static/src/app/components/files/FileUpload.vue
@@ -14,7 +14,8 @@
                 <span v-translate="'selectNewFile'"></span>
             </label>
         </div>
-        <reset-confirmation :continue-editing="uploadSelectedFile"
+        <reset-confirmation v-if="!dataExplorationMode"
+                            :continue-editing="uploadSelectedFile"
                             :cancel-editing="cancelEdit"
                             :open="showUploadConfirmation"></reset-confirmation>
     </div>
@@ -22,7 +23,7 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {mapGetterByName} from "../../utils";
+    import {mapStatePropByName} from "../../utils";
     import ResetConfirmation from "../ResetConfirmation.vue";
 
     interface Methods {
@@ -36,6 +37,7 @@
     }
 
     interface Computed {
+        dataExplorationMode: boolean
         editsRequireConfirmation: boolean
     }
 
@@ -62,7 +64,13 @@
             ResetConfirmation
         },
         computed: {
-            editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation")
+            dataExplorationMode: mapStatePropByName(null, "dataExplorationMode"),
+            editsRequireConfirmation() {
+                if (this.dataExplorationMode){
+                    return false
+                }
+                return this.$store.getters["stepper/editsRequireConfirmation"]
+            }
         },
         methods: {
             handleFileSelect() {

--- a/src/app/static/src/app/components/files/ManageFile.vue
+++ b/src/app/static/src/app/components/files/ManageFile.vue
@@ -21,7 +21,8 @@
                      :uploading="uploading"
                      @uploading="handleUploading"></file-upload>
         <error-alert v-if="hasError" :error="error"></error-alert>
-        <reset-confirmation :continue-editing="deleteSelectedFile"
+        <reset-confirmation v-if="!dataExplorationMode"
+                            :continue-editing="deleteSelectedFile"
                             :cancel-editing="cancelEdit"
                             :open="showDeleteConfirmation"></reset-confirmation>
     </div>
@@ -33,7 +34,7 @@
     import Tick from "../Tick.vue";
     import ErrorAlert from "../ErrorAlert.vue";
     import ResetConfirmation from "../ResetConfirmation.vue";
-    import {mapGetterByName} from "../../utils";
+    import {mapStatePropByName} from "../../utils";
     import {Error} from "../../generated";
 
     interface Data {
@@ -44,6 +45,7 @@
     interface Computed {
         hasError: boolean
         editsRequireConfirmation: boolean
+        dataExplorationMode: boolean
     }
 
     interface Methods {
@@ -85,7 +87,13 @@
             }
         },
         computed: {
-            editsRequireConfirmation: mapGetterByName("stepper", "editsRequireConfirmation"),
+            dataExplorationMode: mapStatePropByName(null, "dataExplorationMode"),
+            editsRequireConfirmation() {
+                if (this.dataExplorationMode){
+                    return false
+                }
+                return this.$store.getters["stepper/editsRequireConfirmation"]
+            },
             hasError: function () {
                 return !!this.error
             }

--- a/src/app/static/src/app/components/header/DataExplorationHeader.vue
+++ b/src/app/static/src/app/components/header/DataExplorationHeader.vue
@@ -5,7 +5,7 @@
                 <div class="navbar-header">
                     {{ title }}
                 </div>
-                <div style="flex: 1 1 auto;"><a href="/">Naomi</a></div>
+                <div style="flex: 1 1 auto;" class="ml-2"><a href="/">Run model</a></div>
                 <span v-if="!isGuest" class="pr-2 mr-2 border-right text-white">
                     <span v-translate="'loggedInAs'"></span> {{ user }}
                 </span>

--- a/src/app/static/src/app/components/header/DataExplorationHeader.vue
+++ b/src/app/static/src/app/components/header/DataExplorationHeader.vue
@@ -1,0 +1,67 @@
+<template>
+    <header class="mb-5">
+        <nav class="navbar navbar-dark bg-secondary">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    {{ title }}
+                </div>
+                <div style="flex: 1 1 auto;"><a href="/">Naomi</a></div>
+                <span v-if="!isGuest" class="pr-2 mr-2 border-right text-white">
+                    <span v-translate="'loggedInAs'"></span> {{ user }}
+                </span>
+                <hintr-version-menu class="pr-2 mr-2 border-right"/>
+                <a v-if="!isGuest" href="/logout" class="pr-2 mr-2 border-right" v-translate="'logout'">
+                </a>
+                <a v-if="isGuest" href="/login" class="pr-2 mr-2 border-right" v-translate="'logIn'">
+                </a>
+                <language-menu></language-menu>
+            </div>
+        </nav>
+
+    </header>
+</template>
+<script lang="ts">
+
+    import Vue from "vue";
+    import {mapGetters} from 'vuex';
+    import FileMenu from "./FileMenu.vue";
+    import LanguageMenu from "./LanguageMenu.vue";
+    import {Language} from "../../store/translations/locales";
+    import {mapStateProp} from "../../utils";
+    import HintrVersionMenu from "./HintrVersionMenu.vue";
+    import OnlineSupportMenu from "./OnlineSupportMenu.vue";
+    import {DataExplorationState} from "../../store/dataExploration/dataExploration";
+
+    interface Props {
+        title: string,
+        user: string
+    }
+
+    interface Computed {
+        helpFilename: string
+    }
+
+    export default Vue.extend<unknown, unknown, Computed, Props>({
+        computed: {
+            helpFilename: mapStateProp<DataExplorationState, string>(null,
+                (state: DataExplorationState) => {
+                    let filename = "Naomi-basic-instructions.pdf";
+                    if (state.language == Language.fr) {
+                        filename = "Naomi-instructions-de-base.pdf";
+                    }
+                    return filename;
+                }),
+            ...mapGetters(["isGuest"])
+        },
+        props: {
+            title: String,
+            user: String
+        },
+        components: {
+            FileMenu,
+            LanguageMenu,
+            HintrVersionMenu,
+            OnlineSupportMenu
+        }
+    })
+</script>

--- a/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
+++ b/src/app/static/src/app/components/surveyAndProgram/SurveyAndProgram.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="row">
+        <div>
             <ul class="nav nav-tabs col-12 mb-3">
                 <li class="nav-item">
                     <a class="nav-link active" v-translate="'map'"></a>

--- a/src/app/static/src/app/dataExploration.ts
+++ b/src/app/static/src/app/dataExploration.ts
@@ -1,0 +1,43 @@
+import Vue from "vue";
+import Vuex, {mapActions, mapState} from "vuex";
+import registerTranslations from "./store/translations/registerTranslations";
+import {DataExplorationState, storeOptions} from "./store/dataExploration/dataExploration";
+import Errors from "./components/Errors.vue";
+import {Language} from "./store/translations/locales";
+import DataExploration from "./components/DataExploration.vue";
+import DataExplorationHeader from "./components/header/DataExplorationHeader.vue";
+
+Vue.use(Vuex);
+
+const store = new Vuex.Store<DataExplorationState>(storeOptions);
+registerTranslations(store);
+
+export const dataExplorationApp = new Vue({
+    el: "#app",
+    store,
+    components: {
+        DataExplorationHeader,
+        Errors,
+        DataExploration
+    },
+    computed: mapState<DataExplorationState>({
+        language: (state: DataExplorationState) => state.language
+    }),
+    methods: {
+        ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
+        ...mapActions({loadSurveyAndProgram: 'surveyAndProgram/getSurveyAndProgramData'}),
+        ...mapActions({getADRSchemas: 'adr/getSchemas'}),
+        ...mapActions({getGenericChartMetadata: 'genericChart/getGenericChartMetadata'})
+    },
+    beforeMount: function () {
+        this.loadBaseline();
+        this.loadSurveyAndProgram();
+        this.getADRSchemas();
+        this.getGenericChartMetadata();
+    },
+    watch: {
+        language(newVal: Language) {
+            document.documentElement.lang = newVal
+        }
+    }
+});

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -30,6 +30,7 @@ export const serialiseState = (rootState: RootState): Partial<RootState> => {
 };
 
 declare const currentUser: string;
+declare const currentMode: string;
 
 export class LocalStorageManager {
 
@@ -46,6 +47,10 @@ export class LocalStorageManager {
         if (currentUser != window.localStorage.getItem("user")) {
             localStorage.clear();
             localStorage.setItem("user", currentUser);
+        }
+        if (currentMode != window.localStorage.getItem("mode")) {
+            localStorage.clear();
+            localStorage.setItem("mode", currentMode);
         }
         const item = window.localStorage.getItem(appStateKey);
         if (item) {

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -43,12 +43,14 @@ import {
 import {ModelCalibrateMutation, ModelCalibrateUpdates} from "./store/modelCalibrate/mutations";
 import {GenericChartState, initialGenericChartState, genericChart} from "./store/genericChart/genericChart";
 import {Warning} from "./generated";
+import {DataExplorationState} from "./store/dataExploration/dataExploration";
 
 export interface TranslatableState {
     language: Language
+    updatingLanguage: boolean
 }
 
-export interface RootState extends TranslatableState {
+export interface RootState extends DataExplorationState {
     version: string,
     adr: ADRState,
     genericChart: GenericChartState,
@@ -68,9 +70,9 @@ export interface RootState extends TranslatableState {
     projects: ProjectsState
     currentUser: string,
     downloadResults: DownloadResultsState,
-    updatingLanguage: boolean,
     errorReportError: Error | null
     errorReportSuccess: boolean
+    dataExplorationMode: false
 }
 
 export interface ReadyState {
@@ -158,7 +160,8 @@ export const emptyState = (): RootState => {
         errors: initialErrorsState(),
         projects: initialProjectsState(),
         currentUser: currentUser,
-        downloadResults: initialDownloadResultsState()
+        downloadResults: initialDownloadResultsState(),
+        dataExplorationMode: false
     }
 };
 const existingState = localStorageManager.getState();

--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -7,16 +7,17 @@ import {ADRMutation} from "./mutations";
 import {datasetFromMetadata} from "../../utils";
 import {Organization, Release} from "../../types";
 import {BaselineMutation} from "../baseline/mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface ADRActions {
-    fetchKey: (store: ActionContext<ADRState, RootState>) => void;
-    saveKey: (store: ActionContext<ADRState, RootState>, key: string) => void;
-    deleteKey: (store: ActionContext<ADRState, RootState>) => void;
-    getDatasets: (store: ActionContext<ADRState, RootState>) => void;
-    getReleases: (store: ActionContext<ADRState, RootState>, id: string) => void;
-    getDataset: (store: ActionContext<ADRState, RootState>, payload: GetDatasetPayload) => void;
-    getSchemas: (store: ActionContext<ADRState, RootState>) => void;
-    getUserCanUpload: (store: ActionContext<ADRState, RootState>) => void;
+    fetchKey: (store: ActionContext<ADRState, DataExplorationState>) => void;
+    saveKey: (store: ActionContext<ADRState, DataExplorationState>, key: string) => void;
+    deleteKey: (store: ActionContext<ADRState, DataExplorationState>) => void;
+    getDatasets: (store: ActionContext<ADRState, DataExplorationState>) => void;
+    getReleases: (store: ActionContext<ADRState, DataExplorationState>, id: string) => void;
+    getDataset: (store: ActionContext<ADRState, DataExplorationState>, payload: GetDatasetPayload) => void;
+    getSchemas: (store: ActionContext<ADRState, DataExplorationState>) => void;
+    getUserCanUpload: (store: ActionContext<ADRState, DataExplorationState>) => void;
 }
 
 export interface GetDatasetPayload {
@@ -24,7 +25,7 @@ export interface GetDatasetPayload {
     release?: Release
 }
 
-export const actions: ActionTree<ADRState, RootState> & ADRActions = {
+export const actions: ActionTree<ADRState, DataExplorationState> & ADRActions = {
     async fetchKey(context) {
         await api<ADRMutation, ADRMutation>(context)
             .ignoreErrors()

--- a/src/app/static/src/app/store/adr/adr.ts
+++ b/src/app/static/src/app/store/adr/adr.ts
@@ -4,6 +4,7 @@ import {Error} from "../../generated";
 import {ADRSchemas} from "../../types";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface ADRState {
     datasets: any[],
@@ -31,7 +32,7 @@ export const initialADRState = (): ADRState => {
 
 const namespaced = true;
 
-export const adr: Module<ADRState, RootState> = {
+export const adr: Module<ADRState, DataExplorationState> = {
     namespaced,
     state: {...initialADRState()},
     actions,

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -1,27 +1,27 @@
 import {ActionContext, ActionTree, Dispatch} from 'vuex';
 import {BaselineState} from "./baseline";
-import {RootState} from "../../root";
 import {api} from "../../apiService";
 import {PjnzResponse, PopulationResponse, ShapeResponse, ValidateBaselineResponse} from "../../generated";
 import {BaselineMutation} from "./mutations";
 import qs from "qs";
 import {findResource, getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
 import {DatasetResourceSet} from "../../types";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface BaselineActions {
-    refreshDatasetMetadata: (store: ActionContext<BaselineState, RootState>) => void
-    importPJNZ: (store: ActionContext<BaselineState, RootState>, url: string) => void
-    importShape: (store: ActionContext<BaselineState, RootState>, url: string) => void,
-    importPopulation: (store: ActionContext<BaselineState, RootState>, url: string) => void,
-    uploadPJNZ: (store: ActionContext<BaselineState, RootState>, formData: FormData) => void
-    uploadShape: (store: ActionContext<BaselineState, RootState>, formData: FormData) => void,
-    uploadPopulation: (store: ActionContext<BaselineState, RootState>, formData: FormData) => void,
-    deletePJNZ: (store: ActionContext<BaselineState, RootState>) => void
-    deleteShape: (store: ActionContext<BaselineState, RootState>) => void,
-    deleteAll: (store: ActionContext<BaselineState, RootState>) => void,
-    deletePopulation: (store: ActionContext<BaselineState, RootState>) => void,
-    getBaselineData: (store: ActionContext<BaselineState, RootState>) => void
-    validate: (store: ActionContext<BaselineState, RootState>) => void
+    refreshDatasetMetadata: (store: ActionContext<BaselineState, DataExplorationState>) => void
+    importPJNZ: (store: ActionContext<BaselineState, DataExplorationState>, url: string) => void
+    importShape: (store: ActionContext<BaselineState, DataExplorationState>, url: string) => void,
+    importPopulation: (store: ActionContext<BaselineState, DataExplorationState>, url: string) => void,
+    uploadPJNZ: (store: ActionContext<BaselineState, DataExplorationState>, formData: FormData) => void
+    uploadShape: (store: ActionContext<BaselineState, DataExplorationState>, formData: FormData) => void,
+    uploadPopulation: (store: ActionContext<BaselineState, DataExplorationState>, formData: FormData) => void,
+    deletePJNZ: (store: ActionContext<BaselineState, DataExplorationState>) => void
+    deleteShape: (store: ActionContext<BaselineState, DataExplorationState>) => void,
+    deleteAll: (store: ActionContext<BaselineState, DataExplorationState>) => void,
+    deletePopulation: (store: ActionContext<BaselineState, DataExplorationState>) => void,
+    getBaselineData: (store: ActionContext<BaselineState, DataExplorationState>) => void
+    validate: (store: ActionContext<BaselineState, DataExplorationState>) => void
 }
 
 const uploadCallback = (dispatch: Dispatch, response: any) => {
@@ -37,7 +37,7 @@ interface UploadImportOptions {
 }
 
 
-async function uploadOrImportPJNZ(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions, filename: string) {
+async function uploadOrImportPJNZ(context: ActionContext<BaselineState, DataExplorationState>, options: UploadImportOptions, filename: string) {
     const {commit, dispatch, state} = context;
     commit({type: BaselineMutation.PJNZUpdated, payload: null});
     await api<BaselineMutation, BaselineMutation>(context)
@@ -56,7 +56,7 @@ async function uploadOrImportPJNZ(context: ActionContext<BaselineState, RootStat
         });
 }
 
-async function uploadOrImportPopulation(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions, filename: string) {
+async function uploadOrImportPopulation(context: ActionContext<BaselineState, DataExplorationState>, options: UploadImportOptions, filename: string) {
     const {commit, dispatch} = context;
     commit({type: BaselineMutation.PopulationUpdated, payload: null});
     await api<BaselineMutation, BaselineMutation>(context)
@@ -72,7 +72,7 @@ async function uploadOrImportPopulation(context: ActionContext<BaselineState, Ro
         });
 }
 
-async function uploadOrImportShape(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions, filename: string) {
+async function uploadOrImportShape(context: ActionContext<BaselineState, DataExplorationState>, options: UploadImportOptions, filename: string) {
     const {commit, dispatch} = context;
     commit({type: BaselineMutation.ShapeUpdated, payload: null});
     await api<BaselineMutation, BaselineMutation>(context)
@@ -88,7 +88,7 @@ async function uploadOrImportShape(context: ActionContext<BaselineState, RootSta
         });
 }
 
-export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
+export const actions: ActionTree<BaselineState, DataExplorationState> & BaselineActions = {
 
     async refreshDatasetMetadata(context) {
         const {commit, state, rootState} = context

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -5,6 +5,7 @@ import {ReadyState, RootState} from "../../root";
 import {NestedFilterOption, PjnzResponse, PopulationResponse, ShapeResponse, Error} from "../../generated";
 import {Dataset, Release, Dict} from "../../types";
 import {localStorageManager} from "../../localStorageManager";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface BaselineState extends ReadyState {
     selectedDataset: Dataset | null
@@ -64,7 +65,7 @@ const namespaced = true;
 
 const existingState = localStorageManager.getState();
 
-export const baseline: Module<BaselineState, RootState> = {
+export const baseline: Module<BaselineState, DataExplorationState> = {
     namespaced,
     state: {...initialBaselineState(), ...existingState && existingState.baseline},
     getters,

--- a/src/app/static/src/app/store/dataExploration/actions.ts
+++ b/src/app/static/src/app/store/dataExploration/actions.ts
@@ -1,0 +1,61 @@
+import {ActionContext, ActionTree} from "vuex";
+import {RootState} from "../../root";
+import {LanguageActions} from "../language/language";
+import {changeLanguage} from "../language/actions";
+import {api} from "../../apiService";
+import {VersionInfo} from "../../generated";
+import {currentHintVersion} from "../../hintVersion";
+import {DataExplorationState} from "./dataExploration";
+import {ErrorReportManualDetails} from "../../types";
+import {LanguageMutation} from "../language/mutations";
+import {DataExplorationMutation} from "./mutations";
+
+export interface DataExplorationActions extends LanguageActions<DataExplorationState> {
+    generateErrorReport: (store: ActionContext<DataExplorationState, DataExplorationState>,
+                          payload: ErrorReportManualDetails) => void;
+}
+
+export const actions: ActionTree<DataExplorationState, DataExplorationState> & DataExplorationActions = {
+
+    async changeLanguage(context, payload) {
+        const {commit, dispatch, rootState} = context;
+
+        if (rootState.language === payload) {
+            return;
+        }
+
+        commit({type: LanguageMutation.SetUpdatingLanguage, payload: true});
+        await changeLanguage<DataExplorationState>(context, payload);
+
+        const actions: Promise<unknown>[] = [];
+
+        if (rootState.baseline?.iso3) {
+            actions.push(dispatch("metadata/getPlottingMetadata", rootState.baseline.iso3));
+        }
+
+        await Promise.all(actions);
+        commit({type: LanguageMutation.SetUpdatingLanguage, payload: false});
+    },
+
+    async generateErrorReport(context, payload) {
+        const {dispatch, rootState, getters} = context
+        const data = {
+            email: payload.email || rootState.currentUser,
+            country: rootState.baseline.country || "no associated country",
+            projectName: "data exploration mode",
+            browserAgent: navigator.userAgent,
+            timeStamp: new Date().toISOString(),
+            jobId: "data exploration mode",
+            description: payload.description,
+            section: "data exploration mode",
+            stepsToReproduce: payload.stepsToReproduce,
+            versions: {hint: currentHintVersion, ...rootState.hintrVersion.hintrVersion as VersionInfo},
+            errors: getters.errors
+        }
+
+        await api<DataExplorationMutation, DataExplorationMutation>(context)
+            .withSuccess(DataExplorationMutation.ErrorReportSuccess)
+            .withError(DataExplorationMutation.ErrorReportError)
+            .postAndReturn("error-report", data)
+    }
+};

--- a/src/app/static/src/app/store/dataExploration/dataExploration.ts
+++ b/src/app/static/src/app/store/dataExploration/dataExploration.ts
@@ -1,0 +1,85 @@
+import {Language} from "../translations/locales";
+import {currentHintVersion} from "../../hintVersion";
+import {hintrVersion, HintrVersionState, initialHintrVersionState} from "../hintrVersion/hintrVersion";
+import {adr, ADRState, initialADRState} from "../adr/adr";
+import {genericChart, GenericChartState, initialGenericChartState} from "../genericChart/genericChart";
+import {ADRUploadState, initialADRUploadState} from "../adrUpload/adrUpload";
+import {baseline, BaselineState, initialBaselineState} from "../baseline/baseline";
+import {initialMetadataState, metadata, MetadataState} from "../metadata/metadata";
+import {
+    initialSurveyAndProgramState,
+    surveyAndProgram,
+    SurveyAndProgramState
+} from "../surveyAndProgram/surveyAndProgram";
+import {
+    initialPlottingSelectionsState,
+    plottingSelections,
+    PlottingSelectionsState
+} from "../plottingSelections/plottingSelections";
+import {errors, ErrorsState, initialErrorsState} from "../errors/errors";
+import {localStorageManager} from "../../localStorageManager";
+import {Module, StoreOptions} from "vuex";
+import {TranslatableState} from "../../root";
+import {Error} from "../../generated";
+import {actions} from "./actions";
+import {mutations} from "./mutations";
+import {getters} from "./getters";
+
+declare const currentUser: string;
+
+export interface DataExplorationState extends TranslatableState {
+    version: string,
+    adr: ADRState,
+    genericChart: GenericChartState,
+    adrUpload: ADRUploadState,
+    hintrVersion: HintrVersionState,
+    baseline: BaselineState,
+    metadata: MetadataState,
+    surveyAndProgram: SurveyAndProgramState,
+    plottingSelections: PlottingSelectionsState,
+    errors: ErrorsState,
+    currentUser: string,
+    updatingLanguage: boolean,
+    errorReportError: Error | null
+    errorReportSuccess: boolean,
+    dataExplorationMode: boolean
+}
+
+export const initialDataExplorationState = (): DataExplorationState => {
+    return {
+        language: Language.en,
+        version: currentHintVersion,
+        updatingLanguage: false,
+        errorReportError: null,
+        errorReportSuccess: false,
+        hintrVersion: initialHintrVersionState(),
+        adr: initialADRState(),
+        genericChart: initialGenericChartState(),
+        adrUpload: initialADRUploadState(),
+        baseline: initialBaselineState(),
+        metadata: initialMetadataState(),
+        surveyAndProgram: initialSurveyAndProgramState(),
+        plottingSelections: initialPlottingSelectionsState(),
+        errors: initialErrorsState(),
+        currentUser: currentUser,
+        dataExplorationMode: true
+    }
+};
+const existingState = localStorageManager.getState();
+
+export const storeOptions: StoreOptions<DataExplorationState> = {
+    state: {...initialDataExplorationState(), ...existingState},
+    modules: {
+        adr,
+        genericChart,
+        baseline,
+        metadata,
+        surveyAndProgram,
+        plottingSelections,
+        errors,
+        hintrVersion
+    },
+    actions,
+    mutations,
+    getters
+};

--- a/src/app/static/src/app/store/dataExploration/getters.ts
+++ b/src/app/static/src/app/store/dataExploration/getters.ts
@@ -1,0 +1,34 @@
+import {Getter, GetterTree} from "vuex";
+import {Error} from "../../generated"
+import {extractErrors} from "../../utils";
+import {DataExplorationState} from "./dataExploration";
+
+interface DataExplorationGetters {
+    isGuest: Getter<DataExplorationState, DataExplorationState>
+    errors: Getter<DataExplorationState, DataExplorationState>
+}
+
+export const getters: DataExplorationGetters & GetterTree<DataExplorationState, DataExplorationState> = {
+    isGuest: (state: DataExplorationState) => {
+        return state.currentUser == "guest";
+    },
+
+    errors: (state: DataExplorationState) => {
+        const {
+            adr,
+            adrUpload,
+            baseline,
+            metadata,
+            plottingSelections,
+            surveyAndProgram
+        } = state;
+
+        return ([] as Error[]).concat.apply([] as Error[], [extractErrors(adr),
+            extractErrors(adrUpload),
+            extractErrors(baseline),
+            extractErrors(metadata),
+            extractErrors(plottingSelections),
+            extractErrors(surveyAndProgram),
+            state.errors.errors]);
+    }
+}

--- a/src/app/static/src/app/store/dataExploration/mutations.ts
+++ b/src/app/static/src/app/store/dataExploration/mutations.ts
@@ -1,0 +1,25 @@
+import {MutationTree} from "vuex";
+import {PayloadWithType} from "../../types";
+import {mutations as languageMutations} from "../language/mutations";
+import {Error} from "../../generated";
+import {DataExplorationState} from "./dataExploration";
+
+export enum DataExplorationMutation {
+    ErrorReportError = "ErrorReportError",
+    ErrorReportSuccess = "ErrorReportSuccess"
+}
+
+export const mutations: MutationTree<DataExplorationState> = {
+
+    [DataExplorationMutation.ErrorReportError](state: DataExplorationState, action: PayloadWithType<Error>) {
+        state.errorReportError = action.payload;
+        state.errorReportSuccess = false;
+    },
+
+    [DataExplorationMutation.ErrorReportSuccess](state: DataExplorationState) {
+        state.errorReportSuccess = true;
+        state.errorReportError = null
+    },
+
+    ...languageMutations
+};

--- a/src/app/static/src/app/store/errors/errors.ts
+++ b/src/app/static/src/app/store/errors/errors.ts
@@ -1,7 +1,7 @@
 import {Module} from "vuex";
-import {RootState} from "../../root";
 import {Error} from "../../generated";
 import {mutations} from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface ErrorsState {
     errors: Error[]
@@ -15,7 +15,7 @@ export const initialErrorsState = (): ErrorsState => {
 
 const namespaced = true;
 
-export const errors: Module<ErrorsState, RootState> = {
+export const errors: Module<ErrorsState, DataExplorationState> = {
     namespaced,
     state: initialErrorsState(),
     mutations

--- a/src/app/static/src/app/store/genericChart/actions.ts
+++ b/src/app/static/src/app/store/genericChart/actions.ts
@@ -3,12 +3,13 @@ import {RootState} from "../../root";
 import {api} from "../../apiService";
 import {GenericChartState} from "./genericChart";
 import {GenericChartMutation} from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface MetadataActions {
-    getGenericChartMetadata: (store: ActionContext<GenericChartState, RootState>) => void
+    getGenericChartMetadata: (store: ActionContext<GenericChartState, DataExplorationState>) => void
 }
 
-export const actions: ActionTree<GenericChartState, RootState> & MetadataActions = {
+export const actions: ActionTree<GenericChartState, DataExplorationState> & MetadataActions = {
     async getGenericChartMetadata(context) {
         await api<GenericChartMutation, "">(context)
             .withSuccess(GenericChartMutation.GenericChartMetadataFetched)

--- a/src/app/static/src/app/store/genericChart/genericChart.ts
+++ b/src/app/static/src/app/store/genericChart/genericChart.ts
@@ -3,6 +3,7 @@ import {Module} from "vuex";
 import {RootState} from "../../root";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface GenericChartState {
     genericChartMetadata: GenericChartMetadataResponse | null
@@ -16,7 +17,7 @@ export const initialGenericChartState = (): GenericChartState => {
 
 const namespaced = true;
 
-export const genericChart: Module<GenericChartState, RootState> = {
+export const genericChart: Module<GenericChartState, DataExplorationState> = {
     namespaced,
     state: {...initialGenericChartState()},
     actions,

--- a/src/app/static/src/app/store/hintrVersion/actions.ts
+++ b/src/app/static/src/app/store/hintrVersion/actions.ts
@@ -1,17 +1,16 @@
-import Vue from "vue";
 import { ActionContext, ActionTree } from "vuex";
 import { api } from "../../apiService";
-import { RootState } from "../../root";
 import { HintrVersionState } from "./hintrVersion";
 import { HintrVersionMutation } from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export type HintrVersionActionTypes = "HintrVersionFetched"
 
 export interface HintrVersionActions {
-    getHintrVersion: (store: ActionContext<HintrVersionState, RootState>) => void
+    getHintrVersion: (store: ActionContext<HintrVersionState, DataExplorationState>) => void
 }
 
-export const actions: ActionTree<HintrVersionState, RootState> & HintrVersionActions = {
+export const actions: ActionTree<HintrVersionState, DataExplorationState> & HintrVersionActions = {
 
     async getHintrVersion(context) 
     {

--- a/src/app/static/src/app/store/hintrVersion/hintrVersion.ts
+++ b/src/app/static/src/app/store/hintrVersion/hintrVersion.ts
@@ -4,6 +4,7 @@ import { mutations } from "./mutations";
 import { HintrVersionResponse } from "../../generated";
 import { RootState } from "../../root";
 import { localStorageManager } from "../../localStorageManager";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface HintrVersionState {
     hintrVersion: HintrVersionResponse
@@ -18,7 +19,7 @@ export const initialHintrVersionState = (): HintrVersionState => {
 const namespaced = true;
 const existingState = localStorageManager.getState();
 
-export const hintrVersion: Module<HintrVersionState, RootState> = {
+export const hintrVersion: Module<HintrVersionState, DataExplorationState> = {
     namespaced,
     state: { ...initialHintrVersionState(), ...existingState && existingState.hintrVersion },
     actions,

--- a/src/app/static/src/app/store/language/mutations.ts
+++ b/src/app/static/src/app/store/language/mutations.ts
@@ -1,15 +1,21 @@
 import {MutationTree} from "vuex";
 import {PayloadWithType} from "../../types";
 import {Language} from "../translations/locales";
-import {TranslatableState} from "../../root";
+import {RootState, TranslatableState} from "../../root";
+import {RootMutation} from "../root/mutations";
 
 export enum LanguageMutation {
-    ChangeLanguage = "ChangeLanguage"
+    ChangeLanguage = "ChangeLanguage",
+    SetUpdatingLanguage = "SetUpdatingLanguage"
 }
 
 export const mutations: MutationTree<TranslatableState> = {
 
     [LanguageMutation.ChangeLanguage](state: TranslatableState, action: PayloadWithType<Language>) {
         state.language = action.payload
+    },
+
+    [LanguageMutation.SetUpdatingLanguage](state: TranslatableState, action: PayloadWithType<boolean>) {
+        state.updatingLanguage = action.payload;
     }
 };

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -1,15 +1,15 @@
 import {ActionContext, ActionTree} from 'vuex';
-import {RootState} from "../../root";
 import {api} from "../../apiService";
 import {MetadataState} from "./metadata";
 import {MetadataMutations} from "./mutations";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface MetadataActions {
-    getPlottingMetadata: (store: ActionContext<MetadataState, RootState>, country: string) => void
-    getAdrUploadMetadata: (store: ActionContext<MetadataState, RootState>, downloadId: string) => Promise<void>
+    getPlottingMetadata: (store: ActionContext<MetadataState, DataExplorationState>, country: string) => void
+    getAdrUploadMetadata: (store: ActionContext<MetadataState, DataExplorationState>, downloadId: string) => Promise<void>
 }
 
-export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
+export const actions: ActionTree<MetadataState, DataExplorationState> & MetadataActions = {
 
     async getPlottingMetadata(context, iso3) {
         await api<MetadataMutations, MetadataMutations>(context)

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -11,6 +11,7 @@ import {
 } from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface MetadataState {
     plottingMetadataError: Error | null
@@ -32,7 +33,7 @@ export const metadataGetters = {
     complete: (state: MetadataState) => {
         return !!state.plottingMetadata
     },
-    sapIndicatorsMetadata: (state: MetadataState, getters: any, rootState: RootState, rootGetters: any) => {
+    sapIndicatorsMetadata: (state: MetadataState, getters: any, rootState: DataExplorationState, rootGetters: any) => {
         const plottingMetadata = state.plottingMetadata;
 
         if (!plottingMetadata) {
@@ -56,7 +57,7 @@ export const metadataGetters = {
 
         return (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
     },
-    outputIndicatorsMetadata: (state: MetadataState, getters: any, rootState: RootState, rootGetters: any) => {
+    outputIndicatorsMetadata: (state: MetadataState, getters: any, rootState: DataExplorationState, rootGetters: any) => {
         return (state.plottingMetadata && state.plottingMetadata.output.choropleth &&
             state.plottingMetadata.output.choropleth.indicators) || [];
     }
@@ -65,7 +66,7 @@ export const metadataGetters = {
 const namespaced = true;
 const existingState = localStorageManager.getState();
 
-export const metadata: Module<MetadataState, RootState> = {
+export const metadata: Module<MetadataState, DataExplorationState> = {
     namespaced,
     state: {...initialMetadataState(), ...existingState && existingState.metadata},
     actions,

--- a/src/app/static/src/app/store/password/password.ts
+++ b/src/app/static/src/app/store/password/password.ts
@@ -11,6 +11,7 @@ export interface PasswordState extends TranslatableState {
 
 export const initialPasswordState: PasswordState = {
     language: Language.en,
+    updatingLanguage: false,
     resetLinkRequested: false,
     requestResetLinkError: null,
     passwordWasReset: false,

--- a/src/app/static/src/app/store/plottingSelections/getters.ts
+++ b/src/app/static/src/app/store/plottingSelections/getters.ts
@@ -1,9 +1,9 @@
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
-import {RootState} from "../../root";
 import {ScaleSelections, PlottingSelectionsState, BarchartSelections} from "./plottingSelections";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export const getters = {
-    selectedSAPColourScales: (state: PlottingSelectionsState, getters: any, rootState: RootState): ScaleSelections => {
+    selectedSAPColourScales: (state: PlottingSelectionsState, getters: any, rootState: DataExplorationState): ScaleSelections => {
         const dataType = rootState.surveyAndProgram.selectedDataType;
         switch (dataType) {
             case DataType.Survey:
@@ -16,7 +16,8 @@ export const getters = {
                 return {}
         }
     },
-    calibratePlotDefaultSelections: (state: PlottingSelectionsState, getters: any, rootState: RootState): BarchartSelections => {
-        return rootState.modelCalibrate.calibratePlotResult!.plottingMetadata.barchart.defaults;
+    calibratePlotDefaultSelections: (state: PlottingSelectionsState, getters: any, rootState: DataExplorationState): BarchartSelections => {
+        // TODO find solution to this hack
+        return (rootState as any).modelCalibrate.calibratePlotResult!.plottingMetadata.barchart.defaults;
     }
 };

--- a/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
+++ b/src/app/static/src/app/store/plottingSelections/plottingSelections.ts
@@ -5,6 +5,7 @@ import {RootState} from "../../root";
 import {mutations} from "./mutations";
 import {getters} from "./getters";
 import {Dict} from "../../types";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface PlottingSelectionsState {
     calibratePlot: BarchartSelections,
@@ -140,7 +141,7 @@ export const initialPlottingSelectionsState = (): PlottingSelectionsState => {
 const namespaced = true;
 const existingState = localStorageManager.getState();
 
-export const plottingSelections: Module<PlottingSelectionsState, RootState> = {
+export const plottingSelections: Module<PlottingSelectionsState, DataExplorationState> = {
     namespaced,
     state: {...initialPlottingSelectionsState(), ...existingState && existingState.plottingSelections},
     mutations,

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -8,29 +8,14 @@ import i18next from "i18next";
 import {api} from "../../apiService";
 import {VersionInfo} from "../../generated";
 import {currentHintVersion} from "../../hintVersion";
+import {ErrorReportManualDetails} from "../../types";
+import {LanguageMutation} from "../language/mutations";
 
 
 export interface RootActions extends LanguageActions<RootState> {
     validate: (store: ActionContext<RootState, RootState>) => void;
     generateErrorReport: (store: ActionContext<RootState, RootState>,
                           payload: ErrorReportManualDetails) => void;
-}
-
-export interface ErrorReportManualDetails {
-    section: string,
-    description: string,
-    stepsToReproduce: string,
-    email: string
-}
-
-export interface ErrorReport extends ErrorReportManualDetails {
-    country: string,
-    projectName: string | undefined,
-    browserAgent: string,
-    timeStamp: string,
-    jobId: string,
-    versions: VersionInfo,
-    errors: Error[]
 }
 
 export const actions: ActionTree<RootState, RootState> & RootActions = {
@@ -80,7 +65,7 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
             return;
         }
 
-        commit({type: RootMutation.SetUpdatingLanguage, payload: true});
+        commit({type: LanguageMutation.SetUpdatingLanguage, payload: true});
         await changeLanguage<RootState>(context, payload);
 
         const actions: Promise<unknown>[] = [];
@@ -94,7 +79,7 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
         }
 
         await Promise.all(actions);
-        commit({type: RootMutation.SetUpdatingLanguage, payload: false});
+        commit({type: LanguageMutation.SetUpdatingLanguage, payload: false});
     },
 
     async generateErrorReport(context, payload) {

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -3,6 +3,7 @@ import {Getter, GetterTree} from "vuex";
 import {Error} from "../../generated"
 import {Warning} from "../../generated";
 import {Dict, StepWarnings} from "../../types";
+import {extractErrors} from "../../utils";
 
 interface RootGetters {
     isGuest: Getter<RootState, RootState>
@@ -68,22 +69,3 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
         }
     }
 }
-
-export const extractErrors = (state: any) => {
-    const errors = [] as Error[];
-    extractErrorsRecursively(state, errors);
-    return errors;
-}
-
-const isComplexObject = (state: any) => {
-    return typeof state === 'object' && !Array.isArray(state) && state !== null
-}
-
-const extractErrorsRecursively = (state: any, errors: Error[]) => {
-    if (isComplexObject(state)) {
-        const keys = Object.keys(state);
-        const errorKeys = keys.filter(key => /error$/i.test(key));
-        errors.push(...errorKeys.map(key => state[key]).filter(err => !!err && !!err.error));
-        keys.forEach(key => extractErrorsRecursively(state[key], errors));
-    }
-};

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -25,7 +25,6 @@ export enum RootMutation {
     ResetOutputs = "ResetOutputs",
     SetProject = "SetProject",
     ResetDownload = "ResetDownload",
-    SetUpdatingLanguage = "SetUpdatingLanguage",
     ErrorReportError = "ErrorReportError",
     ErrorReportSuccess = "ErrorReportSuccess"
 }
@@ -60,7 +59,8 @@ export const mutations: MutationTree<RootState> = {
             errors: initialErrorsState(),
             projects: initialProjectsState(),
             currentUser: state.currentUser,
-            downloadResults: initialDownloadResultsState()
+            downloadResults: initialDownloadResultsState(),
+            dataExplorationMode: false
         };
         Object.assign(state, resetState);
 
@@ -148,10 +148,6 @@ export const mutations: MutationTree<RootState> = {
         });
         Object.assign(state.adrUpload, initialADRUploadState());
         Object.assign(state.downloadResults, initialDownloadResultsState());
-    },
-
-    [RootMutation.SetUpdatingLanguage](state: RootState, action: PayloadWithType<boolean>) {
-        state.updatingLanguage = action.payload;
     },
 
     [RootMutation.ErrorReportError](state: RootState, action: PayloadWithType<Error>) {

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -1,26 +1,26 @@
 import {ActionContext, ActionTree, Commit} from 'vuex';
-import {RootState} from "../../root";
 import {DataType, SurveyAndProgramState} from "./surveyAndProgram";
 import {api} from "../../apiService";
 import {AncResponse, ProgrammeResponse, SurveyResponse} from "../../generated";
 import {SurveyAndProgramMutation} from "./mutations";
 import qs from 'qs';
 import {getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export interface SurveyAndProgramActions {
-    importSurvey: (store: ActionContext<SurveyAndProgramState, RootState>, url: string) => void,
-    importProgram: (store: ActionContext<SurveyAndProgramState, RootState>, url: string) => void,
-    importANC: (store: ActionContext<SurveyAndProgramState, RootState>, url: string) => void,
-    uploadSurvey: (store: ActionContext<SurveyAndProgramState, RootState>, formData: FormData) => void,
-    uploadProgram: (store: ActionContext<SurveyAndProgramState, RootState>, formData: FormData) => void,
-    uploadANC: (store: ActionContext<SurveyAndProgramState, RootState>, formData: FormData) => void
-    getSurveyAndProgramData: (store: ActionContext<SurveyAndProgramState, RootState>) => void;
-    deleteSurvey: (store: ActionContext<SurveyAndProgramState, RootState>) => void
-    deleteProgram: (store: ActionContext<SurveyAndProgramState, RootState>) => void
-    deleteANC: (store: ActionContext<SurveyAndProgramState, RootState>) => void
-    deleteAll: (store: ActionContext<SurveyAndProgramState, RootState>) => void
-    selectDataType: (store: ActionContext<SurveyAndProgramState, RootState>, payload: DataType) => void
-    validateSurveyAndProgramData: (store: ActionContext<SurveyAndProgramState, RootState>) => void;
+    importSurvey: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, url: string) => void,
+    importProgram: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, url: string) => void,
+    importANC: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, url: string) => void,
+    uploadSurvey: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, formData: FormData) => void,
+    uploadProgram: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, formData: FormData) => void,
+    uploadANC: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, formData: FormData) => void
+    getSurveyAndProgramData: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void;
+    deleteSurvey: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void
+    deleteProgram: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void
+    deleteANC: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void
+    deleteAll: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void
+    selectDataType: (store: ActionContext<SurveyAndProgramState, DataExplorationState>, payload: DataType) => void
+    validateSurveyAndProgramData: (store: ActionContext<SurveyAndProgramState, DataExplorationState>) => void;
 }
 
 function commitSelectedDataTypeUpdated(commit: Commit, dataType: DataType) {
@@ -33,7 +33,7 @@ interface UploadImportOptions {
     payload: FormData | string
 }
 
-async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, DataExplorationState>, options: UploadImportOptions,
                                  filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
@@ -52,7 +52,7 @@ async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, R
         });
 }
 
-async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramState, DataExplorationState>, options: UploadImportOptions,
                                      filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
@@ -71,7 +71,7 @@ async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramStat
         });
 }
 
-async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState, RootState>, options: UploadImportOptions,
+async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState, DataExplorationState>, options: UploadImportOptions,
                                     filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
@@ -90,7 +90,7 @@ async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState
         });
 }
 
-export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndProgramActions = {
+export const actions: ActionTree<SurveyAndProgramState, DataExplorationState> & SurveyAndProgramActions = {
 
     selectDataType(context, payload) {
         const {commit} = context;

--- a/src/app/static/src/app/store/surveyAndProgram/getters.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/getters.ts
@@ -5,6 +5,7 @@ import {DisplayFilter} from "../../types";
 import {FilterOption} from "../../generated";
 import {rootOptionChildren} from "../../utils";
 import {Language} from "../translations/locales";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 function response(state: SurveyAndProgramState) {
     switch (state.selectedDataType) {
@@ -39,11 +40,11 @@ export const getters = {
         return res ? res.data : null;
     },
 
-    countryAreaFilterOption: (state: SurveyAndProgramState, getters: any, rootState: RootState): FilterOption => {
+    countryAreaFilterOption: (state: SurveyAndProgramState, getters: any, rootState: DataExplorationState): FilterOption => {
         return rootState.baseline.shape!.filters!.regions as FilterOption;
     },
 
-    filters: (state: SurveyAndProgramState, getters: any, rootState: RootState): DisplayFilter[] => {
+    filters: (state: SurveyAndProgramState, getters: any, rootState: DataExplorationState): DisplayFilter[] => {
         const result = [] as DisplayFilter[];
 
         if (state.selectedDataType == null) {

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -5,6 +5,7 @@ import {ReadyState, RootState} from "../../root";
 import {AncResponse, ProgrammeResponse, SurveyResponse, Error} from "../../generated";
 import {getters} from "./getters";
 import {localStorageManager} from "../../localStorageManager";
+import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export enum DataType { ANC, Program, Survey}
 
@@ -40,7 +41,7 @@ export const initialSurveyAndProgramState = (): SurveyAndProgramState => {
 const namespaced = true;
 
 const existingState = localStorageManager.getState();
-export const surveyAndProgram: Module<SurveyAndProgramState, RootState> = {
+export const surveyAndProgram: Module<SurveyAndProgramState, DataExplorationState> = {
     namespaced,
     state: {...initialSurveyAndProgramState(), ...existingState && existingState.surveyAndProgram},
     getters,

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -1,5 +1,5 @@
 import {Payload} from "vuex";
-import {FilterOption, Error, DownloadStatusResponse, DownloadSubmitResponse, Warning} from "./generated";
+import {FilterOption, Error, DownloadStatusResponse, DownloadSubmitResponse, Warning, VersionInfo} from "./generated";
 
 export interface PayloadWithType<T> extends Payload {
     payload: T
@@ -225,4 +225,21 @@ export interface StepWarnings {
     modelOptions: Warning[],
     modelRun: Warning[],
     modelCalibrate: Warning[]
+}
+
+export interface ErrorReportManualDetails {
+    section: string,
+    description: string,
+    stepsToReproduce: string,
+    email: string
+}
+
+export interface ErrorReport extends ErrorReportManualDetails {
+    country: string,
+    projectName: string | undefined,
+    browserAgent: string,
+    timeStamp: string,
+    jobId: string,
+    versions: VersionInfo,
+    errors: Error[]
 }

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -282,3 +282,22 @@ export function getFilenameFromUploadFormData(formdata: FormData) {
     const file = formdata.get("file");
     return (file as File).name;
 }
+
+export const extractErrors = (state: any) => {
+    const errors = [] as Error[];
+    extractErrorsRecursively(state, errors);
+    return errors;
+}
+
+const isComplexObject = (state: any) => {
+    return typeof state === 'object' && !Array.isArray(state) && state !== null
+}
+
+const extractErrorsRecursively = (state: any, errors: Error[]) => {
+    if (isComplexObject(state)) {
+        const keys = Object.keys(state);
+        const errorKeys = keys.filter(key => /error$/i.test(key));
+        errors.push(...errorKeys.map(key => state[key]).filter(err => !!err && !!err.error));
+        keys.forEach(key => extractErrorsRecursively(state[key], errors));
+    }
+};

--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <title>${title}</title>
+    <link rel="shortcut icon" href="/public/favicon.ico"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <!-- inject:css -->
+    <!-- endinject -->
+</head>
+<body>
+<div id="app" :class="language">
+    <data-exploration-header title="${title}" user="${user}"></data-exploration-header>
+    <div class="container mb-5">
+        <data-exploration></data-exploration>
+    </div>
+    <errors title="${title}"></errors>
+</div>
+<script>
+    var currentUser = "${user}"
+</script>
+</body>
+</html>

--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -17,6 +17,7 @@
 </div>
 <script>
     var currentUser = "${user}"
+    var currentMode = "explore"
 </script>
 </body>
 </html>

--- a/src/app/static/templates/index.ftl
+++ b/src/app/static/templates/index.ftl
@@ -17,6 +17,7 @@
 </div>
 <script>
     var currentUser = "${user}"
+    var currentMode = "naomi"
 </script>
 </body>
 </html>

--- a/src/app/static/webpack.config.js
+++ b/src/app/static/webpack.config.js
@@ -121,7 +121,23 @@ const resetPasswordAppConfig =  {...commonConfig,
     ]
 };
 
-module.exports = [appConfig, forgotPasswordAppConfig, resetPasswordAppConfig];
+const dataExplorationAppConfig =  {...commonConfig,
+    entry: './src/app/dataExploration.ts',
+    output: {
+        path: path.resolve(__dirname, './public'),
+        publicPath: '/public/',
+        filename: 'js/dataExploration.js'
+    },
+    plugins: [...commonConfig.plugins,
+        new HtmlWebpackPlugin({
+            hash: true,
+            template: 'public/data-exploration.ftl',
+            filename: 'data-exploration.ftl'
+        })
+    ]
+};
+
+module.exports = [appConfig, forgotPasswordAppConfig, resetPasswordAppConfig, dataExplorationAppConfig];
 
 if (process.env.NODE_ENV === 'production') {
     module.exports.forEach((moduleExport) =>


### PR DESCRIPTION
Proof of concept for data exploration mode. To see working, run the app locally and navigate to `/explore`. Note there will be console errors if you navigate to step 2 without adding data.

Comments welcome.

I've added a few tickets and tidied up the existing ones:

House-keeping:
* Rename `baseline` and `surveyAndProgram` modules and components - I see that the content of these have diverged from the names and I would like to tidy this up before re-using them
* Move error report related mutations into own class, analogous to language mutations (or possibly into the existing `errors` module?)

Backend:
* Add new route and freemarker template. Include logic to store mode against session and clear version id if moving between modes. Include `var mode` as a js variable in the same way as we do current user and modify local storage manager so that state is not persisted between apps: https://github.com/mrc-ide/hint/pull/595/files#diff-8a4dde40541e3038e68c635e6c52b363a07a7447c06691ee04f8b7cd797e008bR51

Front-end:
* Add new app with shared state and modules
* Show `ResetConfirmation` components conditionally based on flag in state
* New navbar component for data exploration mode
* New error report component for data exploration mode as the existing one is tightly coupled to projects and stepper modules
* Add data exploration component itself, including back/next buttons (validation rule before allowing forward navigation may be different from existing app?)
