### PR TITLE
mrc-2921 Remove calibrate plot result from local storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.88.5
+
+* Remove Calibrate Plot Result from localStorage
+
 # hint 1.88.4
 
 * Remove Projects state from localStorage

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.88.4";
+export const currentHintVersion = "1.88.5";

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -44,7 +44,8 @@ export const serialiseState = (state: DataExplorationState): Partial<RootState> 
             modelOutput: rootState.modelOutput,
             modelCalibrate: {
                 ...rootState.modelCalibrate,
-                result: null
+                result: null,
+                calibratePlotResult: null
             },
             stepper: rootState.stepper,
             hintrVersion: state.hintrVersion,

--- a/src/app/static/src/tests/components/header/fileMenu.test.ts
+++ b/src/app/static/src/tests/components/header/fileMenu.test.ts
@@ -114,7 +114,7 @@ describe("File menu", () => {
             state: {
                 baseline: {selectedDataset: null, selectedRelease: null},
                 modelRun: mockModelRunState(),
-                modelCalibrate: {result: null},
+                modelCalibrate: {result: null, calibratePlotResult: null},
                 metadata: mockMetadataState(),
                 surveyAndProgram: {selectedDataType: null},
                 language: Language.en

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -82,7 +82,10 @@ describe("LocalStorageManager", () => {
             }),
             modelOptions: mockModelOptionsState(),
             modelOutput: mockModelOutputState(),
-            modelCalibrate: mockModelCalibrateState({result: mockCalibrateResultResponse()}),
+            modelCalibrate: mockModelCalibrateState({
+                result: mockCalibrateResultResponse(),
+                calibratePlotResult: {data: "test calibrate plot result"}
+            }),
             stepper: mockStepperState(),
             metadata: mockMetadataState({plottingMetadataError: mockError("metadataError")}),
             plottingSelections: mockPlottingSelections(),


### PR DESCRIPTION
## Description

Second attempt at slimming down saved state to local storage to prevent `setItem` quote exceeded error. Removes calibratePlotResult from state saved to local storage. No other changes appeared to be needed - plot result is re-fetched when project is reloaded. 

I'm struggling a bit to reproduce this bug in order to confirm that this will fix it (Jeff's issue was with full model run of latest Kenya data which I don't currently have access to). But it doesn't seem that this change should make things any worse at least!

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
