### PR TITLE
Replace ART with TARV in French strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.90.4
+
+* Replace 'ART' with 'TARV' in French strings
+
 # hint 1.90.3
 
 * Make hintr warnings dismissable

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
-export const currentHintVersion = "1.90.3";
+export const currentHintVersion = "1.90.4";
 

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -609,7 +609,7 @@ const fr: Partial<Translations> = {
     apiCouldNotParseError: "Impossible d'analyser la réponse de l'API. Veuillez contacter le support.",
     apiMissingError: "La réponse de l'API a échoué mais ne contenait aucune information d'erreur. Veuillez contacter le support.",
     area: "Zone",
-    ART: "ART",
+    ART: "TARV",
     axe: "Accessibilité",
     axeOnNaomiHeading: "Accessibilité sur Naomi",
     axeOnNaomiParagraph1: "Cette déclaration s’applique au contenu publié sur <a href=\"https://naomi.unaids.org/\" target='_blank' rel='noopener noreferrer'> naomi.unaids.org </a>",

--- a/src/app/static/src/tests/components/genericChart/dataSelectors/dataSource.test.ts
+++ b/src/app/static/src/tests/components/genericChart/dataSelectors/dataSource.test.ts
@@ -36,7 +36,7 @@ describe("DataSource component", () => {
             "Teste da CPN", wrapper.vm.$store);
 
         expect(options.at(1).attributes("value")).toBe("dataset2");
-        expectTranslated(options.at(1), "ART", "ART", "TARV", wrapper.vm.$store);
+        expectTranslated(options.at(1), "ART", "TARV", "TARV", wrapper.vm.$store);
     });
 
     it("emits update when value changes", async () => {

--- a/src/app/static/src/tests/components/reviewInputs/reviewInputs.test.ts
+++ b/src/app/static/src/tests/components/reviewInputs/reviewInputs.test.ts
@@ -292,7 +292,7 @@ describe("Survey and programme component", () => {
 
     it("programme (ART) is included in data sources when programme data is present", () => {
         expectDataSource({program: mockProgramResponse(), selectedDataType: DataType.Program},
-            "ART", "ART", "TARV", "1");
+            "ART", "TARV", "TARV", "1");
     });
 
     it("ANC is included in data sources when ANC data is present", () => {


### PR DESCRIPTION
## Description

Ian has requested we replace ART with TARV in French & Portuguese strings. This PR replaces the only occurrence of that I can find in this repo.

Equivalent PRs in
* naomi - https://github.com/mrc-ide/naomi/pull/304
* hintr - https://github.com/mrc-ide/hintr/pull/360

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
