### PR TITLE
mrc-2831 Bug fix in Input Time Series - some lines shown incorrectly in red

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.80.1
+
+* Fix Input Time Series bug where some lines were shown incorrectly in red
+
 # hint 1.80.0
 
 * Add data exploration header

--- a/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
+++ b/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
@@ -4,6 +4,7 @@ $areaNames := $keys($dataByArea);
 
 $lineColor := "rgb(51, 51, 51)";
 $highlightColor := "rgb(255, 51, 51)";
+$colorscale := [[0, $lineColor], [0, $highlightColor]];
 $subplotHeight := 1/subplots.rows * 0.6;
 $timePeriods := $sort(data.time_period);
 $firstXAxisVal := $timePeriods[0];
@@ -13,6 +14,31 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
     "data":
         $map($areaNames, function($v, $i) {(
             $areaData := $lookup($dataByArea, $v);
+
+            /* Check if each successive line should be highlighted - if the difference between a value and its preceding
+             value exceeds the threshold. Generate an array of 1s and 0s to indicate highlight or not*/
+            $highlightedLines := $map($areaData.value[-1], function($thv, $thi) {
+                 ($thv != null)
+                 and
+                 (
+                     ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv > (1.25 * ($areaData.value)[$thi-1]))
+                     or
+                     ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv < (0.75 * ($areaData.value)[$thi-1]))
+                 )
+                 ? 1 : 0
+            });
+
+             /* Generate another array for highlighted markers - check each pair of lines, and if either is
+              highlighted then the marker should be too */
+            $highlighedMarkers := $map( [0..$count($highlightedLines)], function($thi) {
+                 (($thi = 0 and $highlightedLines[0] = 1)
+                 or
+                 ($thi = $count($highlightedLines) and $highlightedLines[$thi-1] = 1)
+                 or
+                 ($thi > 0 and $thi < $count($highlightedLines) and $highlightedLines[$thi-1] = 1 or $highlightedLines[$thi] = 1))
+                 ? 1 : 0
+            });
+
             [
                 {
                     "name": $v,
@@ -23,32 +49,12 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
                     "yaxis": 'y' & ($i+1),
                     "type": "scatter",
                     "line": {
-                        "color": $lineColor
-                    }
-                },
-                {
-                    "name": $v,
-                    "showlegend": false,
-                    "x": $areaData.time_period,
-                    "y": $map($areaData.value, function($thv, $thi) {
-                         ($thv != null)
-                         and
-                         (
-                             ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv > (1.25 * ($areaData.value)[$thi-1]))
-                             or
-                             ((($areaData.value)[$thi+1] != null) and ($thi < $count($areaData.value)-1) and (($areaData.value)[$thi+1] > (1.25 * $thv)))
-                             or
-                             ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv < (0.75 * ($areaData.value)[$thi-1]))
-                             or
-                             ((($areaData.value)[$thi+1] != null) and ($thi < $count($areaData.value)-1) and ($areaData.value)[$thi+1] < (0.75 * $thv))
-                         )
-                         ? $thv : null
-                     }),
-                    "xaxis": 'x' & ($i+1),
-                    "yaxis": 'y' & ($i+1),
-                    "type": "scatter",
-                    "line": {
-                        "color": $highlightColor
+                        "color": $highlightedLines,
+                        "colorscale": $colorscale
+                    },
+                    "marker": {
+                        "color": $highlightedMarkers,
+                        "colorscale": $colorscale
                     }
                 }
             ]

--- a/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
+++ b/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
@@ -17,9 +17,9 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
 
             /* Check if each successive line should be highlighted - if the difference between a value and its preceding
                value exceeds the threshold, and return this as array of boolean */
-            $highlightedLineIndexes := $map([1..$count($values[-1])], function($thv, $thi) {(
-                 $thisVal := $values[$thi];
-                 $prevVal := $values[$thi-1];
+            $highlightedLineIndexes := $map([1..$count($values)-1], function($thv) {(
+                 $thisVal := $values[$thv];
+                 $prevVal := $values[$thv-1];
 
                  $thisVal != null and $prevVal != null and $thisVal > 0
                  and
@@ -30,11 +30,11 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
             $highlightXAndY := $noHighlightsRequired ? [[],[]] : (
                 /* Check if there are any single-value gaps between highlighted indexes - if so, we need to interpolate
                 nulls into the data to force a line break so the line between is not highlighted*/
-                $interpolateIndexes := $map([0..$count($highlightedLineIndexes)-2], function($v, $i){
-                    $i > 0 and
-                    $highlightedLineIndexes[$i-1] and $not($v) and $highlightedLineIndexes[$i+1]
+                $interpolateIndexes := $map([0..$count($highlightedLineIndexes)-2], function($v){
+                    $v > 0 and
+                    $highlightedLineIndexes[$v-1] and $not($highlightedLineIndexes[$v]) and $highlightedLineIndexes[$v+1]
                 });
-                $interpolationRequired := $count($filter($interpolationIndexes, function($v, $i) {$v})) > 0;
+                $interpolationRequired := $count($filter($interpolateIndexes, function($v, $i) {$v}) ) > 0;
 
                 $highlightY := $map([0..$count($values)-1], function($v){(
                    /* Calculate if this marker should be highlighted, if so add value to highlighted y markers, if not add null*/
@@ -42,22 +42,23 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
                          or
                         ($v = $count($highlightedLineIndexes) and $highlightedLineIndexes[$v-1])
                         or
-                        ($v > 0 and $v < $count($highlightedLineIndexes) and $highlightedLineIndexes[$v-1] or $highlightedLineInexes[$v])
+                        ($v > 0 and $v < $count($highlightedLineIndexes) and ($highlightedLineIndexes[$v-1] or $highlightedLineIndexes[$v]))
                         ? $values[$v] : null;
 
-                    $interpolateIndexes[$v] ? [$markerVal, null] : $markerVal
+                    $interpolateIndexes[$v] ? [$markerVal, null] : [$markerVal]
 
-                )});
-                $highlightX := $not($interpolationRequired) ? $areaData.time_period : [0..$count($values)-1].(
-                    $interpolateIndexes[$] ? [$area_time_period[$], null] : $area_time_period[$];
-                );
+                )}).*;
+
+                $timePeriods := $areaData.time_period;
+                $highlightX := $not($interpolationRequired) ? $timePeriods : $map([0..$count($values)-1], function($v){(
+                    $interpolateIndexes[$v] ? [$timePeriods[$v], null] : [$timePeriods[$v]];
+                )}).*;
 
                 [[$highlightX], [$highlightY]]
              );
 
             [
-                {"test": $highlightedLineIndexes},
-                {
+               {
                     "name": $v,
                     "showlegend": false,
                     "x": $areaData.time_period,

--- a/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
+++ b/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
@@ -4,7 +4,6 @@ $areaNames := $keys($dataByArea);
 
 $lineColor := "rgb(51, 51, 51)";
 $highlightColor := "rgb(255, 51, 51)";
-$colorscale := [[0, $lineColor], [0, $highlightColor]];
 $subplotHeight := 1/subplots.rows * 0.6;
 $timePeriods := $sort(data.time_period);
 $firstXAxisVal := $timePeriods[0];
@@ -14,32 +13,50 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
     "data":
         $map($areaNames, function($v, $i) {(
             $areaData := $lookup($dataByArea, $v);
+            $values := $areaData.value;
 
             /* Check if each successive line should be highlighted - if the difference between a value and its preceding
-             value exceeds the threshold. Generate an array of 1s and 0s to indicate highlight or not*/
-            $highlightedLines := $map($areaData.value[-1], function($thv, $thi) {
-                 ($thv != null)
-                 and
-                 (
-                     ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv > (1.25 * ($areaData.value)[$thi-1]))
-                     or
-                     ((($areaData.value)[$thi-1] != null) and ($thi > 0) and $thv < (0.75 * ($areaData.value)[$thi-1]))
-                 )
-                 ? 1 : 0
-            });
+               value exceeds the threshold, and return this as array of boolean */
+            $highlightedLineIndexes := $map([1..$count($values[-1])], function($thv, $thi) {(
+                 $thisVal := $values[$thi];
+                 $prevVal := $values[$thi-1];
 
-             /* Generate another array for highlighted markers - check each pair of lines, and if either is
-              highlighted then the marker should be too */
-            $highlighedMarkers := $map( [0..$count($highlightedLines)], function($thi) {
-                 (($thi = 0 and $highlightedLines[0] = 1)
-                 or
-                 ($thi = $count($highlightedLines) and $highlightedLines[$thi-1] = 1)
-                 or
-                 ($thi > 0 and $thi < $count($highlightedLines) and $highlightedLines[$thi-1] = 1 or $highlightedLines[$thi] = 1))
-                 ? 1 : 0
-            });
+                 $thisVal != null and $prevVal != null and $thisVal > 0
+                 and
+                 ($thisVal > (1.25 * $prevVal) or $thisVal < (0.75 * $prevVal))
+            )});
+
+            $noHighlightsRequired := $count($filter($highlightedLineIndexes, function($v, $i) {$v}) ) = 0;
+            $highlightXAndY := $noHighlightsRequired ? [[],[]] : (
+                /* Check if there are any single-value gaps between highlighted indexes - if so, we need to interpolate
+                nulls into the data to force a line break so the line between is not highlighted*/
+                $interpolateIndexes := $map([0..$count($highlightedLineIndexes)-2], function($v, $i){
+                    $i > 0 and
+                    $highlightedLineIndexes[$i-1] and $not($v) and $highlightedLineIndexes[$i+1]
+                });
+                $interpolationRequired := $count($filter($interpolationIndexes, function($v, $i) {$v})) > 0;
+
+                $highlightY := $map([0..$count($values)-1], function($v){(
+                   /* Calculate if this marker should be highlighted, if so add value to highlighted y markers, if not add null*/
+                   $markerVal := ($v = 0 and $highlightedLineIndexes[0])
+                         or
+                        ($v = $count($highlightedLineIndexes) and $highlightedLineIndexes[$v-1])
+                        or
+                        ($v > 0 and $v < $count($highlightedLineIndexes) and $highlightedLineIndexes[$v-1] or $highlightedLineInexes[$v])
+                        ? $values[$v] : null;
+
+                    $interpolateIndexes[$v] ? [$markerVal, null] : $markerVal
+
+                )});
+                $highlightX := $not($interpolationRequired) ? $areaData.time_period : [0..$count($values)-1].(
+                    $interpolateIndexes[$] ? [$area_time_period[$], null] : $area_time_period[$];
+                );
+
+                [[$highlightX], [$highlightY]]
+             );
 
             [
+                {"test": $highlightedLineIndexes},
                 {
                     "name": $v,
                     "showlegend": false,
@@ -49,12 +66,19 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
                     "yaxis": 'y' & ($i+1),
                     "type": "scatter",
                     "line": {
-                        "color": $highlightedLines,
-                        "colorscale": $colorscale
-                    },
-                    "marker": {
-                        "color": $highlightedMarkers,
-                        "colorscale": $colorscale
+                        "color": $lineColor
+                    }
+                },
+                {
+                    "name": $v,
+                    "showlegend": false,
+                    "x": $highlightXAndY[0],
+                    "y": $highlightXAndY[1],
+                    "xaxis": 'x' & ($i+1),
+                    "yaxis": 'y' & ($i+1),
+                    "type": "scatter",
+                    "line": {
+                        "color": $highlightColor
                     }
                 }
             ]

--- a/src/app/static/src/app/components/genericChart/Plotly.vue
+++ b/src/app/static/src/app/components/genericChart/Plotly.vue
@@ -65,7 +65,6 @@
             },
             data() {
                 const j = jsonata(this.chartMetadata);
-                console.log(JSON.stringify(this.inputData))
                 const results = j.evaluate(this.inputData);
                 return results
             },
@@ -85,7 +84,6 @@
                         const el = this.$refs.chart;
                         const drawFunc = this.layoutRequired ? Plotly.newPlot : Plotly.react;
                         this.layoutRequired = false;
-                        //console.log(JSON.stringify(this.data))
                         drawFunc(el as HTMLElement, this.data.data as any, this.data.layout, this.data.config as any);
                     }
                     finally {

--- a/src/app/static/src/app/components/genericChart/Plotly.vue
+++ b/src/app/static/src/app/components/genericChart/Plotly.vue
@@ -65,6 +65,7 @@
             },
             data() {
                 const j = jsonata(this.chartMetadata);
+                console.log(JSON.stringify(this.inputData))
                 const results = j.evaluate(this.inputData);
                 return results
             },
@@ -84,7 +85,7 @@
                         const el = this.$refs.chart;
                         const drawFunc = this.layoutRequired ? Plotly.newPlot : Plotly.react;
                         this.layoutRequired = false;
-                        console.log(JSON.stringify(this.data))
+                        //console.log(JSON.stringify(this.data))
                         drawFunc(el as HTMLElement, this.data.data as any, this.data.layout, this.data.config as any);
                     }
                     finally {

--- a/src/app/static/src/app/components/genericChart/Plotly.vue
+++ b/src/app/static/src/app/components/genericChart/Plotly.vue
@@ -84,6 +84,7 @@
                         const el = this.$refs.chart;
                         const drawFunc = this.layoutRequired ? Plotly.newPlot : Plotly.react;
                         this.layoutRequired = false;
+                        console.log(JSON.stringify(this.data))
                         drawFunc(el as HTMLElement, this.data.data as any, this.data.layout, this.data.config as any);
                     }
                     finally {

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.80.0";
+export const currentHintVersion = "1.80.1";


### PR DESCRIPTION
## Description

e.g. for Mozambique data, at Distrito level. ART adult plot - for Chifunde (MOZ_2_0715), the section between 2018 Q4 and 2019 Q4 was shown in red, despite the two consective values being 1184 and 1191.
![WhatsApp Image 2021-12-08 at 2 03 54 PM](https://user-images.githubusercontent.com/44669576/145785995-547d7c26-994e-4a5a-8eac-e3771d343fee.jpeg)

This was happening for the specific situation where a single black line should have been drawn between two threshold violating lines. Because the two markers at either end of the should-be-black line were also involved in red lines, they were being added to the 'highlight series', and hence that line in between them was also coloured red. Since there is no way I know of to colour individual lines within a series in Plotly, the only way I could find to break the series and ensure that the incorrect highlighted lines were not drawn, is to interpolate null values in betweeen (in both x and y arrays). 

In order to accommodate this I did a general reformat of the refactoring code - this makes it appear more complex, but should be more efficient. Rather than calculating for each point whether it participates in highlight line in either direction, instead, for each subplot we:
- check if each line segment should be highlighted, generating $highlightedLines
- calculate if there are any points in the series which null interpolation must occur to fix this bug
- for each point in series, first check if it participates in a highlighted line, and if it does add it to the series..
- ..and also check if nulls must be interpolated, in which case do so for both x and y arrays. 

Checking time to evaluate on this branch vs master branch suggests that this has indeed cut the evaluation time - from ~720ms on average for full page of Mozambique data to ~315ms. 

This can be tested with the Mozambique data attached to the ticket. You can see that the expected subplots are now shown for Chifunde and Chinde:
![Screenshot from 2021-12-13 09-39-36](https://user-images.githubusercontent.com/44669576/145831549-d66671ff-462e-4e86-b2eb-d1a245d44e81.png)

One thing this this has brought into focus is the need for some automated tests of the jsonata. Since the jsonata is delivered from the backend but evaluated in the front end, it might makes sense to do this as a front end integration test, to fetch the jsonata and then test that it evluates to expected json with given test data. Ticket for this is here, I've added it into the sprint: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2760

## Type of version change
_Delete as appropriate_

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
