### PR TITLE
mrc-2903 Fix throttling of version state uploads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.89.1
+
+Fix throttling of version state uploads
+
 # hint 1.89.0
 
 * Persist Data Exploration step

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.89.0";
+export const currentHintVersion = "1.89.1";

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -82,7 +82,7 @@ const persistState = (store: Store<RootState>): void => {
         const {dispatch} = store;
         const type = stripNamespace(mutation.type);
         if (type[0] !== "projects" && type[0] !== "errors") {
-            dispatch("projects/uploadVersionState", {root: true});
+            dispatch("projects/queueVersionStateUpload", {root: true});
         }
     })
 };

--- a/src/app/static/src/app/store/projects/actions.ts
+++ b/src/app/static/src/app/store/projects/actions.ts
@@ -25,7 +25,7 @@ export interface ProjectsActions {
     createProject: (store: ActionContext<ProjectsState, RootState>, name: string) => void,
     getProjects: (store: ActionContext<ProjectsState, RootState>) => void
     getCurrentProject: (store: ActionContext<ProjectsState, RootState>) => void
-    uploadVersionState: (store: ActionContext<ProjectsState, RootState>) => void,
+    queueVersionStateUpload: (store: ActionContext<ProjectsState, RootState>) => void,
     newVersion: (store: ActionContext<ProjectsState, RootState>, note: string) => void,
     loadVersion: (store: ActionContext<ProjectsState, RootState>, version: VersionIds) => void
     deleteProject: (store: ActionContext<ProjectsState, RootState>, projectId: number) => void
@@ -113,18 +113,25 @@ export const actions: ActionTree<ProjectsState, RootState> & ProjectsActions = {
         }
     },
 
-    async uploadVersionState(context) {
+    async queueVersionStateUpload(context) {
         const {state, commit} = context;
         if (state.currentVersion) {
-            if (!state.versionUploadPending) {
-                commit({type: ProjectsMutations.SetVersionUploadPending, payload: true});
-                setTimeout(() => {
+            // remove any existing queued upload, as this request should supersede it
+            commit({type: ProjectsMutations.ClearQueuedVersionUpload});
+
+            const queuedId: number = window.setInterval(() => {
+                // wait for any ongoing uploads to finish before starting a new one
+                if (!state.versionUploadInProgress) {
+                    commit({type: ProjectsMutations.ClearQueuedVersionUpload});
                     immediateUploadVersionState(context);
-                }, 2000);
-            }
+                }
+            }, 2000);
+
+            // record the newly queued upload
+            commit({type: ProjectsMutations.SetQueuedVersionUpload, payload: queuedId});
         }
     },
-    
+
     async updateVersionNote(context, versionPayload: versionPayload) {
         const {dispatch} = context
         const {projectId, versionId} = versionPayload.version
@@ -145,7 +152,7 @@ export const actions: ActionTree<ProjectsState, RootState> & ProjectsActions = {
 
         const projectId = state.currentProject && state.currentProject.id;
         const versionId = state.currentVersion && state.currentVersion.id;
-        api<ProjectsMutations, ErrorsMutation>(context)
+        await api<ProjectsMutations, ErrorsMutation>(context)
             .withSuccess(ProjectsMutations.VersionCreated)
             .withError(`errors/${ErrorsMutation.ErrorAdded}` as ErrorsMutation, true)
             .postAndReturn(`project/${projectId}/version/?parent=${versionId}&note=${note}`)
@@ -243,14 +250,15 @@ export const actions: ActionTree<ProjectsState, RootState> & ProjectsActions = {
 };
 
 async function immediateUploadVersionState(context: ActionContext<ProjectsState, RootState>) {
-    const {state, commit, rootState} = context;
+    const {commit, state, rootState} = context;
     const projectId = state.currentProject && state.currentProject.id;
     const versionId = state.currentVersion && state.currentVersion.id;
     if (projectId && versionId) {
+        commit({type: ProjectsMutations.SetVersionUploadInProgress, payload: true});
         await api<ProjectsMutations, ErrorsMutation>(context)
             .withSuccess(ProjectsMutations.VersionUploadSuccess)
             .withError(`errors/${ErrorsMutation.ErrorAdded}` as ErrorsMutation, true)
             .postAndReturn(`/project/${projectId}/version/${versionId}/state/`, serialiseState(rootState));
-        commit({type: ProjectsMutations.SetVersionUploadPending, payload: false});
+        commit({type: ProjectsMutations.SetVersionUploadInProgress, payload: false});
     }
 }

--- a/src/app/static/src/app/store/projects/actions.ts
+++ b/src/app/static/src/app/store/projects/actions.ts
@@ -244,7 +244,6 @@ export const actions: ActionTree<ProjectsState, RootState> & ProjectsActions = {
 
 async function immediateUploadVersionState(context: ActionContext<ProjectsState, RootState>) {
     const {state, commit, rootState} = context;
-    commit({type: ProjectsMutations.SetVersionUploadPending, payload: false});
     const projectId = state.currentProject && state.currentProject.id;
     const versionId = state.currentVersion && state.currentVersion.id;
     if (projectId && versionId) {
@@ -252,5 +251,6 @@ async function immediateUploadVersionState(context: ActionContext<ProjectsState,
             .withSuccess(ProjectsMutations.VersionUploadSuccess)
             .withError(`errors/${ErrorsMutation.ErrorAdded}` as ErrorsMutation, true)
             .postAndReturn(`/project/${projectId}/version/${versionId}/state/`, serialiseState(rootState));
+        commit({type: ProjectsMutations.SetVersionUploadPending, payload: false});
     }
 }

--- a/src/app/static/src/app/store/projects/mutations.ts
+++ b/src/app/static/src/app/store/projects/mutations.ts
@@ -7,7 +7,9 @@ import {router} from "../../router";
 export enum ProjectsMutations {
     SetLoading = "SetLoading",
     SetPreviousProjects = "SetPreviousProjects",
-    SetVersionUploadPending = "SetVersionUploadPending",
+    SetQueuedVersionUpload = "SetQueuedVersionUpload",
+    ClearQueuedVersionUpload = "ClearQueuedVersionUpload",
+    SetVersionUploadInProgress = "SetVersionUploadInProgress",
     ProjectError = "ProjectError",
     VersionCreated = "VersionCreated",
     VersionUploadSuccess = "VersionUploadSuccess",
@@ -26,7 +28,7 @@ export const mutations: MutationTree<ProjectsState> = {
 
     [ProjectsMutations.CloningProject](state: ProjectsState, action: PayloadWithType<boolean | null>) {
         state.cloningProject = !!action.payload;
-        if (state.cloningProject){
+        if (state.cloningProject) {
             state.cloneProjectError = null;
         }
     },
@@ -39,8 +41,15 @@ export const mutations: MutationTree<ProjectsState> = {
         state.previousProjects = action.payload;
         state.loading = false;
     },
-    [ProjectsMutations.SetVersionUploadPending](state: ProjectsState, action: PayloadWithType<boolean>) {
-        state.versionUploadPending = action.payload;
+    [ProjectsMutations.SetQueuedVersionUpload](state: ProjectsState, action: PayloadWithType<number>) {
+        state.queuedVersionUploadIntervalId = action.payload;
+    },
+    [ProjectsMutations.ClearQueuedVersionUpload](state: ProjectsState) {
+        window.clearInterval(state.queuedVersionUploadIntervalId);
+        state.queuedVersionUploadIntervalId = -1;
+    },
+    [ProjectsMutations.SetVersionUploadInProgress](state: ProjectsState, action: PayloadWithType<boolean>) {
+        state.versionUploadInProgress = action.payload;
     },
     [ProjectsMutations.ProjectError](state: ProjectsState, action: PayloadWithType<Error>) {
         state.error = action.payload;
@@ -63,8 +72,7 @@ export const mutations: MutationTree<ProjectsState> = {
         state.currentVersion = action.payload.version;
         // The action which invokes this mutation, fetching current project, is only invoked for logged in users
         // so it is safe to redirect to /projects here if no current project
-        if ((state.currentProject == null) && (router.currentRoute.path == "/"))
-        {
+        if ((state.currentProject == null) && (router.currentRoute.path == "/")) {
             router.push('/projects');
         }
     }

--- a/src/app/static/src/app/store/projects/projects.ts
+++ b/src/app/static/src/app/store/projects/projects.ts
@@ -11,7 +11,8 @@ export interface ProjectsState {
     previousProjects: Project[],
     loading: boolean,
     error: Error | null,
-    versionUploadPending: boolean,
+    versionUploadInProgress: boolean,
+    queuedVersionUploadIntervalId: number;
     versionTime: Date | null,
     cloneProjectError: Error | null,
     cloningProject: boolean
@@ -24,7 +25,8 @@ export const initialProjectsState = (): ProjectsState => {
         previousProjects: [],
         loading: false,
         error: null,
-        versionUploadPending: false,
+        versionUploadInProgress: false,
+        queuedVersionUploadIntervalId: -1,
         versionTime: null,
         cloneProjectError: null,
         cloningProject: false

--- a/src/app/static/src/tests/integration/projects.itest.ts
+++ b/src/app/static/src/tests/integration/projects.itest.ts
@@ -56,15 +56,17 @@ describe("Projects actions", () => {
         state.currentProject = createdProject;
         state.currentVersion = createdProject.versions[0];
 
-        await actions.uploadVersionState({commit, rootState: emptyState(), state} as any);
+        await actions.queueVersionStateUpload({commit, rootState: emptyState(), state} as any);
         setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(5);
-            expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.SetVersionUploadPending);
-            expect(commit.mock.calls[2][0]["payload"]).toBe(true);
-            expect(commit.mock.calls[3][0]["type"]).toBe(ProjectsMutations.SetVersionUploadPending);
-            expect(commit.mock.calls[3][0]["payload"]).toBe(false);
-            expect(commit.mock.calls[4][0]["type"]).toBe(ProjectsMutations.VersionUploadSuccess);
-
+            expect(commit.mock.calls.length).toBe(8);
+            expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);
+            expect(commit.mock.calls[3][0]["type"]).toBe(ProjectsMutations.SetQueuedVersionUpload);
+            expect(commit.mock.calls[4][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);
+            expect(commit.mock.calls[5][0]["type"]).toBe(ProjectsMutations.SetVersionUploadInProgress);
+            expect(commit.mock.calls[5][0]["payload"]).toBe(true);
+            expect(commit.mock.calls[6][0]["type"]).toBe(ProjectsMutations.VersionUploadSuccess);
+            expect(commit.mock.calls[7][0]["type"]).toBe(ProjectsMutations.SetVersionUploadInProgress);
+            expect(commit.mock.calls[7][0]["payload"]).toBe(false);
             done();
         }, 2500);
     });
@@ -80,13 +82,15 @@ describe("Projects actions", () => {
 
         await actions.newVersion({commit, rootState: emptyState(), state} as any, "version note");
         setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(5);
-            expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.SetVersionUploadPending);
-            expect(commit.mock.calls[2][0]["payload"]).toBe(false);
+            expect(commit.mock.calls.length).toBe(6);
+            expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.SetVersionUploadInProgress);
+            expect(commit.mock.calls[2][0]["payload"]).toBe(true);
             expect(commit.mock.calls[3][0]["type"]).toBe(ProjectsMutations.VersionUploadSuccess);
-            expect(commit.mock.calls[4][0]["type"]).toBe(ProjectsMutations.VersionCreated);
+            expect(commit.mock.calls[4][0]["type"]).toBe(ProjectsMutations.SetVersionUploadInProgress);
+            expect(commit.mock.calls[4][0]["payload"]).toBe(false);
+            expect(commit.mock.calls[5][0]["type"]).toBe(ProjectsMutations.VersionCreated);
 
-            const newVersion = commit.mock.calls[4][0]["payload"];
+            const newVersion = commit.mock.calls[5][0]["payload"];
             expect(newVersion.id).toBeTruthy();
             expect(newVersion.id).not.toEqual(createdProject.versions[0].id);
 
@@ -103,7 +107,7 @@ describe("Projects actions", () => {
         state.currentProject = createdProject;
         state.currentVersion = createdProject.versions[0];
 
-        await actions.uploadVersionState({commit, rootState: emptyState(), state} as any);
+        await actions.queueVersionStateUpload({commit, rootState: emptyState(), state} as any);
 
         const dispatch = jest.fn();
         const projectId = createdProject.id;

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -267,7 +267,7 @@ describe("Projects actions", () => {
         const state = mockProjectsState({
             currentProject: mockProject,
             currentVersion: mockProject.versions[0],
-            versionUploadInProgress: false
+            versionUploadInProgress: true
         });
 
         const url = "/project/1/version/version-id/state/";
@@ -285,8 +285,14 @@ describe("Projects actions", () => {
         expect(commit.mock.calls[0][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);
         expect(commit.mock.calls[1][0]["type"]).toBe(ProjectsMutations.SetQueuedVersionUpload);
 
+        // will not yet have run because versionUploadInProgress is true
+        jest.advanceTimersByTime(2001);
+        expect(commit.mock.calls.length).toBe(2);
+
+        state.versionUploadInProgress = false;
         jest.advanceTimersByTime(2001);
 
+        // now should have run
         expect(commit.mock.calls.length).toBe(4);
         expect(mockAxios.history.post.length).toBe(1);
         expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -268,9 +268,9 @@ describe("Projects actions", () => {
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[1][0]).toStrictEqual(
+            expect(commit.mock.calls[1][0].type).toStrictEqual(ProjectsMutations.VersionUploadSuccess);
+            expect(commit.mock.calls[2][0]).toStrictEqual(
                 {type: ProjectsMutations.SetVersionUploadPending, payload: false});
-            expect(commit.mock.calls[2][0].type).toStrictEqual(ProjectsMutations.VersionUploadSuccess);
 
             expect(mockAxios.history.post.length).toBe(1);
             expect(mockAxios.history.post[0].url).toBe(url);
@@ -280,7 +280,7 @@ describe("Projects actions", () => {
         }, 2500);
     });
 
-    it("uploadVersionState commits ErrorAdded on error response", async (done) => {
+    it("uploadVersionState commits ErrorAdded on error response and unsets version pending", async (done) => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
@@ -296,9 +296,10 @@ describe("Projects actions", () => {
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[2][0].type).toStrictEqual(`errors/${ErrorsMutation.ErrorAdded}`);
-            expect(commit.mock.calls[2][0].payload.detail).toStrictEqual("TEST ERROR");
-
+            expect(commit.mock.calls[1][0].type).toStrictEqual(`errors/${ErrorsMutation.ErrorAdded}`);
+            expect(commit.mock.calls[1][0].payload.detail).toStrictEqual("TEST ERROR");
+            expect(commit.mock.calls[2][0]).toStrictEqual(
+                {type: ProjectsMutations.SetVersionUploadPending, payload: false});
             done();
         }, 2500);
     });
@@ -330,12 +331,11 @@ describe("Projects actions", () => {
             expect(mockAxios.history.post[1].url).toBe(url);
 
             expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[0][0].type).toBe(ProjectsMutations.SetVersionUploadPending);
-            expect(commit.mock.calls[0][0].payload).toBe(false);
-            expect(commit.mock.calls[1][0].type).toBe(ProjectsMutations.VersionUploadSuccess);
+            expect(commit.mock.calls[0][0].type).toBe(ProjectsMutations.VersionUploadSuccess);
+            expect(commit.mock.calls[1][0].type).toBe(ProjectsMutations.SetVersionUploadPending);
+            expect(commit.mock.calls[1][0].payload).toBe(false);
             expect(commit.mock.calls[2][0].type).toBe(ProjectsMutations.VersionCreated);
             expect(commit.mock.calls[2][0].payload).toStrictEqual(newVersion);
-
             done();
         });
     });

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -17,6 +17,7 @@ describe("Projects actions", () => {
     afterEach(() => {
         (console.log as jest.Mock).mockClear();
         (console.info as jest.Mock).mockClear();
+        jest.useRealTimers();
     });
 
     const rootState = mockRootState();
@@ -136,7 +137,7 @@ describe("Projects actions", () => {
         });
     });
 
-    it("gets current project and commits mutation on successful response", async(done) => {
+    it("gets current project and commits mutation on successful response", async (done) => {
         const testProjects = [{id: 1, name: "v1", versions: []}];
         mockAxios.onGet("/project/current")
             .reply(200, mockSuccess(testProjects));
@@ -149,7 +150,10 @@ describe("Projects actions", () => {
 
         setTimeout(() => {
             expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetCurrentProject, payload: testProjects});
+            expect(commit.mock.calls[1][0]).toStrictEqual({
+                type: ProjectsMutations.SetCurrentProject,
+                payload: testProjects
+            });
             expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
             done();
         });
@@ -165,7 +169,7 @@ describe("Projects actions", () => {
         const state = mockProjectsState({
             currentProject: mockProject,
             currentVersion: mockProject.versions[0],
-            versionUploadPending: true
+            versionUploadInProgress: true
         });
 
         actions.createProject({commit, state, rootState} as any, "newProject");
@@ -198,7 +202,7 @@ describe("Projects actions", () => {
         });
     });
 
-    it("gets current project and sets error on unsuccessful response", async(done) => {
+    it("gets current project and sets error on unsuccessful response", async (done) => {
         mockAxios.onGet("/project/current")
             .reply(500, mockFailure("TestError"));
 
@@ -220,11 +224,11 @@ describe("Projects actions", () => {
         });
     });
 
-    it("uploadVersionState does nothing if no current version", async (done) => {
+    it("queueVersionStateUpload does nothing if no current version", async (done) => {
         const commit = jest.fn();
         const state = mockProjectsState();
 
-        actions.uploadVersionState({commit, state, rootState} as any);
+        actions.queueVersionStateUpload({commit, state, rootState} as any);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(0);
@@ -233,78 +237,115 @@ describe("Projects actions", () => {
         }, 2500);
     });
 
-    it("uploadVersionState does nothing if no version upload is pending", async (done) => {
+    it("queued upload will not run while version upload is already in progress", async () => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
             currentVersion: mockProject.versions[0],
-            versionUploadPending: true
+            versionUploadInProgress: true
         });
 
-        actions.uploadVersionState({commit, state, rootState} as any);
+        jest.useFakeTimers();
+        jest.spyOn(window, "setInterval");
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(0);
-            expect(mockAxios.history.post.length).toBe(0);
-            done();
-        }, 2500);
+        actions.queueVersionStateUpload({commit, state, rootState} as any);
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(2001);
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]).toStrictEqual(
+            {type: ProjectsMutations.ClearQueuedVersionUpload});
+        expect(commit.mock.calls[1][0]["type"]).toBe(ProjectsMutations.SetQueuedVersionUpload);
+        expect(commit.mock.calls.length).toBe(2);
+        expect(mockAxios.history.post.length).toBe(0);
     });
 
-    it("uploadVersionState sets pending then unsets and uploads state, and commits VersionUploadSuccess", async (done) => {
+    it("queued upload will run if no version upload is in progress", (done) => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
             currentVersion: mockProject.versions[0],
-            versionUploadPending: false
+            versionUploadInProgress: false
         });
 
         const url = "/project/1/version/version-id/state/";
         mockAxios.onPost(url)
-            .reply(200, mockSuccess("ok"));
+            .reply(200, mockSuccess("OK"));
 
-        actions.uploadVersionState({commit, state, rootState} as any);
-        expect(commit.mock.calls[0][0]).toStrictEqual(
-            {type: ProjectsMutations.SetVersionUploadPending, payload: true});
+        jest.useFakeTimers();
+        jest.spyOn(window, "setInterval");
+
+        actions.queueVersionStateUpload({commit, state, rootState} as any);
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);
+        expect(commit.mock.calls[1][0]["type"]).toBe(ProjectsMutations.SetQueuedVersionUpload);
+
+        jest.advanceTimersByTime(2001);
+
+        expect(commit.mock.calls.length).toBe(4);
+        expect(mockAxios.history.post.length).toBe(1);
+        expect(commit.mock.calls[2][0]["type"]).toBe(ProjectsMutations.ClearQueuedVersionUpload);
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: true
+        });
+
+        jest.useRealTimers();
 
         setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[1][0].type).toStrictEqual(ProjectsMutations.VersionUploadSuccess);
-            expect(commit.mock.calls[2][0]).toStrictEqual(
-                {type: ProjectsMutations.SetVersionUploadPending, payload: false});
-
+            expect(commit.mock.calls.length).toBe(6);
+            expect(commit.mock.calls[4][0]).toStrictEqual({
+                type: ProjectsMutations.VersionUploadSuccess,
+                payload: "OK"
+            });
+            expect(commit.mock.calls[5][0]).toStrictEqual({
+                type: ProjectsMutations.SetVersionUploadInProgress,
+                payload: false
+            });
             expect(mockAxios.history.post.length).toBe(1);
             expect(mockAxios.history.post[0].url).toBe(url);
             const posted = mockAxios.history.post[0].data;
             expect(JSON.parse(posted)).toStrictEqual(serialiseState(rootState));
             done();
-        }, 2500);
+        })
     });
 
-    it("uploadVersionState commits ErrorAdded on error response and unsets version pending", async (done) => {
+    it("uploadVersionState commits ErrorAdded on error response and unsets in progress upload", async (done) => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
             currentVersion: mockProject.versions[0],
-            versionUploadPending: false
+            versionUploadInProgress: false
         });
 
         const url = "/project/1/version/version-id/state/";
         mockAxios.onPost(url)
-            .reply(500, mockFailure("TEST ERROR"));
+            .reply(500, mockFailure("ERR"));
 
-        actions.uploadVersionState({commit, state, rootState} as any);
+        jest.useFakeTimers();
+
+        actions.queueVersionStateUpload({commit, state, rootState} as any);
+
+        jest.advanceTimersByTime(2001);
+        jest.useRealTimers();
 
         setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[1][0].type).toStrictEqual(`errors/${ErrorsMutation.ErrorAdded}`);
-            expect(commit.mock.calls[1][0].payload.detail).toStrictEqual("TEST ERROR");
-            expect(commit.mock.calls[2][0]).toStrictEqual(
-                {type: ProjectsMutations.SetVersionUploadPending, payload: false});
+            expect(commit.mock.calls.length).toBe(6);
+            expect(commit.mock.calls[4][0]["type"]).toBe("errors/ErrorAdded");
+            expect(commit.mock.calls[5][0]).toStrictEqual({
+                type: ProjectsMutations.SetVersionUploadInProgress,
+                payload: false
+            });
             done();
-        }, 2500);
+        })
     });
 
-    it("newVersion uploads current version state then requests new version, commits VersionCreated", async (done) => {
+    it("newVersion uploads current version state then requests new version, commits VersionCreated", async () => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
@@ -320,27 +361,34 @@ describe("Projects actions", () => {
         mockAxios.onPost(url)
             .reply(200, mockSuccess(newVersion));
 
-        actions.newVersion({commit, state, rootState} as any, "newVersionNote");
-        setTimeout(() => {
-            expect(mockAxios.history.post.length).toBe(2);
+        await actions.newVersion({commit, state, rootState} as any, "newVersionNote");
 
-            expect(mockAxios.history.post[0].url).toBe(stateUrl);
-            const postedState = mockAxios.history.post[0].data;
-            expect(JSON.parse(postedState)).toStrictEqual(serialiseState(rootState));
+        expect(mockAxios.history.post.length).toBe(2);
 
-            expect(mockAxios.history.post[1].url).toBe(url);
+        expect(mockAxios.history.post[0].url).toBe(stateUrl);
+        const postedState = mockAxios.history.post[0].data;
+        expect(JSON.parse(postedState)).toStrictEqual(serialiseState(rootState));
 
-            expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[0][0].type).toBe(ProjectsMutations.VersionUploadSuccess);
-            expect(commit.mock.calls[1][0].type).toBe(ProjectsMutations.SetVersionUploadPending);
-            expect(commit.mock.calls[1][0].payload).toBe(false);
-            expect(commit.mock.calls[2][0].type).toBe(ProjectsMutations.VersionCreated);
-            expect(commit.mock.calls[2][0].payload).toStrictEqual(newVersion);
-            done();
+        expect(mockAxios.history.post[1].url).toBe(url);
+
+        expect(commit.mock.calls.length).toBe(4);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: true
         });
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.VersionUploadSuccess,
+            payload: "OK"
+        });
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: false
+        });
+        expect(commit.mock.calls[3][0].type).toBe(ProjectsMutations.VersionCreated);
+        expect(commit.mock.calls[3][0].payload).toStrictEqual(newVersion);
     });
 
-    it("newVersion adds error on error response", async (done) => {
+    it("newVersion adds error on error response", async () => {
         const commit = jest.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
@@ -355,17 +403,26 @@ describe("Projects actions", () => {
         mockAxios.onPost(url)
             .reply(500, mockFailure("TEST ERROR"));
 
-        actions.newVersion({commit, state, rootState} as any, "versionNote");
-        setTimeout(() => {
-            expect(mockAxios.history.post.length).toBe(2);
+        await actions.newVersion({commit, state, rootState} as any, "versionNote");
 
-            expect(commit.mock.calls.length).toBe(3);
-            expect(commit.mock.calls[2][0].type).toBe("errors/ErrorAdded");
-            expect(commit.mock.calls[2][0].payload.detail).toStrictEqual("TEST ERROR");
-            expect(commit.mock.calls[2][1]).toStrictEqual({root: true});
+        expect(mockAxios.history.post.length).toBe(2);
 
-            done();
+        expect(commit.mock.calls.length).toBe(4);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: true
         });
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.VersionUploadSuccess,
+            payload: "OK"
+        });
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: false
+        });
+        expect(commit.mock.calls[3][0].type).toBe("errors/ErrorAdded");
+        expect(commit.mock.calls[3][0].payload.detail).toStrictEqual("TEST ERROR");
+        expect(commit.mock.calls[3][1]).toStrictEqual({root: true});
     });
 
     it("loadVersion fetches version details and invokes load state action", async (done) => {

--- a/src/app/static/src/tests/projects/mutations.test.ts
+++ b/src/app/static/src/tests/projects/mutations.test.ts
@@ -70,16 +70,31 @@ describe("Projects mutations", () => {
         expect(state.loading).toBe(false);
     });
 
-    it("sets version upload pending", () => {
+    it("sets version upload in progress", () => {
         const state = mockProjectsState();
-        mutations[ProjectsMutations.SetVersionUploadPending](state, {payload: true});
-        expect(state.versionUploadPending).toBe(true);
+        mutations[ProjectsMutations.SetVersionUploadInProgress](state, {payload: true});
+        expect(state.versionUploadInProgress).toBe(true);
+    });
+
+    it("sets interval id of queued upload", () => {
+        const state = mockProjectsState();
+        mutations[ProjectsMutations.SetQueuedVersionUpload](state, {payload: 123});
+        expect(state.queuedVersionUploadIntervalId).toBe(123);
+    });
+
+    it("clears interval of queued upload", () => {
+        jest.useFakeTimers();
+        jest.spyOn(window, "clearInterval")
+        const state = mockProjectsState({queuedVersionUploadIntervalId: 123});
+        mutations[ProjectsMutations.ClearQueuedVersionUpload](state);
+        expect(state.queuedVersionUploadIntervalId).toBe(-1);
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenLastCalledWith(123);
     });
 
     it("VersionUploadSuccess sets versionTime", () => {
         const state = mockProjectsState();
         mutations[ProjectsMutations.VersionUploadSuccess](state);
-
         expect(state.versionTime!.valueOf()).toEqual(testNow);
     });
 


### PR DESCRIPTION
## Description

Prior to this change, multiple requests to upload version state were pending simultaneously, increasing load on the server and chance of timeouts/crashes while streaming large data downloads over a slow connection.

To see issue prior to this fix, set throttling (e.g. 450kb/s down, 150kb/s up) and watch console/network requests to see multiple pending requests to `/project/{pid}/version/{vid}/state` while downloading results.

After recompiling with this fix, repeat and see that only one pending request is in progress at any one time.

## Type of version change
Patch

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
