### PR TITLE
mrc-2765 Updated incorrect Portuguese translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.70.1
+
+* correct Portuguese translation for "Steps to reproduce"
+
 # hint 1.70.0
 
 * adds basic data exploration app with loading spinner 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.69.0";
+export const currentHintVersion = "1.70.1";

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -1096,7 +1096,7 @@ const pt: Partial<Translations> = {
     renameProjectHeader: "Por favor, introduza um novo nome para o projeto",
     renameProjectHistoryHeader: "Mudar o nome",
     reportBug: "Comunicar um erro",
-    reproduce: "Reportar problemas",
+    reproduce: "Passos para reproduzir",
     reproduceErrorHelp: "Descreva como reproduzir o erro para que outra pessoa possa seguir seus passos.",
     requestReset: "Solicitar e-mail de reposição de palavra-passe",
     required: "necessário",

--- a/src/app/static/src/tests/components/errorReport.test.ts
+++ b/src/app/static/src/tests/components/errorReport.test.ts
@@ -131,7 +131,7 @@ describe("Error report component", () => {
         expectTranslated(labels.at(4),
             "Steps to reproduce",
             "Étapes à reproduire",
-            "Reportar problemas",
+            "Passos para reproduzir",
             store)
 
         const mutedText = wrapper.findAll("div.small.text-muted")


### PR DESCRIPTION
## Description

See [ticket](https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2765) for description - opportunistic correction of translation found while compiling latest translations spreadsheet.  The Portuguese translation for `reproduce` should translate "Steps to reproduce", but its value was "Reportar problemas" i.e. "Report problems". I've updated this to the more plausbile "Passos para reproduzir"

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
