### PR TITLE
mrc-2830 Improve performance of labelledData method in GenericChartTable

### DIFF
--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -101,33 +101,12 @@
                 // associated labels
                 const columnsDict = this.columns.reduce((dict, column) => ({...dict, [column.id]: column}), {} as Dict<GenericChartColumn>);
 
-                // Convert each label column's filter options to a dictionary of id to labels so we do not need to find values'
-                // labels in the options array per row
-                const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
-                const reduceConfigLabelColumnsOptionsToDict = (dict: Dict<Dict<string>>, columnConfig: GenericChartTableColumnConfig) => {
-                    const key = columnConfig.data.labelColumn!;
-                    // If key is not already in dictionary, and options are an array (not always the case for hierarchies)
-                    if (!dict[key] && columnsDict[key].values.reduce) {
-                        const filterOptions = columnsDict[key].values;
-                        const labelDict = filterOptions.reduce((innerDict, option) => {
-                            innerDict[option.id] = option.label;
-                            return innerDict;
-                        }, {} as Dict<string>);
-                        dict[key] = labelDict;
-                    }
-                    return dict;
-                };
-                const columnValueLabels = configLabelColumns.reduce(reduceConfigLabelColumnsOptionsToDict, {} as Dict<Dict<string>>);
-
                 const result = this.filteredData.map(row => {
                     const friendlyRow = {...row};
-                    // Check the table configuration for each configured column, and replace data values
-                    // with friendly values (labels) taken from columnValueLabels where configured to do so - i.e.
-                    // when there is a 'labelColumn' value
-                    configLabelColumns.forEach(columnConfig => {
-                        const columnId = columnConfig.data.columnId;
-                        const rowValue = row[columnId];
-                        friendlyRow[columnId] = columnValueLabels[columnConfig.data.labelColumn!][rowValue];
+                    this.tableConfig.columns.filter(column => column.data.labelColumn).forEach(columnConfig => {
+                        const column = columnsDict[columnConfig.data.labelColumn!];
+                        const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
+                        friendlyRow[columnConfig.data.columnId] = friendlyValue;
                     });
 
                     // Include additional fields for any columns configured to include hierarchy values - use the

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -96,17 +96,21 @@
                return result;
             },
             labelledData() {
-                console.log("started labelled data:" +  new Date().toISOString())
                 // Build a dictionary of the columns defined in the fetched dataset, which include all values and
                 // associated labels
                 const columnsDict = this.columns.reduce((dict, column) => ({...dict, [column.id]: column}), {} as Dict<GenericChartColumn>);
 
                 const result = this.filteredData.map(row => {
-                    const friendlyRow = {...row};
-                    this.tableConfig.columns.filter(column => column.data.labelColumn).forEach(columnConfig => {
-                        const column = columnsDict[columnConfig.data.labelColumn!];
-                        const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
-                        friendlyRow[columnConfig.data.columnId] = friendlyValue;
+                    const friendlyRow = {} as Dict<unknown>;
+                    this.tableConfig.columns.forEach(columnConfig => {
+                        const columnId = columnConfig.data.columnId;
+                        if (columnConfig.data.labelColumn) {
+                            const column = columnsDict[columnConfig.data.labelColumn!];
+                            const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
+                            friendlyRow[columnId] = friendlyValue;
+                        } else {
+                            friendlyRow[columnId] = row[columnId];
+                        }
                     });
 
                     // Include additional fields for any columns configured to include hierarchy values - use the
@@ -118,7 +122,6 @@
                     });
                     return friendlyRow;
                 });
-                console.log("finished labelled data:" +  new Date().toISOString())
                 return result;
             }
         },

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -1,6 +1,4 @@
 <template>
-    <div>
-    <div>{{hierarchyColumnPaths}}</div>
     <table-view :fields="generatedFields" :filtered-data="labelledData">
         <template v-for="column in columnsWithHierarchy" v-slot:[`cell(${column.data.columnId})`]="data">
             <div :key="column.data.columnId">
@@ -9,18 +7,13 @@
             </div>
         </template>
     </table-view>
-    </div>
 </template>
 
 <script lang="ts">
     import Vue from "vue";
     import {FilterOption, NestedFilterOption} from "../../generated";
-    import {
-        Dict, GenericChartColumn, GenericChartTableColumnConfig,
-        GenericChartTableConfig
-    } from "../../types";
+    import {Dict, GenericChartColumn, GenericChartTableColumnConfig, GenericChartTableConfig} from "../../types";
     import TableView, {Field} from "../plots/table/Table.vue";
-    import {findPath} from "../plots/utils";
 
     interface Props {
         filteredData: any[],
@@ -77,12 +70,16 @@
                 return this.tableConfig.columns.filter(column => column.data.hierarchyColumn);
             },
             hierarchyColumnPaths() {
-                console.log("Started hierarchyColumnsToPaths: " + new Date().toISOString())
+               // Generate a dictionary of dictionaries allowing hierarchy label lookup for all  hierarchy columns (i.e. area)
+               // to save the hierarchy string for each option. This traverses the entire hierarchy once only, which is
+               // quicker than calling findPath on each row value.
                const addPathsToDict = (option: NestedFilterOption, parentPath: string,  dict: Dict<string>) => {
+                   //Add the path for this item...
                    dict[option.id] = parentPath;
+                   //...then adds paths for any children
                    const path = parentPath + (parentPath.length ? "/" : "") + option.label;
                    if (option.children) {
-                       option.children.forEach((child: any) => addPathsToDict(child as any, path, dict));
+                       option.children.forEach((child) => addPathsToDict(child as NestedFilterOption, path, dict));
                    }
                };
 
@@ -94,52 +91,55 @@
                    addPathsToDict(column.values as any, "", pathsDict);
                    result[columnId] = pathsDict;
                });
-                console.log("Finished hierarchyColumnsToPaths: " + new Date().toISOString())
                return result;
             },
             labelledData() {
-                console.log("Starting labelledData: " + new Date().toISOString())
                 // Build a dictionary of the columns defined in the fetched dataset, which include all values and
                 // associated labels
                 const columnsDict = this.columns.reduce((dict, column) => ({...dict, [column.id]: column}), {} as Dict<GenericChartColumn>);
 
-                //This above gives a dict of column ids to metadata columns, with all metadata
-                // We actually want to key filter option labels by id
-                // Map each column's filter options to a dictionary of id to label
-                const columnValueLabels = Object.keys(columnsDict).reduce((dict, key) => {
-                    const filterOptions = columnsDict[key].values;
-                    const labelDict = filterOptions.reduce ? filterOptions.reduce((dict, o) => ({...dict, [o.id]: o.label}), {} as Dict<string>) : {};
-                    return {
-                        ...dict,
-                        [key]: labelDict
+                // Convert each label column's filter options to a dictionary of id to labels so we do not need to find values'
+                // labels in the options array per row
+                const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
+                const columnValueLabels = configLabelColumns.reduce((dict, columnConfig) => {
+                    const key = columnConfig.data.labelColumn!;
+                    // If key is not already in dictionary, and options are an array (not the case for hierarchies)
+                    if (!dict[key] && columnsDict[key].values.reduce) {
+                        const filterOptions = columnsDict[key].values;
+                        const labelDict = filterOptions.reduce((dict, option) => ({
+                            ...dict,
+                            [option.id]: option.label
+                        }), {} as Dict<string>);
+
+                        return {
+                            ...dict,
+                            [key]: labelDict
+                        }
+                    } else {
+                        return dict;
                     }
                 }, {} as Dict<Dict<string>>);
-                console.log("Finished making value labels dict: " + new Date().toISOString())
 
-                const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
                 const result = this.filteredData.map(row => {
                     const friendlyRow = {...row};
                     // Check the table configuration for each configured column, and replace data values
                     // with friendly values (labels) taken from columnValueLabels where configured to do so - i.e.
                     // when there is a 'labelColumn' value
                     configLabelColumns.forEach(columnConfig => {
-                        //const column = columnsDict[columnConfig.data.labelColumn!];
-                        //const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
-                        const rowValue = row[columnConfig.data.columnId];
-                        const friendlyValue = columnValueLabels[columnConfig.data.labelColumn!][rowValue];
-                        friendlyRow[columnConfig.data.columnId] = friendlyValue;
+                        const columnId = columnConfig.data.columnId;
+                        const rowValue = row[columnId];
+                        friendlyRow[columnId] = columnValueLabels[columnConfig.data.labelColumn!][rowValue];
                     });
+
                     // Include additional fields for any columns configured to include hierarchy values - use the
                     // configured column's data column id, suffixed with '_hierarchy' as the field id
                     this.columnsWithHierarchy.forEach((columnConfig) => {
                         const hierarchyColumn = columnsDict[columnConfig.data.hierarchyColumn!];
                         const value = row[hierarchyColumn.column_id];
-                        const hierarchy = findPath(value, hierarchyColumn.values);
-                        friendlyRow[`${columnConfig.data.columnId}_hierarchy`] = hierarchy;
+                        friendlyRow[`${columnConfig.data.columnId}_hierarchy`] = this.hierarchyColumnPaths[hierarchyColumn.id][value];
                     });
                     return friendlyRow;
                 });
-                console.log("Finished labelledData: " + new Date().toISOString())
                 return result;
             }
         },

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -1,4 +1,6 @@
 <template>
+    <div>
+    <div>{{hierarchyColumnPaths}}</div>
     <table-view :fields="generatedFields" :filtered-data="labelledData">
         <template v-for="column in columnsWithHierarchy" v-slot:[`cell(${column.data.columnId})`]="data">
             <div :key="column.data.columnId">
@@ -7,11 +9,12 @@
             </div>
         </template>
     </table-view>
+    </div>
 </template>
 
 <script lang="ts">
     import Vue from "vue";
-    import {FilterOption} from "../../generated";
+    import {FilterOption, NestedFilterOption} from "../../generated";
     import {
         Dict, GenericChartColumn, GenericChartTableColumnConfig,
         GenericChartTableConfig
@@ -29,7 +32,8 @@
     interface Computed {
         generatedFields: Field[],
         labelledData: any[],
-        columnsWithHierarchy: GenericChartTableColumnConfig[]
+        columnsWithHierarchy: GenericChartTableColumnConfig[],
+        hierarchyColumnPaths: Dict<Dict<string>>
     }
 
     const props = {
@@ -72,18 +76,57 @@
             columnsWithHierarchy() {
                 return this.tableConfig.columns.filter(column => column.data.hierarchyColumn);
             },
+            hierarchyColumnPaths() {
+                console.log("Started hierarchyColumnsToPaths: " + new Date().toISOString())
+               const addPathsToDict = (option: NestedFilterOption, parentPath: string,  dict: Dict<string>) => {
+                   dict[option.id] = parentPath;
+                   const path = parentPath + (parentPath.length ? "/" : "") + option.label;
+                   if (option.children) {
+                       option.children.forEach((child: any) => addPathsToDict(child as any, path, dict));
+                   }
+               };
+
+               const result = {} as Dict<Dict<string>>;
+               this.columnsWithHierarchy.forEach((columnConfig) => {
+                   const columnId = columnConfig.data.hierarchyColumn!;
+                   const pathsDict = {};
+                   const column = this.columns.find((column) => column.id == columnId)!;
+                   addPathsToDict(column.values as any, "", pathsDict);
+                   result[columnId] = pathsDict;
+               });
+                console.log("Finished hierarchyColumnsToPaths: " + new Date().toISOString())
+               return result;
+            },
             labelledData() {
+                console.log("Starting labelledData: " + new Date().toISOString())
                 // Build a dictionary of the columns defined in the fetched dataset, which include all values and
                 // associated labels
                 const columnsDict = this.columns.reduce((dict, column) => ({...dict, [column.id]: column}), {} as Dict<GenericChartColumn>);
-                return this.filteredData.map(row => {
+
+                //This above gives a dict of column ids to metadata columns, with all metadata
+                // We actually want to key filter option labels by id
+                // Map each column's filter options to a dictionary of id to label
+                const columnValueLabels = Object.keys(columnsDict).reduce((dict, key) => {
+                    const filterOptions = columnsDict[key].values;
+                    const labelDict = filterOptions.reduce ? filterOptions.reduce((dict, o) => ({...dict, [o.id]: o.label}), {} as Dict<string>) : {};
+                    return {
+                        ...dict,
+                        [key]: labelDict
+                    }
+                }, {} as Dict<Dict<string>>);
+                console.log("Finished making value labels dict: " + new Date().toISOString())
+
+                const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
+                const result = this.filteredData.map(row => {
                     const friendlyRow = {...row};
                     // Check the table configuration for each configured column, and replace data values
-                    // with friendly values (labels) taken from the columnsDict where configured to do so - i.e.
+                    // with friendly values (labels) taken from columnValueLabels where configured to do so - i.e.
                     // when there is a 'labelColumn' value
-                    this.tableConfig.columns.filter(column => column.data.labelColumn).forEach(columnConfig => {
-                        const column = columnsDict[columnConfig.data.labelColumn!];
-                        const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
+                    configLabelColumns.forEach(columnConfig => {
+                        //const column = columnsDict[columnConfig.data.labelColumn!];
+                        //const friendlyValue = column.values.find(value => value.id == row[columnConfig.data.columnId])?.label;
+                        const rowValue = row[columnConfig.data.columnId];
+                        const friendlyValue = columnValueLabels[columnConfig.data.labelColumn!][rowValue];
                         friendlyRow[columnConfig.data.columnId] = friendlyValue;
                     });
                     // Include additional fields for any columns configured to include hierarchy values - use the
@@ -96,6 +139,8 @@
                     });
                     return friendlyRow;
                 });
+                console.log("Finished labelledData: " + new Date().toISOString())
+                return result;
             }
         },
         components: {

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -88,7 +88,9 @@
                    const columnId = columnConfig.data.hierarchyColumn!;
                    const pathsDict = {};
                    const column = this.columns.find((column) => column.id == columnId)!;
-                   addPathsToDict(column.values as any, "", pathsDict);
+                   // Deal with both array or object as top-level values type
+                   const values = Array.isArray(column.values) ? column.values : [column.values];
+                   values.forEach((value) => addPathsToDict(value, "", pathsDict));
                    result[columnId] = pathsDict;
                });
                return result;

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -105,7 +105,7 @@
                 const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
                 const columnValueLabels = configLabelColumns.reduce((dict, columnConfig) => {
                     const key = columnConfig.data.labelColumn!;
-                    // If key is not already in dictionary, and options are an array (not the case for hierarchies)
+                    // If key is not already in dictionary, and options are an array (not always the case for hierarchies)
                     if (!dict[key] && columnsDict[key].values.reduce) {
                         const filterOptions = columnsDict[key].values;
                         const labelDict = filterOptions.reduce((dict, option) => ({

--- a/src/app/static/src/app/components/genericChart/GenericChartTable.vue
+++ b/src/app/static/src/app/components/genericChart/GenericChartTable.vue
@@ -96,6 +96,7 @@
                return result;
             },
             labelledData() {
+                console.log("started labelled data:" +  new Date().toISOString())
                 // Build a dictionary of the columns defined in the fetched dataset, which include all values and
                 // associated labels
                 const columnsDict = this.columns.reduce((dict, column) => ({...dict, [column.id]: column}), {} as Dict<GenericChartColumn>);
@@ -103,24 +104,20 @@
                 // Convert each label column's filter options to a dictionary of id to labels so we do not need to find values'
                 // labels in the options array per row
                 const configLabelColumns = this.tableConfig.columns.filter(column => column.data.labelColumn);
-                const columnValueLabels = configLabelColumns.reduce((dict, columnConfig) => {
+                const reduceConfigLabelColumnsOptionsToDict = (dict: Dict<Dict<string>>, columnConfig: GenericChartTableColumnConfig) => {
                     const key = columnConfig.data.labelColumn!;
                     // If key is not already in dictionary, and options are an array (not always the case for hierarchies)
                     if (!dict[key] && columnsDict[key].values.reduce) {
                         const filterOptions = columnsDict[key].values;
-                        const labelDict = filterOptions.reduce((dict, option) => ({
-                            ...dict,
-                            [option.id]: option.label
-                        }), {} as Dict<string>);
-
-                        return {
-                            ...dict,
-                            [key]: labelDict
-                        }
-                    } else {
-                        return dict;
+                        const labelDict = filterOptions.reduce((innerDict, option) => {
+                            innerDict[option.id] = option.label;
+                            return innerDict;
+                        }, {} as Dict<string>);
+                        dict[key] = labelDict;
                     }
-                }, {} as Dict<Dict<string>>);
+                    return dict;
+                };
+                const columnValueLabels = configLabelColumns.reduce(reduceConfigLabelColumnsOptionsToDict, {} as Dict<Dict<string>>);
 
                 const result = this.filteredData.map(row => {
                     const friendlyRow = {...row};
@@ -142,6 +139,7 @@
                     });
                     return friendlyRow;
                 });
+                console.log("finished labelled data:" +  new Date().toISOString())
                 return result;
             }
         },

--- a/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
@@ -110,8 +110,8 @@ describe("GenericChartTable component", () => {
         const wrapper = getWrapper();
         const table = wrapper.find(Table);
         const expectedData = [
-            {area_name: "Malawi", area_level_id: "Country", age_group: "0-15", plot_type: "prevalence", value: 200},
-            {area_name: "Chitipa", area_level_id: "Region", age_group: "15-49", plot_type: "prevalence", value: 100}
+            {area_name: "Malawi", area_level_id: "Country", age_group: "0-15", value: 200},
+            {area_name: "Chitipa", area_level_id: "Region", age_group: "15-49", value: 100}
         ];
         expect(table.props("filteredData")).toStrictEqual(expectedData);
     });
@@ -146,8 +146,8 @@ describe("GenericChartTable component", () => {
         const wrapper = shallowMount(GenericChartTable, {propsData});
         const table = wrapper.find(Table);
         const expectedData = [
-            {area_name: "Malawi", area_level_id: "Country", area_level_id_2: "Region", age_group: "0-15", plot_type: "prevalence", value: 200},
-            {area_name: "Chitipa", area_level_id: "Region", area_level_id_2: "Country", age_group: "15-49", plot_type: "prevalence", value: 100}
+            {area_name: "Malawi", area_level_id: "Country", area_level_id_2: "Region", age_group: "0-15", value: 200},
+            {area_name: "Chitipa", area_level_id: "Region", area_level_id_2: "Country", age_group: "15-49", value: 100}
         ];
         expect(table.props("filteredData")).toStrictEqual(expectedData);
     });
@@ -162,6 +162,15 @@ describe("GenericChartTable component", () => {
                 "header": {
                     "type": "columnLabel",
                     "column": "area_name"
+                }
+            },
+            {
+                "data": {
+                    "columnId": "value"
+                },
+                "header": {
+                    "type": "columnLabel",
+                    "column": "value"
                 }
             }
         ]
@@ -192,6 +201,11 @@ describe("GenericChartTable component", () => {
                     ]
                 }
             ]
+        },
+        {
+            id: "value",
+            label: "value",
+            column_id: "value"
         }
     ];
 
@@ -214,14 +228,15 @@ describe("GenericChartTable component", () => {
 
         const table = wrapper.find(Table);
         const expectedData = [
-            {area_name: "Malawi", area_id: "MWI", value: 200, area_name_hierarchy: ""},
-            {area_name: "Chitipa", area_id: "MWI_1_2", value: 100, area_name_hierarchy: "Malawi/Northern"},
-            {area_name: "Southern", area_id: "MWI_2", value: 150, area_name_hierarchy: "Malawi"}
+            {area_name: "Malawi", value: 200, area_name_hierarchy: ""},
+            {area_name: "Chitipa", value: 100, area_name_hierarchy: "Malawi/Northern"},
+            {area_name: "Southern", value: 150, area_name_hierarchy: "Malawi"}
         ];
         expect(table.props("filteredData")).toStrictEqual(expectedData);
 
         const expectedFields = [
-            {key: "area_name", label: "area_name", sortable: true, sortByFormatted: true}
+            {key: "area_name", label: "area_name", sortable: true, sortByFormatted: true},
+            {key: "value", label: "value", sortable: true, sortByFormatted: true}
         ];
         expect(table.props("fields")).toStrictEqual(expectedFields);
     });

--- a/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChartTable.test.ts
@@ -116,6 +116,42 @@ describe("GenericChartTable component", () => {
         expect(table.props("filteredData")).toStrictEqual(expectedData);
     });
 
+    it("renders table component with expected labelled data when labelColumn is re-used", () => {
+        const tableConfigWithTwoAreaIdColumns = {
+            columns: [
+                ...tableConfig.columns,
+                {
+                    "data": {
+                        "columnId": "area_level_id_2",
+                        "labelColumn": "area_level"
+                    },
+                    "header": {
+                        "type": "columnLabel",
+                        "column": "area_level"
+                    }
+                }
+            ]
+        };
+        const filteredDataWithTwoAreaIdColumns = [
+            {...filteredData[0], area_level_id_2: 1},
+            {...filteredData[1], area_level_id_2: 0}
+        ];
+
+        const propsData = {
+            tableConfig: tableConfigWithTwoAreaIdColumns,
+            filteredData: filteredDataWithTwoAreaIdColumns,
+            columns,
+            selectedFilterOptions
+        };
+        const wrapper = shallowMount(GenericChartTable, {propsData});
+        const table = wrapper.find(Table);
+        const expectedData = [
+            {area_name: "Malawi", area_level_id: "Country", area_level_id_2: "Region", age_group: "0-15", plot_type: "prevalence", value: 200},
+            {area_name: "Chitipa", area_level_id: "Region", area_level_id_2: "Country", age_group: "15-49", plot_type: "prevalence", value: 100}
+        ];
+        expect(table.props("filteredData")).toStrictEqual(expectedData);
+    });
+
     const tableConfigWithHierarchy = {
         "columns": [
             {


### PR DESCRIPTION
## Description

This makes two changes to improve performance:

- the biggest difference comes from not using `findPath` to get the area hierarchy string per row (which means traversing the hierarchy for every row). Instead, a new computed property saves a dictionary of column value ids to hierarchy strings for each 'hierarchy column' which is configured (in practice, we only have one, the area hierarchy). This is done at the level of the dataset, so does not need to be recalculated when filters change, but does when changing ART to ANC. This computed property is quick to calculate, ~5ms for me.
- uses a dictionary of ids to labels for each column which is configured to display labels, rather than having to find labels in the column metadata per row

Together, these have reduced the time taken for the labelledData method for DRC data at district level from ~1500ms to ~160ms.

Any ideas for additional improvements? We could potentially keep some of these intermediary lookup data structures in the state, to save components having to recreate them every time they are re-rendered or have their selected data change. But that feels like it could be part of a more general refactor of data to improve efficiency in the whole app. (We should schedule a discussion of our 2022 wishlist in the new year, to include that sort of thing.)

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
