### PR TITLE
mrc-2903 rename downloading methods and properties for clarity

### DIFF
--- a/src/app/static/src/app/components/downloadResults/Download.vue
+++ b/src/app/static/src/app/components/downloadResults/Download.vue
@@ -10,7 +10,7 @@
         <div>
             <download-progress v-if="!modalOpen" id="progress"
                                :translate-key="'downloading'"
-                               :downloading="file.downloading"/>
+                               :downloading="file.preparing"/>
         </div>
         <error-alert id="error" v-if="file.error" :error="file.error"></error-alert>
     </div>

--- a/src/app/static/src/app/components/downloadResults/DownloadResults.vue
+++ b/src/app/static/src/app/components/downloadResults/DownloadResults.vue
@@ -109,12 +109,12 @@
         getUserCanUpload: () => void
         getUploadFiles: () => void
         clearStatus: () => void;
-        downloadCoarseOutput: () => void
-        downloadSpectrum: () => void
+        prepareCoarseOutput: () => void
+        prepareSpectrumOutput: () => void
+        prepareSummaryReport: () => void
         downloadSummary: () => void
-        getSummaryDownload: () => void
-        getSpectrumDownload: () => void
-        getCoarseOutputDownload: () => void
+        downloadSpectrum: () => void
+        downloadCoarseOutput: () => void
         getUploadMetadata: (id: string) => void
         downloadUrl: (downloadId: string) => string
         stopPolling: (pollingId: number) => void
@@ -135,21 +135,21 @@
         computed: {
             ...mapStateProps<DownloadResultsState, keyof Computed>("downloadResults", {
                 spectrum: state => ({
-                    downloading: state.spectrum.downloading,
+                    preparing: state.spectrum.preparing,
                     complete: state.spectrum.complete,
                     downloadId: state.spectrum.downloadId,
                     statusPollId: state.spectrum.statusPollId,
                     error: state.spectrum.error
                 }),
                 summary: state => ({
-                    downloading: state.summary.downloading,
+                    preparing: state.summary.preparing,
                     complete: state.summary.complete,
                     downloadId: state.summary.downloadId,
                     statusPollId: state.summary.statusPollId,
                     error: state.summary.error
                 }),
                 coarseOutput: state => ({
-                    downloading: state.coarseOutput.downloading,
+                    preparing: state.coarseOutput.preparing,
                     complete: state.coarseOutput.complete,
                     downloadId: state.coarseOutput.downloadId,
                     statusPollId: state.coarseOutput.statusPollId,
@@ -187,7 +187,7 @@
                 }
             },
             isDownloading() {
-                return !!this.summary.downloading || !!this.spectrum.downloading || !!this.coarseOutput.downloading
+                return !!this.summary.preparing || !!this.spectrum.preparing || !!this.coarseOutput.preparing
             }
         },
         methods: {
@@ -198,18 +198,18 @@
                 this.uploadModalOpen = true;
             },
             downloadSpectrum() {
-                if (!this.spectrum.downloading) {
-                    this.getSpectrumDownload();
+                if (!this.spectrum.preparing) {
+                    this.prepareSpectrumOutput();
                 }
             },
             downloadSummary() {
-                if (!this.summary.downloading) {
-                    this.getSummaryDownload();
+                if (!this.summary.preparing) {
+                    this.prepareSummaryReport();
                 }
             },
             downloadCoarseOutput() {
-                if (!this.coarseOutput.downloading) {
-                    this.getCoarseOutputDownload();
+                if (!this.coarseOutput.preparing) {
+                    this.prepareCoarseOutput();
                 }
             },
             stopPolling(id) {
@@ -230,12 +230,13 @@
             clearStatus: mapMutationByName("adrUpload", "ClearStatus"),
             getUserCanUpload: mapActionByName("adr", "getUserCanUpload"),
             getUploadFiles: mapActionByName("adrUpload", "getUploadFiles"),
-            getSpectrumDownload: mapActionByName("downloadResults", "downloadSpectrum"),
-            getSummaryDownload: mapActionByName("downloadResults", "downloadSummary"),
-            getCoarseOutputDownload: mapActionByName("downloadResults", "downloadCoarseOutput"),
+            prepareSpectrumOutput: mapActionByName("downloadResults", "prepareSpectrumOutput"),
+            prepareSummaryReport: mapActionByName("downloadResults", "prepareSummaryReport"),
+            prepareCoarseOutput: mapActionByName("downloadResults", "prepareCoarseOutput"),
             getUploadMetadata: mapActionByName("metadata", "getAdrUploadMetadata"),
         },
         mounted() {
+            console.log((this.$store as any)._modulesNamespaceMap["downloadResults/"]._rawModule);
             this.getUserCanUpload();
             this.getUploadFiles()
         },

--- a/src/app/static/src/app/store/downloadResults/actions.ts
+++ b/src/app/static/src/app/store/downloadResults/actions.ts
@@ -20,7 +20,7 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.CoarseOutputBundlingStarted)
+            .withSuccess(DownloadResultsMutation.PreparingCoarseOutput)
             .withError(DownloadResultsMutation.CoarseOutputError)
             .get(`download/submit/coarse-output/${calibrateId}`)
 
@@ -35,7 +35,7 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.SummaryBundlingStarted)
+            .withSuccess(DownloadResultsMutation.PreparingSummaryReport)
             .withError(DownloadResultsMutation.SummaryError)
             .get(`download/submit/summary/${calibrateId}`)
 
@@ -50,7 +50,7 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.SpectrumBundlingStarted)
+            .withSuccess(DownloadResultsMutation.PreparingSpectrumOutput)
             .withError(DownloadResultsMutation.SpectrumError)
             .get(`download/submit/spectrum/${calibrateId}`)
 
@@ -80,7 +80,7 @@ export const getSummaryReportStatus = async function (context: ActionContext<Dow
     const {state} = context;
     const downloadId = state.summary.downloadId;
     return api<DownloadResultsMutation, DownloadResultsMutation>(context)
-        .withSuccess(DownloadResultsMutation.SummaryStatusUpdated)
+        .withSuccess(DownloadResultsMutation.SummaryReportStatusUpdated)
         .withError(DownloadResultsMutation.SummaryError)
         .get<ModelStatusResponse>(`download/status/${downloadId}`)
 };

--- a/src/app/static/src/app/store/downloadResults/actions.ts
+++ b/src/app/static/src/app/store/downloadResults/actions.ts
@@ -6,20 +6,21 @@ import {DownloadResultsMutation} from "./mutations";
 import {ModelStatusResponse} from "../../generated";
 
 export interface DownloadResultsActions {
-    downloadSummary: (store : ActionContext<DownloadResultsState, RootState>) => void
-    downloadSpectrum: (store : ActionContext<DownloadResultsState, RootState>) => void
-    downloadCoarseOutput: (store : ActionContext<DownloadResultsState, RootState>) => void
+    prepareSummaryReport: (store: ActionContext<DownloadResultsState, RootState>) => void
+    prepareSpectrumOutput: (store: ActionContext<DownloadResultsState, RootState>) => void
+    prepareCoarseOutput: (store: ActionContext<DownloadResultsState, RootState>) => void
     poll: (store: ActionContext<DownloadResultsState, RootState>, downloadType: string) => void
 }
 
 export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResultsActions = {
 
-    async downloadCoarseOutput(context) {
-        const {dispatch, rootState} = context
+    async prepareCoarseOutput(context) {
+        const {state, dispatch, rootState} = context
+
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.CoarseOutputDownloadStarted)
+            .withSuccess(DownloadResultsMutation.CoarseOutputBundlingStarted)
             .withError(DownloadResultsMutation.CoarseOutputError)
             .get(`download/submit/coarse-output/${calibrateId}`)
 
@@ -28,12 +29,13 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         }
     },
 
-    async downloadSummary(context) {
-        const {dispatch, rootState} = context
+    async prepareSummaryReport(context) {
+
+        const {state, dispatch, rootState} = context
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.SummaryDownloadStarted)
+            .withSuccess(DownloadResultsMutation.SummaryBundlingStarted)
             .withError(DownloadResultsMutation.SummaryError)
             .get(`download/submit/summary/${calibrateId}`)
 
@@ -42,12 +44,13 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         }
     },
 
-    async downloadSpectrum(context) {
-        const {dispatch, rootState} = context
+    async prepareSpectrumOutput(context) {
+        const {dispatch, rootState, state} = context
+
         const calibrateId = rootState.modelCalibrate.calibrateId
 
         const response = await api<DownloadResultsMutation, DownloadResultsMutation>(context)
-            .withSuccess(DownloadResultsMutation.SpectrumDownloadStarted)
+            .withSuccess(DownloadResultsMutation.SpectrumBundlingStarted)
             .withError(DownloadResultsMutation.SpectrumError)
             .get(`download/submit/spectrum/${calibrateId}`)
 
@@ -60,14 +63,12 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
         const {commit} = context;
         const id = setInterval(() => {
 
-            if(downloadType === DOWNLOAD_TYPE.SPECTRUM) {
-                getSpectrumDownloadStatus(context)
-            }
-            else if(downloadType === DOWNLOAD_TYPE.COARSE) {
-                getCoarseOutputDownloadStatus(context)
-            }
-            else if (downloadType === DOWNLOAD_TYPE.SUMMARY) {
-                getSummaryDownloadStatus(context)
+            if (downloadType === DOWNLOAD_TYPE.SPECTRUM) {
+                getSpectrumOutputStatus(context)
+            } else if (downloadType === DOWNLOAD_TYPE.COARSE) {
+                getCoarseOutputStatus(context)
+            } else if (downloadType === DOWNLOAD_TYPE.SUMMARY) {
+                getSummaryReportStatus(context)
             }
         }, 2000);
 
@@ -75,29 +76,29 @@ export const actions: ActionTree<DownloadResultsState, RootState> & DownloadResu
     },
 };
 
-export const getSummaryDownloadStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
+export const getSummaryReportStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
     const {state} = context;
     const downloadId = state.summary.downloadId;
     return api<DownloadResultsMutation, DownloadResultsMutation>(context)
-        .withSuccess(DownloadResultsMutation.SummaryDownloadStatusUpdated)
+        .withSuccess(DownloadResultsMutation.SummaryStatusUpdated)
         .withError(DownloadResultsMutation.SummaryError)
         .get<ModelStatusResponse>(`download/status/${downloadId}`)
 };
 
-export const getSpectrumDownloadStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
+export const getSpectrumOutputStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
     const {state} = context;
     const downloadId = state.spectrum.downloadId;
     return api<DownloadResultsMutation, DownloadResultsMutation>(context)
-        .withSuccess(DownloadResultsMutation.SpectrumDownloadStatusUpdated)
+        .withSuccess(DownloadResultsMutation.SpectrumOutputStatusUpdated)
         .withError(DownloadResultsMutation.SpectrumError)
         .get<ModelStatusResponse>(`download/status/${downloadId}`)
 };
 
-export const getCoarseOutputDownloadStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
+export const getCoarseOutputStatus = async function (context: ActionContext<DownloadResultsState, RootState>) {
     const {state} = context;
     const downloadId = state.coarseOutput.downloadId;
     return api<DownloadResultsMutation, DownloadResultsMutation>(context)
-        .withSuccess(DownloadResultsMutation.CoarseOutputDownloadStatusUpdated)
+        .withSuccess(DownloadResultsMutation.CoarseOutputStatusUpdated)
         .withError(DownloadResultsMutation.CoarseOutputError)
         .get<ModelStatusResponse>(`download/status/${downloadId}`)
 };

--- a/src/app/static/src/app/store/downloadResults/downloadResults.ts
+++ b/src/app/static/src/app/store/downloadResults/downloadResults.ts
@@ -1,5 +1,4 @@
 import {RootState} from "../../root";
-import {DownloadStatusResponse} from "../../generated";
 import {Module} from "vuex";
 import {actions} from "./actions";
 import {mutations} from "./mutations";
@@ -13,9 +12,8 @@ export interface DownloadResultsState {
 
 export const initialDownloadResults = {
     downloadId: "",
-    downloading: false,
+    preparing: false,
     statusPollId: -1,
-    status: {} as DownloadStatusResponse,
     complete: false,
     error: null
 }

--- a/src/app/static/src/app/store/downloadResults/mutations.ts
+++ b/src/app/static/src/app/store/downloadResults/mutations.ts
@@ -4,14 +4,14 @@ import {PayloadWithType, PollingStarted} from "../../types";
 import {DownloadStatusResponse, DownloadSubmitResponse, Error} from "../../generated";
 
 export enum DownloadResultsMutation {
-    SpectrumBundlingStarted = "SpectrumBundlingStarted",
+    PreparingSpectrumOutput = "PreparingSpectrumOutput",
     SpectrumOutputStatusUpdated = "SpectrumOutputStatusUpdated",
     SpectrumError = "SpectrumError",
-    CoarseOutputBundlingStarted = "CoarseOutputBundlingStarted",
+    PreparingCoarseOutput = "PreparingCoarseOutput",
     CoarseOutputStatusUpdated = "CoarseOutputStatusUpdated",
     CoarseOutputError = "CoarseOutputError",
-    SummaryBundlingStarted = "SummaryBundlingStarted",
-    SummaryStatusUpdated = "SummaryStatusUpdated",
+    PreparingSummaryReport = "PreparingSummaryReport",
+    SummaryReportStatusUpdated = "SummaryReportStatusUpdated",
     SummaryError = "SummaryError",
     PollingStatusStarted = "PollingStatusStarted",
     ResetIds = "ResetIds"
@@ -19,7 +19,7 @@ export enum DownloadResultsMutation {
 
 export const mutations: MutationTree<DownloadResultsState> = {
 
-    [DownloadResultsMutation.SpectrumBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.PreparingSpectrumOutput](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
         state.spectrum = {...state.spectrum, downloadId, preparing: true, complete: false, error: null}
     },
@@ -37,7 +37,7 @@ export const mutations: MutationTree<DownloadResultsState> = {
         state.spectrum.preparing = false
     },
 
-    [DownloadResultsMutation.CoarseOutputBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.PreparingCoarseOutput](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
         state.coarseOutput = {...state.coarseOutput, downloadId, preparing: true, complete: false, error: null}
     },
@@ -55,12 +55,12 @@ export const mutations: MutationTree<DownloadResultsState> = {
         state.coarseOutput.preparing = false
     },
 
-    [DownloadResultsMutation.SummaryBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.PreparingSummaryReport](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
         state.summary = {...state.summary, downloadId, preparing: true, complete: false, error: null}
     },
 
-    [DownloadResultsMutation.SummaryStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
+    [DownloadResultsMutation.SummaryReportStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
         if (action.payload.done) {
             state.summary.complete = true;
             state.summary.preparing = false;

--- a/src/app/static/src/app/store/downloadResults/mutations.ts
+++ b/src/app/static/src/app/store/downloadResults/mutations.ts
@@ -4,72 +4,73 @@ import {PayloadWithType, PollingStarted} from "../../types";
 import {DownloadStatusResponse, DownloadSubmitResponse, Error} from "../../generated";
 
 export enum DownloadResultsMutation {
-    SpectrumDownloadStarted = "SpectrumDownloadStarted",
-    SpectrumDownloadStatusUpdated = "SpectrumDownloadStatusUpdated",
+    SpectrumBundlingStarted = "SpectrumBundlingStarted",
+    SpectrumOutputStatusUpdated = "SpectrumOutputStatusUpdated",
     SpectrumError = "SpectrumError",
-    CoarseOutputDownloadStarted = "CoarseOutputDownloadStarted",
-    CoarseOutputDownloadStatusUpdated = "CoarseOutputDownloadStatusUpdated",
+    CoarseOutputBundlingStarted = "CoarseOutputBundlingStarted",
+    CoarseOutputStatusUpdated = "CoarseOutputStatusUpdated",
     CoarseOutputError = "CoarseOutputError",
-    SummaryDownloadStarted = "SummaryDownloadStarted",
-    SummaryDownloadStatusUpdated = "SummaryDownloadStatusUpdated",
+    SummaryBundlingStarted = "SummaryBundlingStarted",
+    SummaryStatusUpdated = "SummaryStatusUpdated",
     SummaryError = "SummaryError",
-    PollingStatusStarted = "PollingStatusStarted"
+    PollingStatusStarted = "PollingStatusStarted",
+    ResetIds = "ResetIds"
 }
 
 export const mutations: MutationTree<DownloadResultsState> = {
 
-    [DownloadResultsMutation.SpectrumDownloadStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.SpectrumBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
-        state.spectrum = {...state.spectrum, downloadId, downloading: true, complete: false, error: null}
+        state.spectrum = {...state.spectrum, downloadId, preparing: true, complete: false, error: null}
     },
 
-    [DownloadResultsMutation.SpectrumDownloadStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
+    [DownloadResultsMutation.SpectrumOutputStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
         if (action.payload.done) {
             state.spectrum.complete = true;
-            state.spectrum.downloading = false;
+            state.spectrum.preparing = false;
         }
         state.spectrum.error = null;
     },
 
     [DownloadResultsMutation.SpectrumError](state: DownloadResultsState, action: PayloadWithType<Error>) {
         state.spectrum.error = action.payload
-        state.spectrum.downloading = false
+        state.spectrum.preparing = false
     },
 
-    [DownloadResultsMutation.CoarseOutputDownloadStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.CoarseOutputBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
-        state.coarseOutput = {...state.coarseOutput, downloadId, downloading: true, complete: false, error: null}
+        state.coarseOutput = {...state.coarseOutput, downloadId, preparing: true, complete: false, error: null}
     },
 
-    [DownloadResultsMutation.CoarseOutputDownloadStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
+    [DownloadResultsMutation.CoarseOutputStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
         if (action.payload.done) {
             state.coarseOutput.complete = true;
-            state.coarseOutput.downloading = false;
+            state.coarseOutput.preparing = false;
         }
         state.coarseOutput.error = null;
     },
 
     [DownloadResultsMutation.CoarseOutputError](state: DownloadResultsState, action: PayloadWithType<Error>) {
         state.coarseOutput.error = action.payload
-        state.coarseOutput.downloading = false
+        state.coarseOutput.preparing = false
     },
 
-    [DownloadResultsMutation.SummaryDownloadStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
+    [DownloadResultsMutation.SummaryBundlingStarted](state: DownloadResultsState, action: PayloadWithType<DownloadSubmitResponse>) {
         const downloadId = action.payload.id
-        state.summary = {...state.summary, downloadId, downloading: true, complete: false, error: null}
+        state.summary = {...state.summary, downloadId, preparing: true, complete: false, error: null}
     },
 
-    [DownloadResultsMutation.SummaryDownloadStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
+    [DownloadResultsMutation.SummaryStatusUpdated](state: DownloadResultsState, action: PayloadWithType<DownloadStatusResponse>) {
         if (action.payload.done) {
             state.summary.complete = true;
-            state.summary.downloading = false;
+            state.summary.preparing = false;
         }
         state.summary.error = null;
     },
 
     [DownloadResultsMutation.SummaryError](state: DownloadResultsState, action: PayloadWithType<Error>) {
         state.summary.error = action.payload
-        state.summary.downloading = false
+        state.summary.preparing = false
     },
 
     [DownloadResultsMutation.PollingStatusStarted](state: DownloadResultsState, action: PayloadWithType<PollingStarted>) {
@@ -87,5 +88,11 @@ export const mutations: MutationTree<DownloadResultsState> = {
                 break
             }
         }
+    },
+
+    [DownloadResultsMutation.ResetIds](state: DownloadResultsState) {
+        state.summary.downloadId = "";
+        state.spectrum.downloadId = "";
+        state.coarseOutput.downloadId = "";
     }
 };

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -166,9 +166,8 @@ export interface UploadFile {
 
 export interface DownloadResultsDependency {
     downloadId: string
-    downloading: boolean
+    preparing: boolean
     statusPollId: number
-    status: DownloadStatusResponse
     complete: boolean
     error: Error | null
 }

--- a/src/app/static/src/tests/components/downloadResults/download.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/download.test.ts
@@ -1,14 +1,12 @@
 import {shallowMount} from "@vue/test-utils";
 import Download from "../../../app/components/downloadResults/Download.vue"
+import {mockDownloadResultsDependency} from "../../mocks";
 
 describe(`download`, () => {
 
-    const downloadSummary = {
-        downloading: true,
-        complete: false,
-        downloadId: null,
-        error: null
-    }
+    const downloadSummary = mockDownloadResultsDependency({
+        preparing: true
+    })
 
     const downloadTranslate = {
         header: "downloadSummaryReport",
@@ -69,12 +67,8 @@ describe(`download`, () => {
 
     it(`can emit download`, async () => {
         const wrapper = getWrapper()
-        const downloadSummary = {
-            downloading: false,
-            complete: false,
-            downloadId: null,
-            error: null
-        }
+        const downloadSummary = mockDownloadResultsDependency();
+
         const button = wrapper.find("button")
         await wrapper.setProps({file: downloadSummary})
         button.trigger("click")

--- a/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/downloadResults.test.ts
@@ -2,7 +2,7 @@ import {createLocalVue, shallowMount, mount} from '@vue/test-utils';
 import Vuex, {Store} from 'vuex';
 import {
     mockADRState,
-    mockADRUploadState,
+    mockADRUploadState, mockDownloadResultsDependency,
     mockDownloadResultsState, mockError, mockMetadataState,
     mockModelCalibrateState
 } from "../../mocks";
@@ -25,12 +25,12 @@ describe("Download Results component", () => {
     const mockCoarseOutputDownloadAction = jest.fn();
     const mockUploadMetadataAction = jest.fn();
 
-    const mockDownloading = {
-        downloading: true,
+    const mockDownloading = mockDownloadResultsDependency({
+        preparing: true,
         complete: false,
         error: null,
-        downloadId: null
-    }
+        downloadId: ""
+    })
 
     afterEach(() => {
         jest.useRealTimers()
@@ -73,9 +73,9 @@ describe("Download Results component", () => {
                     namespaced: true,
                     state: mockDownloadResultsState(downloadResults),
                     actions: {
-                        downloadSpectrum: mockSpectrumDownloadAction,
-                        downloadSummary: mockSummaryDownloadAction,
-                        downloadCoarseOutput: mockCoarseOutputDownloadAction
+                        prepareSpectrumOutput: mockSpectrumDownloadAction,
+                        prepareSummaryReport: mockSummaryDownloadAction,
+                        prepareCoarseOutput: mockCoarseOutputDownloadAction
                     }
                 },
                 metadata: {
@@ -246,24 +246,24 @@ describe("Download Results component", () => {
     it("can download spectrum file when download is complete", () => {
         const store = createStore();
         const downloadResults = {
-            summary: {
-                downloading: true,
+            summary: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            coarseOutput: {
-                downloading: true,
+                downloadId: ""
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            spectrum: {
-                downloading: false,
+                downloadId: ""
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: false,
                 complete: true,
                 error: null,
                 downloadId: "123"
-            }
+            })
         }
         downloadFile(store, downloadResults)
     });
@@ -298,12 +298,13 @@ describe("Download Results component", () => {
     });
 
     it("can render error when spectrum download action is unsuccessful", () => {
-        const testError = {
-            downloading: false,
+        const testError = mockDownloadResultsDependency({
+            preparing: false,
             complete: false,
             error: mockError("TEST FAILED"),
-            downloadId: null
-        }
+            downloadId: ""
+        });
+
         const store = createStore(
             false,
             jest.fn(),
@@ -322,34 +323,34 @@ describe("Download Results component", () => {
     });
 
     it("can stop polling spectrum download when error response", () => {
-        const spectrumDownloadStatus = {
-            downloading: true,
+        const spectrumDownloadStatus = mockDownloadResultsDependency({
+            preparing: true,
             complete: false,
             error: null,
-            downloadId: 1,
+            downloadId: "1",
             statusPollId: 123
-        }
+        });
 
         const spectrumTestError = {
-            summary: {
-                downloading: false,
+            summary: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            coarseOutput: {
-                downloading: false,
+                downloadId: ""
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            spectrum: {
-                downloading: false,
+                downloadId: ""
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: mockError("TEST FAILED"),
-                downloadId: null,
+                downloadId: "",
                 statusPollId: 123
-            }
+            })
         }
 
         const store = createStore(
@@ -374,12 +375,13 @@ describe("Download Results component", () => {
     });
 
     it("can fetch upload metadata when spectrum download action is complete", () => {
-        const testComplete = {
-            downloading: false,
+        const testComplete = mockDownloadResultsDependency({
+            preparing: false,
             complete: true,
             error: null,
             downloadId: "123"
-        }
+        });
+
         const store = createStore(
             false,
             jest.fn(),
@@ -424,35 +426,36 @@ describe("Download Results component", () => {
     it("can download coarseOutput file when download is complete", () => {
         const store = createStore();
         const downloadResults = {
-            summary: {
-                downloading: false,
+            summary: mockDownloadResultsDependency({
+                preparing: false,
                 complete: true,
                 error: null,
                 downloadId: "123"
-            },
-            coarseOutput: {
-                downloading: true,
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            spectrum: {
-                downloading: true,
+                downloadId: ""
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            }
+                downloadId: ""
+            })
         }
         downloadFile(store, downloadResults)
     });
 
     it("can render error when summary download action is unsuccessful", () => {
-        const testError = {
-            downloading: false,
+        const testError = mockDownloadResultsDependency({
+            preparing: false,
             complete: false,
             error: mockError("TEST FAILED"),
-            downloadId: null
-        }
+            downloadId: ""
+        });
+
         const store = createStore(
             false,
             jest.fn(),
@@ -471,12 +474,13 @@ describe("Download Results component", () => {
     });
 
     it("can fetch upload metadata when summary download action is complete", () => {
-        const testComplete = {
-            downloading: false,
+        const testComplete = mockDownloadResultsDependency({
+            preparing: false,
             complete: true,
             error: null,
             downloadId: "123"
-        }
+        });
+
         const store = createStore(
             false,
             jest.fn(),
@@ -496,34 +500,34 @@ describe("Download Results component", () => {
     });
 
     it("can stop polling summary download when error response", () => {
-        const summaryDownloadStatus = {
-            downloading: true,
+        const summaryDownloadStatus = mockDownloadResultsDependency({
+            preparing: true,
             complete: false,
             error: null,
-            downloadId: 1,
+            downloadId: "1",
             statusPollId: 123
-        }
+        });
 
         const summaryTestError = {
-            summary: {
-                downloading: false,
+            summary: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: mockError("TEST FAILED"),
-                downloadId: null,
+                downloadId: "",
                 statusPollId: 123
-            },
-            coarseOutput: {
-                downloading: false,
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            spectrum: {
-                downloading: false,
+                downloadId: ""
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            }
+                downloadId: ""
+            })
         }
 
         const store = createStore(
@@ -548,24 +552,24 @@ describe("Download Results component", () => {
     it("can download coarseOutput file when download is complete", () => {
         const store = createStore();
         const downloadResults = {
-            summary: {
-                downloading: true,
+            summary: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            coarseOutput: {
-                downloading: false,
+                downloadId: ""
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: false,
                 complete: true,
                 error: null,
                 downloadId: "123"
-            },
-            spectrum: {
-                downloading: true,
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: true,
                 complete: false,
                 error: null,
-                downloadId: null
-            }
+                downloadId: ""
+            })
         }
         downloadFile(store, downloadResults)
     });
@@ -597,12 +601,13 @@ describe("Download Results component", () => {
     });
 
     it("can render error when coarseOutput download action is unsuccessful", () => {
-        const testError = {
-            downloading: false,
+        const testError = mockDownloadResultsDependency({
+            preparing: false,
             complete: false,
             error: mockError("TEST FAILED"),
-            downloadId: null
-        }
+            downloadId: ""
+        });
+
         const store = createStore(
             false,
             jest.fn(),
@@ -619,34 +624,34 @@ describe("Download Results component", () => {
     });
 
     it("can stop polling coarseOutput download when error response", () => {
-        const coarseDownloadStatus = {
-            downloading: true,
+        const coarseDownloadStatus = mockDownloadResultsDependency({
+            preparing: true,
             complete: false,
             error: null,
-            downloadId: 1,
+            downloadId: "1",
             statusPollId: 123
-        }
+        });
 
         const coarseTestError = {
-            summary: {
-                downloading: false,
+            summary: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            },
-            coarseOutput: {
-                downloading: false,
+                downloadId: ""
+            }),
+            coarseOutput: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: mockError("TEST FAILED"),
-                downloadId: null,
+                downloadId: "",
                 statusPollId: 123
-            },
-            spectrum: {
-                downloading: false,
+            }),
+            spectrum: mockDownloadResultsDependency({
+                preparing: false,
                 complete: false,
                 error: null,
-                downloadId: null
-            }
+                downloadId: ""
+            })
         }
 
         const store = createStore(

--- a/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
+++ b/src/app/static/src/tests/components/downloadResults/uploadModal.test.ts
@@ -6,7 +6,7 @@ import {
     mockADRState,
     mockADRUploadState,
     mockBaselineState,
-    mockDatasetResource,
+    mockDatasetResource, mockDownloadResultsDependency,
     mockDownloadResultsState, mockError, mockMetadataState
 } from "../../mocks";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
@@ -80,25 +80,25 @@ describe(`uploadModal `, () => {
     }
 
     const mockDownloadResults = {
-        summary: {complete: false, downloading: false } as any,
-        spectrum: {complete: false, downloading: false} as any
+        summary: mockDownloadResultsDependency({complete: false, preparing: false }),
+        spectrum: mockDownloadResultsDependency({complete: false, preparing: false})
     } as any
 
     const failedDownloadResults = {
-        summary: {
-            downloading: false,
+        summary: mockDownloadResultsDependency({
+            preparing: false,
             complete: false,
             error: null,
-            downloadId: null,
+            downloadId: "",
             statusPollId: 123
-        },
-        spectrum: {
-            downloading: false,
+        }),
+        spectrum: mockDownloadResultsDependency({
+            preparing: false,
             complete: false,
             error: mockError("TEST FAILED"),
-            downloadId: null,
+            downloadId: "",
             statusPollId: 123
-        }
+        })
     }
 
     const mockSpectrumDownload = jest.fn();
@@ -309,9 +309,9 @@ describe(`uploadModal `, () => {
 
     it(`can send upload files to ADR when download status is complete`, async () => {
         const downloadResults = {
-            summary: {complete: true, downloading: false} as any,
-            spectrum: {complete: true, downloading: false} as any,
-            coarseOutput: {} as any
+            summary: mockDownloadResultsDependency({complete: true, preparing: false}),
+            spectrum: mockDownloadResultsDependency({complete: true, preparing: false}),
+            coarseOutput: mockDownloadResultsDependency()
         }
         const store = createStore()
         const wrapper = mount(UploadModal, {store})
@@ -336,9 +336,9 @@ describe(`uploadModal `, () => {
 
     it(`can set createRelease and upload files in uploadFilesToAdrAction`, async () => {
         const downloadResults = {
-            summary: {complete: true, downloading: false} as any,
-            spectrum: {complete: true, downloading: false} as any,
-            coarseOutput: {} as any
+            summary: mockDownloadResultsDependency({complete: true, preparing: false}),
+            spectrum: mockDownloadResultsDependency({complete: true, preparing: false}),
+            coarseOutput: mockDownloadResultsDependency()
         }
         const store = createStore(metadataWithInput, downloadResults)
         const wrapper = mount(UploadModal, {store})
@@ -358,9 +358,9 @@ describe(`uploadModal `, () => {
 
     it(`can set upload files in uploadFilesToAdrAction and not set createRelease`, async () => {
         const downloadResults = {
-            summary: {complete: true, downloading: false} as any,
-            spectrum: {complete: true, downloading: false} as any,
-            coarseOutput: {} as any
+            summary: mockDownloadResultsDependency({complete: true, preparing: false}),
+            spectrum: mockDownloadResultsDependency({complete: true, preparing: false}),
+            coarseOutput: mockDownloadResultsDependency()
         }
         const store = createStore(metadataWithInput, downloadResults)
         const wrapper = mount(UploadModal, {store})
@@ -382,9 +382,9 @@ describe(`uploadModal `, () => {
 
     it(`can remove some upload files from uploadFilesToAdrAction`, async () => {
         const downloadResults = {
-            summary: {complete: true, downloading: false} as any,
-            spectrum: {complete: true, downloading: false} as any,
-            coarseOutput: {} as any
+            summary: mockDownloadResultsDependency({complete: true, preparing: false}),
+            spectrum: mockDownloadResultsDependency({complete: true, preparing: false}),
+            coarseOutput: mockDownloadResultsDependency()
         }
         const store = createStore(metadataWithInput, downloadResults)
         const wrapper = mount(UploadModal, {store})
@@ -410,8 +410,8 @@ describe(`uploadModal `, () => {
 
     it(`ok button is enabled when inputs are set and triggers close modal`, async () => {
         const downloadResults = {
-            summary: {complete: true} as any,
-            spectrum: {complete: true} as any
+            summary: mockDownloadResultsDependency({complete: true}),
+            spectrum: mockDownloadResultsDependency({complete: true})
         }
         const wrapper = mount(UploadModal, {store: createStore(fakeMetadata, downloadResults)})
 
@@ -429,10 +429,10 @@ describe(`uploadModal `, () => {
         expect(wrapper.emitted("close").length).toBe(1)
     });
 
-    it(`ok button is enabled when inputs are set and does not triggers close modal when downloading files`, async () => {
+    it(`ok button is enabled when inputs are set and does not trigger close modal when downloading files`, async () => {
         const downloadResults = {
-            summary: {downloading: true} as any,
-            spectrum: {downloading: true} as any
+            summary: mockDownloadResultsDependency({preparing: true}),
+            spectrum: mockDownloadResultsDependency({preparing: true})
         }
         const store = createStore(fakeMetadata, downloadResults)
         const wrapper = mount(UploadModal, {store})
@@ -477,8 +477,8 @@ describe(`uploadModal `, () => {
 
     it("can clear timer when download action is complete", async () => {
         const store = createStore({outputZip: fakeMetadata.outputZip}, {
-            summary: {complete: false, downloading: false } as any,
-            spectrum: {complete: false, downloading: false } as any
+            summary: mockDownloadResultsDependency({complete: false}),
+            spectrum: mockDownloadResultsDependency({complete: false})
         });
         const wrapper = mount(UploadModal, {store})
 
@@ -585,8 +585,8 @@ describe(`uploadModal `, () => {
 
     it(`ok and cancel buttons are disabled when upload to ADR is in progress`, async () => {
         const downloadResults = {
-            summary: {downloading: false} as any,
-            spectrum: {downloading: true} as any
+            summary: mockDownloadResultsDependency({preparing: false}),
+            spectrum: mockDownloadResultsDependency({preparing: true})
         }
         const wrapper = mount(UploadModal,
             {

--- a/src/app/static/src/tests/downloadResults/actions.test.ts
+++ b/src/app/static/src/tests/downloadResults/actions.test.ts
@@ -1,14 +1,14 @@
 import {
-    mockAxios,
+    mockAxios, mockDownloadResultsDependency,
     mockDownloadResultsState, mockError, mockFailure, mockModelCalibrateState,
     mockRootState,
     mockSuccess
 } from "../mocks";
 import {actions} from "../../app/store/downloadResults/actions";
 import {DOWNLOAD_TYPE} from "../../app/store/downloadResults/downloadResults";
+import {DownloadStatusResponse} from "../../app/generated";
 
-
-export const RunningStatusResponse = {
+const RunningStatusResponse: DownloadStatusResponse = {
     id: "db0c4957aea4b32c507ac02d63930110",
     done: false,
     progress: ["Generating summary report"],
@@ -17,10 +17,10 @@ export const RunningStatusResponse = {
     queue: 0
 }
 
-export const CompleteStatusResponse =  {
+const CompleteStatusResponse: DownloadStatusResponse = {
     id: "db0c4957aea4b32c507ac02d63930110",
     done: true,
-    progress:["Generating summary report"],
+    progress: ["Generating summary report"],
     status: "COMPLETE",
     success: true,
     queue: 0
@@ -34,91 +34,44 @@ describe(`download Results actions`, () => {
         mockAxios.reset();
     });
 
-    it("can submit download summary, commits and starts polling", async () => {
+    it("prepare summary commits download id and starts polling for status", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1"};
+        const partialDownloadResultsState = mockDownloadResultsDependency({downloadId: "1"});
         const root = mockRootState({
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"})
         });
 
-        const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/summary/calibrate1`)
             .reply(200, mockSuccess(partialDownloadResultsState));
 
-        await actions.downloadSummary({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareSummaryReport({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0]["type"]).toBe( "SummaryDownloadStarted")
+        expect(commit.mock.calls[0][0]["type"]).toBe("SummaryBundlingStarted")
         expect(commit.mock.calls[0][0]["payload"]).toEqual(partialDownloadResultsState)
         expect(mockAxios.history.get.length).toBe(1);
         expect(mockAxios.history.get[0]["url"]).toBe("download/submit/summary/calibrate1");
 
         expect(dispatch.mock.calls.length).toBe(1)
-        expect(dispatch.mock.calls[0]).toEqual( ["poll", DOWNLOAD_TYPE.SUMMARY])
+        expect(dispatch.mock.calls[0]).toEqual(["poll", DOWNLOAD_TYPE.SUMMARY])
     });
 
-    it("can invoke summary poll action, gets pollId, commits PollingStatusStarted", async (done) => {
-        const commit = jest.fn();
-        const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1"};
-
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
-
-        const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
-
-        mockAxios.onGet(`download/submit/summary/calibrate1`)
-            .reply(200, mockSuccess(partialDownloadResultsState));
-        mockAxios.onGet(`download/status/1`)
-            .reply(200, mockSuccess(RunningStatusResponse));
-
-        await actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.SUMMARY);
-
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryDownloadStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-
-        }, 2100)
-    });
-
-    it("can get summary results and commits", async (done) => {
+    it("can poll for summary status, get pollId and commit result", async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn()
         const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
 
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
-
         const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
+            summary: partialDownloadResultsState
         } as any);
 
         mockAxios.onGet(`download/status/1`)
             .reply(200, mockSuccess(RunningStatusResponse));
-        mockAxios.onGet(`/meta/adr/1`)
-            .reply(200, mockSuccess({type: "summary", description: "summary"}))
 
-        await actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.SUMMARY);
+        await actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2);
@@ -126,31 +79,26 @@ describe(`download Results actions`, () => {
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
 
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryDownloadStatusUpdated")
+            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryStatusUpdated")
             expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
             done()
         }, 2100)
     });
 
-    it("does not send download summary request when unsuccessful", async () => {
+    it("does not poll for summary status when submission is unsuccessful", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
 
         const root = mockRootState({
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
         });
 
-        const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/summary/calibrate1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.downloadSummary({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareSummaryReport({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "SummaryError",
@@ -161,22 +109,16 @@ describe(`download Results actions`, () => {
     it("does not continue to poll summary status when unsuccessful", async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
-
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
+        const partialDownloadResultsState = mockDownloadResultsDependency({downloadId: "1"});
 
         const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+            summary: partialDownloadResultsState
+        });
 
         mockAxios.onGet(`download/status/1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.SUMMARY);
+        await actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2)
@@ -202,25 +144,21 @@ describe(`download Results actions`, () => {
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"})
         });
 
-        const state = mockDownloadResultsState({
-            summary: downloadId,
-            spectrum: downloadId,
-            coarseOutput: downloadId
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/spectrum/calibrate1`)
             .reply(200, mockSuccess(downloadId));
 
-        await actions.downloadSpectrum({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareSpectrumOutput({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0]["type"]).toBe( "SpectrumDownloadStarted")
+        expect(commit.mock.calls[0][0]["type"]).toBe("SpectrumBundlingStarted")
         expect(commit.mock.calls[0][0]["payload"]).toEqual(downloadId)
         expect(mockAxios.history.get.length).toBe(1);
         expect(mockAxios.history.get[0]["url"]).toBe("download/submit/spectrum/calibrate1");
 
         expect(dispatch.mock.calls.length).toBe(1)
-        expect(dispatch.mock.calls[0]).toEqual( ["poll", DOWNLOAD_TYPE.SPECTRUM])
+        expect(dispatch.mock.calls[0]).toEqual(["poll", DOWNLOAD_TYPE.SPECTRUM])
     });
 
     it("can invoke spectrum poll action, gets pollId, commits PollingStatusStarted", async (done) => {
@@ -233,13 +171,9 @@ describe(`download Results actions`, () => {
         });
 
         const state = mockDownloadResultsState({
-            summary: downloadId,
-            spectrum: downloadId,
-            coarseOutput: downloadId
-        } as any);
+            spectrum: mockDownloadResultsDependency({downloadId: "1"})
+        });
 
-        mockAxios.onGet(`download/submit/spectrum/calibrate1`)
-            .reply(200, mockSuccess(downloadId));
         mockAxios.onGet(`download/status/1`)
             .reply(200, mockSuccess(RunningStatusResponse));
 
@@ -251,33 +185,24 @@ describe(`download Results actions`, () => {
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
 
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumDownloadStatusUpdated")
+            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
             expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
             done()
 
         }, 2100)
     });
 
-    it("can get spectrum results, commits and dispatch upload metadata", async (done) => {
+    it("can poll for spectrum output status", async (done) => {
         const commit = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
-
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
 
         const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+            spectrum: mockDownloadResultsDependency({downloadId: "1"})
+        });
 
         mockAxios.onGet(`download/status/1`)
             .reply(200, mockSuccess(RunningStatusResponse));
-        mockAxios.onGet(`/meta/adr/1`)
-            .reply(200, mockSuccess({type: "spectrum", description: "spectrum"}))
 
-        await actions.poll({commit, state, rootState: root} as any, DOWNLOAD_TYPE.SPECTRUM);
+        await actions.poll({commit, state, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2);
@@ -285,31 +210,26 @@ describe(`download Results actions`, () => {
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
 
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumDownloadStatusUpdated")
+            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
             expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
             done()
         }, 2100)
     });
 
-    it("does not send download spectrum request when unsuccessful", async () => {
+    it("does not start polling for spectrum output status when submission is unsuccessful", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
 
         const root = mockRootState({
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
         });
 
-        const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/spectrum/calibrate1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.downloadSpectrum({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareSpectrumOutput({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "SpectrumError",
@@ -319,23 +239,15 @@ describe(`download Results actions`, () => {
 
     it("does not continue to poll spectrum status when unsuccessful", async (done) => {
         const commit = jest.fn();
-        const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
-
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
 
         const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+            spectrum: mockDownloadResultsDependency({downloadId: "1"})
+        });
 
         mockAxios.onGet(`download/status/1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.SPECTRUM);
+        await actions.poll({commit, state, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2)
@@ -354,7 +266,7 @@ describe(`download Results actions`, () => {
         }, 2100)
     });
 
-    it("can submit coarse-output download request, commits and starts polling", async () => {
+    it("can prepare coarse output, commits and starts polling", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const downloadId = {downloadId: "1"};
@@ -362,46 +274,34 @@ describe(`download Results actions`, () => {
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
         });
 
-        const state = mockDownloadResultsState({
-            summary: downloadId,
-            spectrum: downloadId,
-            coarseOutput: downloadId
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/coarse-output/calibrate1`)
             .reply(200, mockSuccess(downloadId));
 
-        await actions.downloadCoarseOutput({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareCoarseOutput({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0]["type"]).toBe( "CoarseOutputDownloadStarted")
+        expect(commit.mock.calls[0][0]["type"]).toBe("CoarseOutputBundlingStarted")
         expect(commit.mock.calls[0][0]["payload"]).toEqual(downloadId)
         expect(mockAxios.history.get.length).toBe(1);
         expect(mockAxios.history.get[0]["url"]).toBe("download/submit/coarse-output/calibrate1");
 
         expect(dispatch.mock.calls.length).toBe(1)
-        expect(dispatch.mock.calls[0]).toEqual( ["poll", DOWNLOAD_TYPE.COARSE])
+        expect(dispatch.mock.calls[0]).toEqual(["poll", DOWNLOAD_TYPE.COARSE])
     });
 
-    it("can invoke coarse output poll action, gets pollId, commits PollingStatusStarted", async (done) => {
+    it("can invoke coarse output poll action, get pollId and commit PollingStatusStarted", async (done) => {
         const commit = jest.fn();
-        const downloadId = {downloadId: "1"};
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
 
         const state = mockDownloadResultsState({
-            summary: downloadId,
-            spectrum: downloadId,
-            coarseOutput: downloadId
-        } as any);
+            coarseOutput: mockDownloadResultsDependency({downloadId: "1"})
+        });
 
-        mockAxios.onGet(`download/submit/coarse-output/calibrate1`)
-            .reply(200, mockSuccess(downloadId));
         mockAxios.onGet(`download/status/1`)
             .reply(200, mockSuccess(RunningStatusResponse));
 
-        await actions.poll({commit, state, rootState: root} as any, DOWNLOAD_TYPE.COARSE);
+        await actions.poll({commit, state, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2);
@@ -409,31 +309,23 @@ describe(`download Results actions`, () => {
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
 
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputDownloadStatusUpdated")
+            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
             expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
             done()
         }, 2100)
     });
 
-    it("can get coarse output results,commits and dispatch upload metadata", async (done) => {
+    it("can get coarse output status results", async (done) => {
         const commit = jest.fn();
-        const downloadStateMetadata = {downloadId: "1", status: CompleteStatusResponse};
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
 
         const state = mockDownloadResultsState({
-            summary: downloadStateMetadata,
-            spectrum: downloadStateMetadata,
-            coarseOutput: downloadStateMetadata
-        } as any);
+            coarseOutput: mockDownloadResultsDependency({downloadId: "1"})
+        });
 
         mockAxios.onGet(`download/status/1`)
             .reply(200, mockSuccess(RunningStatusResponse));
-        mockAxios.onGet(`/meta/adr/1`)
-            .reply(200, mockSuccess({type: "coarse_output", description: "coarseOutput"}))
 
-        await actions.poll({commit, state, rootState: root} as any, DOWNLOAD_TYPE.COARSE);
+        await actions.poll({commit, state, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2);
@@ -441,31 +333,26 @@ describe(`download Results actions`, () => {
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
 
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputDownloadStatusUpdated")
+            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
             expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
 
             done()
         }, 2100)
     });
 
-    it("does not send download coarse output request when unsuccessful", async () => {
+    it("does not poll for coarse output status when submission is unsuccessful", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
         const root = mockRootState({
             modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
         });
 
-        const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
-            coarseOutput: partialDownloadResultsState
-        } as any);
+        const state = mockDownloadResultsState();
 
         mockAxios.onGet(`download/submit/coarse-output/calibrate1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.downloadCoarseOutput({commit, state, dispatch, rootState: root} as any);
+        await actions.prepareCoarseOutput({commit, state, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: "CoarseOutputError",
@@ -476,25 +363,19 @@ describe(`download Results actions`, () => {
     it("does not continue to poll coarse output status when unsuccessful", async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
-        const root = mockRootState({
-            modelCalibrate: mockModelCalibrateState({calibrateId: "calibrate1"}),
-        });
+        const partialDownloadResultsState = mockDownloadResultsDependency({downloadId: "1"});
 
         const state = mockDownloadResultsState({
-            summary: partialDownloadResultsState,
-            spectrum: partialDownloadResultsState,
             coarseOutput: partialDownloadResultsState
-        } as any);
+        });
 
         mockAxios.onGet(`download/status/1`)
             .reply(500, mockFailure("TEST FAILED"));
 
-        await actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.COARSE);
+        await actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
 
         setTimeout(() => {
             expect(commit.mock.calls.length).toBe(2)
-
             expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
             expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
             expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)

--- a/src/app/static/src/tests/downloadResults/mutations.test.ts
+++ b/src/app/static/src/tests/downloadResults/mutations.test.ts
@@ -22,7 +22,7 @@ describe(`download results mutations`, () => {
 
     it("sets summary download started on SummaryDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SummaryBundlingStarted](state, {payload: downloadStartedPayload});
+        mutations[DownloadResultsMutation.PreparingSummaryReport](state, {payload: downloadStartedPayload});
         expect(state.summary.preparing).toBe(true);
         expect(state.summary.downloadId).toBe("P123");
         expect(state.summary.complete).toBe(false);
@@ -47,7 +47,7 @@ describe(`download results mutations`, () => {
 
     it("set summary download status update to complete on SummaryDownloadStatusUpdated", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SummaryStatusUpdated](state, {payload: CompleteStatusResponse});
+        mutations[DownloadResultsMutation.SummaryReportStatusUpdated](state, {payload: CompleteStatusResponse});
         expect(state.summary.preparing).toBe(false);
         expect(state.summary.complete).toBe(true);
         expect(state.summary.error).toBe(null);
@@ -55,7 +55,7 @@ describe(`download results mutations`, () => {
 
     it("sets spectrum download started on SpectrumDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SpectrumBundlingStarted](state, {payload: downloadStartedPayload});
+        mutations[DownloadResultsMutation.PreparingSpectrumOutput](state, {payload: downloadStartedPayload});
         expect(state.spectrum.preparing).toBe(true);
         expect(state.spectrum.downloadId).toBe("P123");
         expect(state.spectrum.complete).toBe(false);
@@ -88,7 +88,7 @@ describe(`download results mutations`, () => {
 
     it("sets coarseOutput download started on CoarseOutputDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.CoarseOutputBundlingStarted](state, {payload: downloadStartedPayload});
+        mutations[DownloadResultsMutation.PreparingCoarseOutput](state, {payload: downloadStartedPayload});
         expect(state.coarseOutput.preparing).toBe(true);
         expect(state.coarseOutput.downloadId).toBe("P123");
         expect(state.coarseOutput.complete).toBe(false);

--- a/src/app/static/src/tests/downloadResults/mutations.test.ts
+++ b/src/app/static/src/tests/downloadResults/mutations.test.ts
@@ -4,18 +4,26 @@ import {
 import {mutations} from "../../app/store/downloadResults/mutations";
 import {DownloadResultsMutation} from "../../app/store/downloadResults/mutations";
 import {DOWNLOAD_TYPE} from "../../app/store/downloadResults/downloadResults";
-import {CompleteStatusResponse, RunningStatusResponse} from "./actions.test";
+import {DownloadStatusResponse} from "../../app/generated";
 
 describe(`download results mutations`, () => {
 
     const downloadStartedPayload = {id: "P123"}
     const error = mockError("TEST FAILED")
     const errorMsg = {detail: "TEST FAILED", error: "OTHER_ERROR"}
+    const CompleteStatusResponse: DownloadStatusResponse = {
+        id: "db0c4957aea4b32c507ac02d63930110",
+        done: true,
+        progress: ["Generating summary report"],
+        status: "COMPLETE",
+        success: true,
+        queue: 0
+    }
 
     it("sets summary download started on SummaryDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SummaryDownloadStarted](state, {payload: downloadStartedPayload});
-        expect(state.summary.downloading).toBe(true);
+        mutations[DownloadResultsMutation.SummaryBundlingStarted](state, {payload: downloadStartedPayload});
+        expect(state.summary.preparing).toBe(true);
         expect(state.summary.downloadId).toBe("P123");
         expect(state.summary.complete).toBe(false);
         expect(state.summary.error).toBe(null);
@@ -24,7 +32,7 @@ describe(`download results mutations`, () => {
     it("sets summary download error on SummaryError", () => {
         const state = mockDownloadResultsState();
         mutations[DownloadResultsMutation.SummaryError](state, {payload: error});
-        expect(state.summary.downloading).toBe(false);
+        expect(state.summary.preparing).toBe(false);
         expect(state.summary.error).toEqual(errorMsg);
         expect(state.spectrum.error).toBe(null);
         expect(state.coarseOutput.error).toBe(null);
@@ -39,16 +47,16 @@ describe(`download results mutations`, () => {
 
     it("set summary download status update to complete on SummaryDownloadStatusUpdated", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SummaryDownloadStatusUpdated](state, {payload: CompleteStatusResponse});
-        expect(state.summary.downloading).toBe(false);
+        mutations[DownloadResultsMutation.SummaryStatusUpdated](state, {payload: CompleteStatusResponse});
+        expect(state.summary.preparing).toBe(false);
         expect(state.summary.complete).toBe(true);
         expect(state.summary.error).toBe(null);
     });
 
     it("sets spectrum download started on SpectrumDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SpectrumDownloadStarted](state, {payload: downloadStartedPayload});
-        expect(state.spectrum.downloading).toBe(true);
+        mutations[DownloadResultsMutation.SpectrumBundlingStarted](state, {payload: downloadStartedPayload});
+        expect(state.spectrum.preparing).toBe(true);
         expect(state.spectrum.downloadId).toBe("P123");
         expect(state.spectrum.complete).toBe(false);
         expect(state.spectrum.error).toBe(null);
@@ -57,7 +65,7 @@ describe(`download results mutations`, () => {
     it("sets spectrum download error on SpectrumError", () => {
         const state = mockDownloadResultsState();
         mutations[DownloadResultsMutation.SpectrumError](state, {payload: error});
-        expect(state.spectrum.downloading).toBe(false);
+        expect(state.spectrum.preparing).toBe(false);
         expect(state.spectrum.error).toEqual(errorMsg);
         expect(state.coarseOutput.error).toBe(null);
         expect(state.summary.error).toBe(null);
@@ -72,16 +80,16 @@ describe(`download results mutations`, () => {
 
     it("set spectrum download status update to complete on SpectrumDownloadStatusUpdated", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.SpectrumDownloadStatusUpdated](state, {payload: CompleteStatusResponse});
+        mutations[DownloadResultsMutation.SpectrumOutputStatusUpdated](state, {payload: CompleteStatusResponse});
         expect(state.spectrum.complete).toBe(true);
-        expect(state.spectrum.downloading).toBe(false);
+        expect(state.spectrum.preparing).toBe(false);
         expect(state.spectrum.error).toBe(null);
     });
 
     it("sets coarseOutput download started on CoarseOutputDownloadStarted", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.CoarseOutputDownloadStarted](state, {payload: downloadStartedPayload});
-        expect(state.coarseOutput.downloading).toBe(true);
+        mutations[DownloadResultsMutation.CoarseOutputBundlingStarted](state, {payload: downloadStartedPayload});
+        expect(state.coarseOutput.preparing).toBe(true);
         expect(state.coarseOutput.downloadId).toBe("P123");
         expect(state.coarseOutput.complete).toBe(false);
         expect(state.coarseOutput.error).toBe(null);
@@ -90,7 +98,7 @@ describe(`download results mutations`, () => {
     it("sets coarseOutput download error on CoarseOutputError", () => {
         const state = mockDownloadResultsState();
         mutations[DownloadResultsMutation.CoarseOutputError](state, {payload: error});
-        expect(state.coarseOutput.downloading).toBe(false);
+        expect(state.coarseOutput.preparing).toBe(false);
         expect(state.coarseOutput.error).toEqual(errorMsg);
         expect(state.spectrum.error).toBe(null);
         expect(state.summary.error).toBe(null);
@@ -105,9 +113,9 @@ describe(`download results mutations`, () => {
 
     it("set coarseOutput download status update to complete on CoarseOutputDownloadStatusUpdated", () => {
         const state = mockDownloadResultsState();
-        mutations[DownloadResultsMutation.CoarseOutputDownloadStatusUpdated](state, {payload: CompleteStatusResponse});
+        mutations[DownloadResultsMutation.CoarseOutputStatusUpdated](state, {payload: CompleteStatusResponse});
         expect(state.coarseOutput.complete).toBe(true);
-        expect(state.coarseOutput.downloading).toBe(false);
+        expect(state.coarseOutput.preparing).toBe(false);
         expect(state.coarseOutput.error).toBe(null);
     });
 

--- a/src/app/static/src/tests/integration/downloadResults.itest.ts
+++ b/src/app/static/src/tests/integration/downloadResults.itest.ts
@@ -6,7 +6,7 @@ import {
 
 describe(`download results actions integration`, () => {
 
-    it(`can send summary download request`, async () => {
+    it(`can prepare summary report for download`, async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {
@@ -14,7 +14,7 @@ describe(`download results actions integration`, () => {
             modelCalibrate: {calibrateId: "calibrate123"}
         };
 
-        await actions.downloadSummary({commit, dispatch, rootState: root} as any);
+        await actions.prepareSummaryReport({commit, dispatch, rootState: root} as any);
 
         // passing an invalid calibrateId so this will return an error
         // but the expected error message confirms
@@ -24,7 +24,7 @@ describe(`download results actions integration`, () => {
         expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll summary download for status update`, async (done) => {
+    it(`can poll summary report for status update`, async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {
@@ -49,7 +49,7 @@ describe(`download results actions integration`, () => {
         }, 3100)
     })
 
-    it(`can send spectrum download request`, async () => {
+    it(`can prepare spectrum output for download`, async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {
@@ -57,14 +57,14 @@ describe(`download results actions integration`, () => {
             modelCalibrate: {calibrateId: "calibrate123"}
         };
 
-        await actions.downloadSpectrum({commit, dispatch, rootState: root} as any);
+        await actions.prepareSpectrumOutput({commit, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]["type"]).toBe("SpectrumError");
         expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll spectrum download for status update`, async (done) => {
+    it(`can poll spectrum output for status update`, async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {
@@ -89,7 +89,7 @@ describe(`download results actions integration`, () => {
         }, 3100)
     })
 
-    it(`can send coarseOutput download request`, async () => {
+    it(`can prepare coarse output for download`, async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {
@@ -97,14 +97,14 @@ describe(`download results actions integration`, () => {
             modelCalibrate: {calibrateId: "calibrate123"}
         };
 
-        await actions.downloadCoarseOutput({commit, dispatch, rootState: root} as any);
+        await actions.prepareCoarseOutput({commit, dispatch, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]["type"]).toBe("CoarseOutputError");
         expect(commit.mock.calls[0][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll coarseOutput download for status update`, async (done) => {
+    it(`can poll coarseOutput for status update`, async (done) => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -36,7 +36,7 @@ import {
 } from "../app/store/plottingSelections/plottingSelections";
 import {ErrorsState, initialErrorsState} from "../app/store/errors/errors";
 import {ColourScalesState, initialColourScalesState} from "../app/store/plottingSelections/plottingSelections";
-import {Dataset, DatasetResource, Release} from "../app/types";
+import {Dataset, DatasetResource, DownloadResultsDependency, Release} from "../app/types";
 import {initialProjectsState, ProjectsState} from "../app/store/projects/projects";
 import {initialModelCalibrateState, ModelCalibrateState} from "../app/store/modelCalibrate/modelCalibrate";
 import { HintrVersionState, initialHintrVersionState } from "../app/store/hintrVersion/hintrVersion";
@@ -444,3 +444,14 @@ export const mockWarning = (props: Partial<Warning> = {}): Warning => {
         ...props
     };
 };
+
+export const mockDownloadResultsDependency = (props: Partial<DownloadResultsDependency> = {}): DownloadResultsDependency => {
+    return {
+        downloadId: "",
+        preparing: false,
+        statusPollId: -1,
+        complete: false,
+        error: null,
+        ...props
+    }
+}


### PR DESCRIPTION
## Description

This PR just renames some methods and properties, fixes some type definitions, and adds a mock helper to the tests. This is ahead of some restructuring of the download logic (since the restructure is going to be a fairly large changeset, making these minor changes first to make the subsequent diff more reviewable.)

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
