### PR TITLE
mrc-2797 Remove calibration plot when user changes calibration options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.73.2
+
+* Remove calibration plot when user changes calibration options
+
 # hint 1.73.1
 
 * fix issues with displaying Input Time Series for DRC data

--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -23,7 +23,7 @@
             >
                 {{ submitText }}
             </button>
-            <p v-if="calibrationPlotGenerated" id="reviewResults" class="mb-0" v-translate="'reviewResults'"></p>
+            <p v-if="showCalibrateResults" id="reviewResults" class="mb-0" v-translate="'reviewResults'"></p>
         </div>
         <div v-if="calibrating" id="calibrating" class="mt-3">
             <loading-spinner size="xs"></loading-spinner>
@@ -44,7 +44,7 @@
             <span v-translate="'genCalibResults'"></span>
         </div>
         <calibration-results
-            v-if="calibrationPlotGenerated && complete"
+            v-if="showCalibrateResults"
         ></calibration-results>
     </div>
 </template>
@@ -94,6 +94,7 @@
         hasError: boolean;
         error: Error;
         progressMessage: string;
+        showCalibrateResults: boolean
     }
 
     interface Data {
@@ -129,8 +130,11 @@
                     } else {
                         return null;
                     }
-                },
+                }
             }),
+            showCalibrateResults() {
+                return this.calibrationPlotGenerated && this.complete
+            },
             currentLanguage: mapStateProp<RootState, Language>(
                 null,
                 (state: RootState) => state.language

--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -62,13 +62,11 @@
 
     import {
         mapActionByName,
-        mapGetterByName,
         mapMutationByName,
         mapStateProp,
         mapStateProps,
     } from "../../utils";
     import { ModelCalibrateMutation } from "../../store/modelCalibrate/mutations";
-    import { StepDescription } from "../../store/stepper/stepper";
     import { RootState } from "../../root";
     import { Language } from "../../store/translations/locales";
     import { ModelCalibrateState } from "../../store/modelCalibrate/modelCalibrate";

--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -44,7 +44,7 @@
             <span v-translate="'genCalibResults'"></span>
         </div>
         <calibration-results
-            v-if="calibrationPlotGenerated"
+            v-if="calibrationPlotGenerated && complete"
         ></calibration-results>
     </div>
 </template>
@@ -113,18 +113,18 @@
         },
         computed: {
             ...mapStateProps<ModelCalibrateState, keyof Computed>(namespace, {
-                loading: (s) => s.fetching,
-                calibrating: (s) => s.calibrating,
-                generatingCalibrationPlot: (s) => s.generatingCalibrationPlot,
-                calibrationPlotGenerated: (s) => !!s.calibratePlotResult,
-                error: (s) => s.error,
-                progressMessage: (s) => {
+                loading: (state) => state.fetching,
+                calibrating: (state) => state.calibrating,
+                generatingCalibrationPlot: (state) => state.generatingCalibrationPlot,
+                calibrationPlotGenerated: (state) => !!state.calibratePlotResult,
+                error: (state) => state.error,
+                progressMessage: (state) => {
                     if (
-                        s.status &&
-                        s.status.progress &&
-                        s.status.progress.length > 0
+                        state.status &&
+                        state.status.progress &&
+                        state.status.progress.length > 0
                     ) {
-                        const p = s.status.progress[0]; //This may be either a string or ProgressPhase
+                        const p = state.status.progress[0]; //This may be either a string or ProgressPhase
                         return typeof p == "string"
                             ? p
                             : `${p.name}: ${p.helpText}`;
@@ -179,6 +179,6 @@
         },
         mounted() {
             this.fetchOptions();
-        },
+        }
     });
 </script>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.73.1";
+export const currentHintVersion = "1.73.2";

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -1,8 +1,8 @@
-import Vuex, {ActionTree, MutationTree, Store} from "vuex";
+import Vuex, {Store} from "vuex";
 import {mockError, mockModelCalibrateState, mockRootState} from "../../mocks";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {RootState} from "../../../app/root";
-import {ModelCalibrateState} from "../../../app/store/modelCalibrate/modelCalibrate";;
+import {ModelCalibrateState} from "../../../app/store/modelCalibrate/modelCalibrate";
 import {mount, shallowMount} from "@vue/test-utils";
 import ModelCalibrate from "../../../app/components/modelCalibrate/ModelCalibrate.vue";
 import CalibrationResults from "../../../app/components/modelCalibrate/CalibrationResults.vue";
@@ -74,7 +74,7 @@ describe("Model calibrate component", () => {
     it("invokes fetch options action on mount", () => {
         const mockFetch = jest.fn();
         const store = getStore({}, mockFetch);
-        const wrapper = getWrapper(store);
+        getWrapper(store);
         expect(mockFetch.mock.calls.length).toBe(1);
     });
 

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -176,11 +176,17 @@ describe("Model calibrate component", () => {
         "Générer des résultats d'étalonnage", "Gerando resultados de calibração", store);
     });
 
-    it("renders calibration plot", () => {
+    it("renders calibration plot if calibration is complete", () => {
         const store = getStore({complete: true, calibratePlotResult: {}});
         const wrapper = getWrapper(store);
         expect(wrapper.find(CalibrationResults).exists()).toBe(true);
         expectTranslated(wrapper.find("#reviewResults"), "(Review results below)",
         "(Consultez les résultats ci-dessous)", "(Analise os resultados abaixo)", store);
+    });
+
+    it("it does not render calibration plot if calibration is incomplete", () => {
+        const store = getStore({complete: false, calibratePlotResult: {}});
+        const wrapper = getWrapper(store);
+        expect(wrapper.find(CalibrationResults).exists()).toBe(false);
     });
 });

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -176,7 +176,7 @@ describe("Model calibrate component", () => {
         "Générer des résultats d'étalonnage", "Gerando resultados de calibração", store);
     });
 
-    it("renders calibration plot if calibration is complete", () => {
+    it("renders calibration plot and label if calibration is complete", () => {
         const store = getStore({complete: true, calibratePlotResult: {}});
         const wrapper = getWrapper(store);
         expect(wrapper.find(CalibrationResults).exists()).toBe(true);
@@ -184,9 +184,10 @@ describe("Model calibrate component", () => {
         "(Consultez les résultats ci-dessous)", "(Analise os resultados abaixo)", store);
     });
 
-    it("it does not render calibration plot if calibration is incomplete", () => {
+    it("it does not render calibration plot and label if calibration is incomplete", () => {
         const store = getStore({complete: false, calibratePlotResult: {}});
         const wrapper = getWrapper(store);
         expect(wrapper.find(CalibrationResults).exists()).toBe(false);
+        expect(wrapper.find("#reviewResults").exists()).toBe(false)
     });
 });


### PR DESCRIPTION
Displays calibrate plot only when calibration is complete

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
