### PR TITLE
mrc-2920 Remove Projects state from local storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.88.4
+
+* Remove Projects state from localStorage
+
 # hint 1.88.3
 Use area_id to define unique areas in Input Time Series
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.88.3";
+export const currentHintVersion = "1.88.4";

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -47,7 +47,6 @@ export const serialiseState = (state: DataExplorationState): Partial<RootState> 
                 result: null
             },
             stepper: rootState.stepper,
-            projects: rootState.projects,
             hintrVersion: state.hintrVersion,
             language: state.language
         };

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -108,7 +108,6 @@ describe("LocalStorageManager", () => {
             metadata: mockMetadataState(),
             plottingSelections: mockPlottingSelections(),
             surveyAndProgram: {selectedDataType: DataType.Survey},
-            projects: mockProjectsState(),
             hintrVersion: mockHintrVersionState(),
             language: Language.en
         });


### PR DESCRIPTION
## Description
This branch removes `projects` state from the state saved to localStorage. This state was actually unused anyway, as project list and current project are loaded from the backend. 

This should fix the bug Jeff has reported, where he is unable to use the application, and sees setItem quota exceeded messages logged to console on any operation e.g. load project. This is probably because, with many projects, the localStorage size grows over time.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/44669576/151852757-97a69de7-0e23-4d88-a53b-c26d198662f1.png)

When testing locally, I would also see 'Could not parse API error' when opening a project when local storage is exceeded. I think this is because, when that quota error is thrown in the course of _onSuccess in apiService, it gets thrown out to _handleError, and treated as if it is an AxiosError, and of course can't be parsed as a HINT Error.

To test:
- Run the master branch locally and add projects until you get quota exceeded errors logged to console. The easiest way to do this is to add very verbose notes to the projects (most project state is not saved locally for non-current project, but notes are) until the total storage size exceeds 5MB.  

- Observe that the app is unusable - projects cannot be loaded. 

- Checkout this branch, compile front end and reload app. 

- The application shoukld now be usable - should be able to load and run projects. Refreshing the page should retain the current state in the current project. No localStorage errors should be logged, 

- Similarly, current state should be retained when running as guest. 

## Type of version change
_Delete as appropriate_

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
