### PR TITLE
mrc-2997 Revert hintr version to master

### DIFF
--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-mrc-2918
+master


### PR DESCRIPTION
## Description

I overenthusiastically merged https://github.com/mrc-ide/hint/pull/683 without reverting hintr version to master, so making that change here. I've checked that targeting hintr master, which does not return warnings with Input Time Series data, works correctly with no errors. 

## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
