### PR TITLE
mrc-2852 Allow continue as guest to Data Exploration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.86.1
+
+* Allow Continue as guest in Data Exploration
+
 # hint 1.86.0
 
 * Persist Data Exploration state

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/LoginController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/LoginController.kt
@@ -42,6 +42,7 @@ class LoginController(private val request: HttpServletRequest,
         {
             appProperties.applicationTitle
         }
+        model["continueTo"] = redirectTo ?: "/"
         session.setRequestedUrl(redirectTo)
 
         return "login"

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/LoginControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/LoginControllerTests.kt
@@ -26,6 +26,7 @@ class LoginControllerTests
         Assertions.assertThat(model["title"]).isEqualTo("Login")
         Assertions.assertThat(model["username"]).isEqualTo("")
         Assertions.assertThat(model["error"]).isEqualTo("")
+        Assertions.assertThat(model["continueTo"]).isEqualTo("/")
     }
 
     @Test
@@ -95,6 +96,7 @@ class LoginControllerTests
 
         Assertions.assertThat(result).isEqualTo("login")
         Assertions.assertThat(model["appTitle"]).isEqualTo("Naomi Data Exploration")
+        Assertions.assertThat(model["continueTo"]).isEqualTo("explore")
         verify(mockSession).setRequestedUrl("explore")
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
@@ -76,6 +76,7 @@ class LoginTests
         model["error"] = ""
         model["title"] = "test title"
         model["appTitle"] = "Naomi"
+        model["continueTo"] = "/"
         val doc = template.jsoupDocFor(model)
 
         assertThat(doc.select("h1").count()).isEqualTo(1)

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/templates/LoginTests.kt
@@ -19,6 +19,7 @@ class LoginTests
         model["error"] = "test error"
         model["title"] = "test title"
         model["appTitle"] = "Naomi"
+        model["continueTo"] = "/"
         val doc = template.jsoupDocFor(model)
 
         assertThat(doc.select("form").attr("onsubmit")).isEqualTo("validate(event);")
@@ -54,6 +55,7 @@ class LoginTests
         model["error"] = ""
         model["title"] = "test title"
         model["appTitle"] = "Naomi"
+        model["continueTo"] = "/"
         val doc = template.jsoupDocFor(model)
 
         assertThat(doc.select("form label[for='user-id']").text()).isEqualTo("Username (email address)")
@@ -87,17 +89,19 @@ class LoginTests
     }
 
     @Test
-    fun `renders data exploration title`()
+    fun `renders correctly for data exploration`()
     {
         val model = ConcurrentModel()
         model["username"] = ""
         model["error"] = ""
         model["title"] = "test title"
         model["appTitle"] = "Naomi Data Exploration"
+        model["continueTo"] = "explore"
         val doc = template.jsoupDocFor(model)
 
         assertThat(doc.select("h1").count()).isEqualTo(1)
         assertThat(doc.select("h1").text()).isEqualTo("Naomi Data Exploration")
+        assertThat(doc.select("#continue-as-guest a").attr("href")).isEqualTo("explore")
     }
 
 }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
-export const currentHintVersion = "1.86.0";
+export const currentHintVersion = "1.86.1";
 

--- a/src/app/static/templates/login.ftl
+++ b/src/app/static/templates/login.ftl
@@ -55,7 +55,7 @@
     </div>
     <div id="continue-as-guest" class="text-center mt-3">
         <div class="mb-3">OR</div>
-        <a class="btn btn-red" onclick="continueAsGuest()" type="submit" href="/">Continue as guest</a>
+        <a class="btn btn-red" onclick="continueAsGuest()" type="submit" href="${continueTo}">Continue as guest</a>
     </div>
     <div id="partner-logos" class="logos mx-auto mt-5">
       <a href="https://www.fjelltopp.org"><img src="public/images/fjelltopp_logo.png" class="small-logo"></a>


### PR DESCRIPTION
## Description

This fixes bug where clicking 'Continue as guest' from "/explore" redirected the user to main Naomi app, not Data Exploration. 

Not sure how that happened - I thought this must have been working before, but not sure how? 

This fix updates the href for "Continue as guest" to use the `redirectTo` qs param if set.  

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
