### PR TITLE
mrc-2753 Add /explore endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.66.0
+
+* Add /explore endpoint
+
 # hint 1.65.0
 
 * Show Input Time Series plots

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -27,6 +27,7 @@ interface AppProperties
     val emailSender: String
     val emailUsername: String
     val emailPassword: String
+    val exploreApplicationTitle: String
     val tokenIssuer: String
     val uploadDirectory: String
     val dbUser: String
@@ -61,6 +62,7 @@ class ConfiguredAppProperties(private val props: HintProperties = properties) : 
     override val emailSender = propString("email_sender")
     override val emailUsername = propString("email_username")
     override val emailPassword = propString("email_password")
+    override val exploreApplicationTitle = propString("explore_application_title")
     override val tokenIssuer = propString("token_issuer")
     override val uploadDirectory = propString("upload_dir")
     override val dbUser: String = propString("db_user")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
@@ -28,10 +28,22 @@ class HomeController(
     fun index(model: Model): String
     {
         val userProfile = session.getUserProfile()
+        session.setMode("naomi")
         versionRepository.saveVersion(session.getVersionId(), null)
         model["title"] = appProperties.applicationTitle
         model["user"] = userProfile.id
         return "index"
+    }
+
+    @GetMapping(value = ["/explore"])
+    fun explore(model: Model): String
+    {
+        val userProfile = session.getUserProfile()
+        session.setMode("explore")
+        versionRepository.saveVersion(session.getVersionId(), null)
+        model["title"] = "Naomi Data Exploration"
+        model["user"] = userProfile.id
+        return "data-exploration"
     }
 
     @GetMapping("/metrics", produces = ["text/plain"])

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HomeController.kt
@@ -27,23 +27,23 @@ class HomeController(
     @GetMapping(value = ["/", "/projects", "accessibility"])
     fun index(model: Model): String
     {
-        val userProfile = session.getUserProfile()
-        session.setMode("naomi")
-        versionRepository.saveVersion(session.getVersionId(), null)
-        model["title"] = appProperties.applicationTitle
-        model["user"] = userProfile.id
-        return "index"
+        return loadApp("naomi", appProperties.applicationTitle, "index", model)
     }
 
     @GetMapping(value = ["/explore"])
     fun explore(model: Model): String
     {
+        return loadApp("explore", appProperties.exploreApplicationTitle, "data-exploration", model)
+    }
+
+    private fun loadApp(mode: String, applicationTitle: String, template: String, model: Model): String
+    {
         val userProfile = session.getUserProfile()
-        session.setMode("explore")
+        session.setMode(mode)
         versionRepository.saveVersion(session.getVersionId(), null)
-        model["title"] = "Naomi Data Exploration"
+        model["title"] = applicationTitle
         model["user"] = userProfile.id
-        return "data-exploration"
+        return template
     }
 
     @GetMapping("/metrics", produces = ["text/plain"])

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -67,8 +67,6 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
     {
         var savedMode = pac4jConfig.sessionStore.get(webContext, MODE) as String?
 
-        println("Setting to mode to $mode - saved mode was $savedMode")
-
         if (savedMode != mode)
         {
             // If mode has changed, clear the session version id too

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -65,8 +65,7 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
 
     fun setMode(mode: String)
     {
-        var savedMode = pac4jConfig.sessionStore.get(webContext, MODE) as String?
-
+        val savedMode = pac4jConfig.sessionStore.get(webContext, MODE) as String?
         if (savedMode != mode)
         {
             // If mode has changed, clear the session version id too

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -46,6 +46,7 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
     companion object
     {
         private const val VERSION_ID = "version_id"
+        private const val MODE = "mode"
     }
 
     fun getUserProfile(): CommonProfile
@@ -60,6 +61,20 @@ class Session(private val webContext: WebContext, private val pac4jConfig: Confi
     fun userIsGuest(): Boolean
     {
         return getUserProfile().id == GUEST_USER
+    }
+
+    fun setMode(mode: String)
+    {
+        var savedMode = pac4jConfig.sessionStore.get(webContext, MODE) as String?
+
+        println("Setting to mode to $mode - saved mode was $savedMode")
+
+        if (savedMode != mode)
+        {
+            // If mode has changed, clear the session version id too
+            pac4jConfig.sessionStore.set(webContext, MODE, mode)
+            setVersionId(null)
+        }
     }
 
     fun getVersionId(): String

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -16,6 +16,7 @@ email_port=587
 email_sender=naomi-notifications@imperial.ac.uk
 email_username=naomi
 email_password=
+explore_application_title=Naomi Data Exploration
 upload_dir=uploads
 token_issuer=mrc-ide
 hintr_url=http://localhost:8888

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/HintApplicationTests.kt
@@ -27,6 +27,13 @@ class HintApplicationTests : SecureIntegrationTests()
 
     @ParameterizedTest
     @EnumSource(IsAuthorized::class)
+    fun `all users can access explore`(isAuthorized: IsAuthorized)
+    {
+        testAllUserAccess("/explore", isAuthorized)
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
     fun `all users can access projects`(isAuthorized: IsAuthorized)
     {
         testAllUserAccess("/projects", isAuthorized)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/AppPropertiesTest.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/AppPropertiesTest.kt
@@ -55,6 +55,14 @@ class AppPropertiesTests
     }
 
     @Test
+    fun `can read exploreApplicationTitle`()
+    {
+        val props = readPropsFromTempFile("explore_application_title=Explore TestTitle")
+        val sut = ConfiguredAppProperties(props)
+        assertThat(sut.exploreApplicationTitle).isEqualTo("Explore TestTitle")
+    }
+
+    @Test
     fun `can read applicationUrl`()
     {
         val props = readPropsFromTempFile("application_url=https://test")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/HomeControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/HomeControllerTests.kt
@@ -2,12 +2,18 @@ package org.imperial.mrc.hint.unit.controllers
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.clients.HintrAPIClient
 import org.imperial.mrc.hint.controllers.HomeController
+import org.imperial.mrc.hint.db.VersionRepository
+import org.imperial.mrc.hint.security.Session
 import org.junit.jupiter.api.Test
+import org.pac4j.core.profile.CommonProfile
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.ui.Model
 
 class HomeControllerTests
 {
@@ -15,6 +21,62 @@ class HomeControllerTests
             "\"data\":{\"chocolatey_whippet_2\":\"IDLE\",\"chocolatey_whippet_1\":\"IDLE\"," +
             "\"chocolatey_whippet_3\":\"PAUSED\", \"chocolatey_whippet_4\":\"EXITED\"," +
             "\"chocolatey_whippet_5\":\"BUSY\"}}"
+
+    @Test
+    fun `index saves version and sets model properties`()
+    {
+        val mockRepo = mock<VersionRepository>()
+
+        val mockProfile = mock<CommonProfile> {
+            on { id } doReturn "test-user"
+        }
+        val mockSession = mock<Session> {
+            on { getUserProfile() } doReturn mockProfile
+            on { getVersionId() } doReturn "test-version"
+        }
+        val mockAppProps = mock<AppProperties> {
+            on { applicationTitle } doReturn "Test App Title"
+        }
+        val mockModel = mock<Model>()
+
+        val sut = HomeController(mockRepo, mockSession, mockAppProps, mock())
+
+        val result = sut.index(mockModel)
+        assertThat(result).isEqualTo("index")
+
+        verify(mockSession).setMode("naomi")
+        verify(mockRepo).saveVersion("test-version", null)
+        verify(mockModel).addAttribute("title", "Test App Title")
+        verify(mockModel).addAttribute("user", "test-user")
+    }
+
+    @Test
+    fun `explore saves version and sets model properties`()
+    {
+        val mockRepo = mock<VersionRepository>()
+
+        val mockProfile = mock<CommonProfile> {
+            on { id } doReturn "test-user"
+        }
+        val mockSession = mock<Session> {
+            on { getUserProfile() } doReturn mockProfile
+            on { getVersionId() } doReturn "test-version"
+        }
+        val mockAppProps = mock<AppProperties> {
+            on { exploreApplicationTitle } doReturn "Test Explore App Title"
+        }
+        val mockModel = mock<Model>()
+
+        val sut = HomeController(mockRepo, mockSession, mockAppProps, mock())
+
+        val result = sut.explore(mockModel)
+        assertThat(result).isEqualTo("data-exploration")
+
+        verify(mockSession).setMode("explore")
+        verify(mockRepo).saveVersion("test-version", null)
+        verify(mockModel).addAttribute("title", "Test Explore App Title")
+        verify(mockModel).addAttribute("user", "test-user")
+    }
 
     @Test
     fun `gets metrics for each worker status type`()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SessionTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SessionTests.kt
@@ -1,8 +1,6 @@
 package org.imperial.mrc.hint.unit.security
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.pac4j.core.config.Config
@@ -54,6 +52,43 @@ class SessionTests
         UUID.fromString(versionId)
 
         verify(mockSessionStore).set(mockWebContext, "version_id", versionId)
+    }
+
+    @Test
+    fun `setMode saves new mode and clears version id if mode has changed`()
+    {
+        val mockWebContext = mock<WebContext>()
+        val mockSessionStore = mock<SessionStore<WebContext>> {
+            on { get(mockWebContext, "mode") } doReturn "naomi"
+        }
+        val mockConfig = mock<Config>
+        {
+            on {sessionStore} doReturn mockSessionStore
+        }
+
+        val sut = Session(mockWebContext, mockConfig)
+        sut.setMode("explore")
+
+        verify(mockSessionStore).set(mockWebContext, "mode", "explore")
+        verify(mockSessionStore).set(mockWebContext, "version_id", null)
+    }
+
+    @Test
+    fun `setMode does nothing if mode has not changed`()
+    {
+        val mockWebContext = mock<WebContext>()
+        val mockSessionStore = mock<SessionStore<WebContext>> {
+            on { get(mockWebContext, "mode") } doReturn "naomi"
+        }
+        val mockConfig = mock<Config>
+        {
+            on {sessionStore} doReturn mockSessionStore
+        }
+
+        val sut = Session(mockWebContext, mockConfig)
+        sut.setMode("naomi")
+
+        verify(mockSessionStore, never()).set(any(), any(), any())
     }
 }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/DataExplorationTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/DataExplorationTests.kt
@@ -1,0 +1,26 @@
+package org.imperial.mrc.hint.unit.templates
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.ui.ConcurrentModel
+
+class DataExplorationTests
+{
+    companion object
+    {
+        val template = FreemarkerTemplateLoader("data-exploration.ftl")
+
+    }
+
+    @Test
+    fun `renders as expected`()
+    {
+        val model = ConcurrentModel()
+        model["title"] = "ExploreAppTitle"
+        model["user"] = "guest"
+        val doc = template.jsoupDocFor(model)
+
+        assertThat(doc.select("title").text()).isEqualTo("ExploreAppTitle")
+        assertThat(doc.select(".container").text()).isEqualTo("Data Exploration content will go here")
+    }
+}

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.65.0";
+export const currentHintVersion = "1.66.0";

--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <title>${title}</title>
+    <link rel="shortcut icon" href="/public/favicon.ico"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <!-- inject:css -->
+    <!-- endinject -->
+</head>
+<body>
+<div id="app" :class="language">
+    <div class="container mb-5">
+        <div class="row h4 mt-4">
+            Data Exploration Content will go here
+        </div>
+    </div>
+</div>
+<script>
+    var currentUser = "${user}";
+</script>
+</body>
+</html>

--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -11,7 +11,7 @@
 <div id="app" :class="language">
     <div class="container mb-5">
         <div class="row h4 mt-4">
-            Data Exploration Content will go here
+            Data Exploration content will go here
         </div>
     </div>
 </div>

--- a/src/app/static/webpack.config.js
+++ b/src/app/static/webpack.config.js
@@ -121,7 +121,23 @@ const resetPasswordAppConfig =  {...commonConfig,
     ]
 };
 
-module.exports = [appConfig, forgotPasswordAppConfig, resetPasswordAppConfig];
+const dataExplorationAppConfig = {...commonConfig,
+    entry: './src/app/index.ts', //TODO: replace with './src/app/dataExploration.ts' in mrc-2756
+    output: {
+        path: path.resolve(__dirname, './public'),
+        publicPath: '/public/',
+        filename: 'js/app.js' //TODO: replace with  'js/dataExploration.js' in mrc-2756
+    },
+    plugins: [...commonConfig.plugins,
+        new HtmlWebpackPlugin({
+            hash: true,
+            template: 'public/data-exploration.ftl',
+            filename: 'data-exploration.ftl'
+        })
+    ]
+};
+
+module.exports = [appConfig, forgotPasswordAppConfig, resetPasswordAppConfig, dataExplorationAppConfig];
 
 if (process.env.NODE_ENV === 'production') {
     module.exports.forEach((moduleExport) =>


### PR DESCRIPTION
## Description

This branch adds an `/explore` endpoint which returns a placeholder template.

The `index` and `explore` methods in the `HomeController` now set mode in the session, "naomi" or "explore", and when mode changes, the Session clear the version id so that the underlying project version state is never persisted between modes.

Note that one of the routes for the `index` method is `/accessibility` so this means loading then refreshing the accessibility page from data exploration would reset the mode to 'naomi'. We'll need some way of dealing with this when the accessibility page is added for data exploration - perhaps a separate route.

To test the endpoint: browse to `/explore` and see a page with placeholder content. The title in the browser tab should be 'Naomi Data Exploration'
To test the version clearing behaviour: while logged in, open any project in the normal naomi mode. Browse to `/explore` then back to `/` - the previously open project should not be retained, but the app should show the Projects page

## Type of version change
_Delete as appropriate_

Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
