### PR TITLE
mrc-2775 Filter Survey and Program choropleth indicators by those included in response metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.70.3
+
+* bug fix for input indicators being included when not relevant for dataset
+
 # hint 1.70.2
 
 * bug fix for undefined indicator in choropleth while new data is loading

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.70.2";
+export const currentHintVersion = "1.70.3";

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -42,7 +42,7 @@ export const metadataGetters = {
         const selectedDataType = sap.selectedDataType;
 
         let metadataForType: Metadata | null = null;
-        let dataIndicators: FilterOption[];
+        let dataIndicators: FilterOption[] = [];
         switch (selectedDataType) {
             case (DataType.ANC):
                 metadataForType = plottingMetadata.anc;
@@ -58,10 +58,10 @@ export const metadataGetters = {
                 break;
         }
 
-        const unfiltered =  (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
+        const unfiltered = (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
         return (unfiltered as ChoroplethIndicatorMetadata[]).filter(
-            (metaIndicator: any) => dataIndicators!.some(
-                (dataIndicator: any) => metaIndicator.indicator === dataIndicator.id
+            (metaIndicator: ChoroplethIndicatorMetadata) => dataIndicators.some(
+                (dataIndicator: FilterOption) => metaIndicator.indicator === dataIndicator.id
             )
         )
     },

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -58,7 +58,7 @@ export const metadataGetters = {
                 break;
         }
 
-        const unfiltered = (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
+        const unfiltered = metadataForType?.choropleth ? metadataForType.choropleth.indicators : [];
         return (unfiltered as ChoroplethIndicatorMetadata[]).filter(
             (metaIndicator: ChoroplethIndicatorMetadata) => dataIndicators.some(
                 (dataIndicator: FilterOption) => metaIndicator.indicator === dataIndicator.id

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -5,7 +5,7 @@ import {
     PlottingMetadataResponse,
     Error,
     Metadata,
-    AdrMetadataResponse, FilterOption
+    AdrMetadataResponse, FilterOption, ChoroplethIndicatorMetadata
 } from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
@@ -39,7 +39,7 @@ export const metadataGetters = {
         }
 
         const sap = rootState.surveyAndProgram;
-        const selectedDataType = rootState.surveyAndProgram.selectedDataType;
+        const selectedDataType = sap.selectedDataType;
 
         let metadataForType: Metadata | null = null;
         let dataIndicators: FilterOption[];
@@ -59,7 +59,7 @@ export const metadataGetters = {
         }
 
         const unfiltered =  (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
-        return (unfiltered as any).filter(
+        return (unfiltered as ChoroplethIndicatorMetadata[]).filter(
             (metaIndicator: any) => dataIndicators!.some(
                 (dataIndicator: any) => metaIndicator.indicator === dataIndicator.id
             )

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -5,7 +5,7 @@ import {
     PlottingMetadataResponse,
     Error,
     Metadata,
-    AdrMetadataResponse
+    AdrMetadataResponse, FilterOption
 } from "../../generated";
 import {localStorageManager} from "../../localStorageManager";
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
@@ -38,22 +38,32 @@ export const metadataGetters = {
             return [];
         }
 
+        const sap = rootState.surveyAndProgram;
         const selectedDataType = rootState.surveyAndProgram.selectedDataType;
 
         let metadataForType: Metadata | null = null;
+        let dataIndicators: FilterOption[];
         switch (selectedDataType) {
             case (DataType.ANC):
                 metadataForType = plottingMetadata.anc;
+                dataIndicators = sap.anc?.filters.indicators || [];
                 break;
             case (DataType.Program):
                 metadataForType = plottingMetadata.programme;
+                dataIndicators = sap.program?.filters.indicators || [];
                 break;
             case (DataType.Survey):
                 metadataForType = plottingMetadata.survey;
+                dataIndicators = sap.survey?.filters.indicators ||[];
                 break;
         }
 
-        return (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
+        const unfiltered =  (metadataForType && metadataForType.choropleth) ? metadataForType.choropleth.indicators : [];
+        return (unfiltered as any).filter(
+            (metaIndicator: any) => dataIndicators!.some(
+                (dataIndicator: any) => metaIndicator.indicator === dataIndicator.id
+            )
+        )
     },
     outputIndicatorsMetadata: (state: MetadataState, getters: any, rootState: DataExplorationState, rootGetters: any) => {
         return (state.plottingMetadata && state.plottingMetadata.output.choropleth &&

--- a/src/app/static/src/tests/metadata/metadata.test.ts
+++ b/src/app/static/src/tests/metadata/metadata.test.ts
@@ -9,8 +9,18 @@ import {
 
 const testIndicators = [
     {indicator: "art_coverage", name: "ART Coverage"},
-    {indicator: "prevalence", name: "Prevalence"}
+    {indicator: "prevalence", name: "Prevalence"},
+    {indicator: "not_included", name: "Should Not Be Included"}
 ];
+
+const testIndicatorsForDataset = {
+    filters: {
+        indicators: [
+            {id: "art_coverage", name: "ART Coverage"},
+            {id: "prevalence", name: "Prevalence"}
+        ]
+    }
+};
 
 const testChoroMetadata = {
     choropleth: {
@@ -20,26 +30,35 @@ const testChoroMetadata = {
 
 function testGetsSAPIndicatorsMetadataForDataType(dataType: DataType) {
     let metadataProps = null as any;
+    let sapState = null as any;
     switch (dataType) {
         case(DataType.ANC):
             metadataProps = {anc: testChoroMetadata};
+            sapState = {anc: testIndicatorsForDataset};
             break;
         case(DataType.Survey):
             metadataProps = {survey: testChoroMetadata};
+            sapState = {survey: testIndicatorsForDataset};
             break;
         case(DataType.Program):
             metadataProps = {programme: testChoroMetadata};
+            sapState = {program: testIndicatorsForDataset};
             break;
     }
 
     const metadataState = mockMetadataState(
         {plottingMetadata: mockPlottingMetadataResponse(metadataProps)});
 
-    const rootState = mockRootState({surveyAndProgram: mockSurveyAndProgramState({selectedDataType: dataType})});
+    const rootState = mockRootState({
+        surveyAndProgram: mockSurveyAndProgramState({
+            ...sapState,
+            selectedDataType: dataType
+        })
+    });
 
     const result = metadataGetters.sapIndicatorsMetadata(metadataState, null, rootState, null);
 
-    expect(result).toStrictEqual(testIndicators);
+    expect(result).toStrictEqual([testIndicators[0], testIndicators[1]]);
 }
 
 describe("Metadata ", () => {
@@ -67,7 +86,12 @@ describe("Metadata ", () => {
 
     it("gets SAP choropleth indicators", () => {
 
-        const rootState = mockRootState({surveyAndProgram: mockSurveyAndProgramState({selectedDataType: DataType.ANC})});
+        const rootState = mockRootState({
+            surveyAndProgram: mockSurveyAndProgramState({
+                selectedDataType: DataType.ANC,
+                anc: testIndicatorsForDataset as any
+            })
+        });
 
         const testMetadata = {
             anc: testChoroMetadata,
@@ -80,7 +104,7 @@ describe("Metadata ", () => {
             {plottingMetadata: testMetadata}
         ), null, rootState, null);
 
-        expect(result).toStrictEqual(testIndicators);
+        expect(result).toStrictEqual([testIndicators[0], testIndicators[1]]);
     });
 
     it("gets outputIndicators", () => {


### PR DESCRIPTION
## Description

This branch address addresses the bug whereby 'VLS tested` and 'VLS tests suppressed' indicators were still being displayed for ART data even when using the 'no vls' ART file (attached to ticket), which contains no VLS data. 

The problem here was that indicator metadata is spread across two sets of responses and we were only using one of them:
- the 'full' indicator metadata, including complete specification of column ids etc comes from the plotting metadata endpoint. This is only refreshed when a new PJNZ is uploaded
- the data response for survey, anc and programme (ART) contains a `filters` section which actually includes `indicators`,which lists the indicators which should be available for the current dataset

This branch combines these metadata sources to filter the full indicator metadata returned by the `sapIndicatorsMetadata` getter to include only those indicators listed in the relevant data response. 

To test:
 - import ADR Antarctica dataset as usual, and observe VLS indicators in Review Input's Map view for ART data
 - Go back to step 1 and replace the ART file with manual upload of `programme_no_vls.csv` attached to this ticket
 - Proceed to step 2, and observe that VLS indicators have been removed from the Map view for ART data 

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
