### PR TITLE
mrc-3111 Avoid mocking FuelManager instance client

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -40,7 +40,7 @@ abstract class FuelClient(protected val baseUrl: String)
                 .asResponseEntity()
     }
 
-    protected fun postJson(urlPath: String?, json: String): ResponseEntity<String>
+    protected open fun postJson(urlPath: String?, json: String): ResponseEntity<String>
     {
         val url = if (urlPath === null)
         {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
@@ -1,0 +1,98 @@
+package org.imperial.mrc.hint.unit.clients
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions
+import org.imperial.mrc.hint.AppProperties
+import org.imperial.mrc.hint.clients.FuelFlowClient
+import org.imperial.mrc.hint.models.ErrorReport
+import org.imperial.mrc.hint.models.Errors
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+
+class FuelFlowClientTests
+{
+    private val data = ErrorReport(
+            "test.user@example.com",
+            "Kenya",
+            "Kenya2022",
+            "Model",
+            "123",
+            "1234",
+            mapOf("spectrum" to "spectrum123", "summary" to "summary123", "coarse_output" to "coarse123" ),
+            listOf(
+                    Errors("#65ae0d095ea", "test error msg", "fomot-hasah-livad"),
+                    Errors("#25ae0d095e1", "test error msg2", "fomot-hasah-livid")
+            ),
+            "",
+            "test steps",
+            "test agent",
+            mapOf(
+                    "naomi" to "v1",
+                    "hintr" to "v2",
+                    "rrq" to "v3",
+                    "traduire" to "v4",
+                    "hint" to "v5"
+            ),
+            "2021-10-12T14:07:22.759Z"
+    )
+
+    @Test
+    fun `can serialize request body`()
+    {
+        class LocalFuelFlowClient(objectMapper: ObjectMapper,
+                                  appProperties: AppProperties
+        ): FuelFlowClient(objectMapper, appProperties)
+        {
+            var urlPathCapture: String? = null
+            var jsonCapture: String? = null
+
+            override fun postJson(urlPath: String?, json:String): ResponseEntity<String>
+            {
+                urlPathCapture = urlPath
+                jsonCapture = json
+                return mock()
+            }
+        }
+
+        val mockAppProperties = mock<AppProperties>{
+            on { issueReportUrl } doReturn "http://testreport.com"
+        }
+
+        val sut = LocalFuelFlowClient(ObjectMapper(), mockAppProperties)
+
+        sut.notifyTeams(data)
+
+        Assertions.assertThat(sut.urlPathCapture).isNull()
+
+        val requestJson = ObjectMapper().readValue<JsonNode>(sut.jsonCapture!!)
+
+        Assertions.assertThat(requestJson["email"].asText()).isEqualTo("test.user@example.com")
+        Assertions.assertThat(requestJson["country"].asText()).isEqualTo("Kenya")
+        Assertions.assertThat(requestJson["projectName"].asText()).isEqualTo("Kenya2022")
+        Assertions.assertThat(requestJson["section"].asText()).isEqualTo("Model")
+        Assertions.assertThat(requestJson["modelRunId"].asText()).isEqualTo("123")
+        Assertions.assertThat(requestJson["calibrateId"].asText()).isEqualTo("1234")
+        Assertions.assertThat(requestJson["downloadIds"]["spectrum"].asText()).isEqualTo("spectrum123")
+        Assertions.assertThat(requestJson["downloadIds"]["summary"].asText()).isEqualTo("summary123")
+        Assertions.assertThat(requestJson["downloadIds"]["coarse_output"].asText()).isEqualTo("coarse123")
+        Assertions.assertThat(requestJson["errors"][0]["key"].asText()).isEqualTo("fomot-hasah-livad")
+        Assertions.assertThat(requestJson["errors"][0]["error"].asText()).isEqualTo("test error msg")
+        Assertions.assertThat(requestJson["errors"][0]["detail"].asText()).isEqualTo("#65ae0d095ea")
+        Assertions.assertThat(requestJson["errors"][1]["key"].asText()).isEqualTo("fomot-hasah-livid")
+        Assertions.assertThat(requestJson["errors"][1]["error"].asText()).isEqualTo("test error msg2")
+        Assertions.assertThat(requestJson["errors"][1]["detail"].asText()).isEqualTo("#25ae0d095e1")
+        Assertions.assertThat(requestJson["description"].asText()).isEqualTo("")
+        Assertions.assertThat(requestJson["stepsToReproduce"].asText()).isEqualTo("test steps")
+        Assertions.assertThat(requestJson["browserAgent"].asText()).isEqualTo("test agent")
+        Assertions.assertThat(requestJson["versions"]["naomi"].asText()).isEqualTo("v1")
+        Assertions.assertThat(requestJson["versions"]["hintr"].asText()).isEqualTo("v2")
+        Assertions.assertThat(requestJson["versions"]["rrq"].asText()).isEqualTo("v3")
+        Assertions.assertThat(requestJson["versions"]["traduire"].asText()).isEqualTo("v4")
+        Assertions.assertThat(requestJson["versions"]["hint"].asText()).isEqualTo("v5")
+        Assertions.assertThat(requestJson["timeStamp"].asText()).isEqualTo("2021-10-12T14:07:22.759Z")
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ErrorReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ErrorReportControllerTests.kt
@@ -1,24 +1,13 @@
 package org.imperial.mrc.hint.unit.controllers
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.kittinunf.fuel.core.Client
-import com.github.kittinunf.fuel.core.FuelManager
-import com.github.kittinunf.fuel.core.Response
-import com.github.kittinunf.fuel.core.requests.DefaultBody
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
-import org.imperial.mrc.hint.ConfiguredAppProperties
 import org.imperial.mrc.hint.clients.FuelFlowClient
 import org.imperial.mrc.hint.controllers.ErrorReportController
-import org.imperial.mrc.hint.helpers.readPropsFromTempFile
-
 import org.imperial.mrc.hint.models.ErrorReport
 import org.imperial.mrc.hint.models.Errors
 import org.junit.jupiter.api.Test
 import org.springframework.http.*
-import java.net.URL
 
 class ErrorReportControllerTests
 {
@@ -64,55 +53,6 @@ class ErrorReportControllerTests
         val result = testFlowClient(ResponseEntity.badRequest().build())
 
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-    }
-
-    @Test
-    fun `can serialize request body`()
-    {
-        val client = mock<Client> {
-            onGeneric { executeRequest(any()) } doReturn
-                    Response(statusCode = 200, body = DefaultBody(), url = URL("http://a.com"))
-        }
-        FuelManager.instance.client = client
-
-        val sut = ErrorReportController(FuelFlowClient(ObjectMapper(),
-                ConfiguredAppProperties(readPropsFromTempFile("issue_report_url=http://flow.com"))))
-
-        sut.postErrorReport(data)
-
-        verify(client).executeRequest(check {
-
-            assertThat(it.url.toString()).isEqualTo("http://flow.com")
-
-            assertThat(it.header("Content-Type")).isEqualTo(listOf("application/json"))
-
-            val response = ObjectMapper().readValue<JsonNode>(it.body.asString("application/json"))
-
-            assertThat(response["email"].asText()).isEqualTo("test.user@example.com")
-            assertThat(response["country"].asText()).isEqualTo("Kenya")
-            assertThat(response["projectName"].asText()).isEqualTo("Kenya2022")
-            assertThat(response["section"].asText()).isEqualTo("Model")
-            assertThat(response["modelRunId"].asText()).isEqualTo("123")
-            assertThat(response["calibrateId"].asText()).isEqualTo("1234")
-            assertThat(response["downloadIds"]["spectrum"].asText()).isEqualTo("spectrum123")
-            assertThat(response["downloadIds"]["summary"].asText()).isEqualTo("summary123")
-            assertThat(response["downloadIds"]["coarse_output"].asText()).isEqualTo("coarse123")
-            assertThat(response["errors"][0]["key"].asText()).isEqualTo("fomot-hasah-livad")
-            assertThat(response["errors"][0]["error"].asText()).isEqualTo("test error msg")
-            assertThat(response["errors"][0]["detail"].asText()).isEqualTo("#65ae0d095ea")
-            assertThat(response["errors"][1]["key"].asText()).isEqualTo("fomot-hasah-livid")
-            assertThat(response["errors"][1]["error"].asText()).isEqualTo("test error msg2")
-            assertThat(response["errors"][1]["detail"].asText()).isEqualTo("#25ae0d095e1")
-            assertThat(response["description"].asText()).isEqualTo("")
-            assertThat(response["stepsToReproduce"].asText()).isEqualTo("test steps")
-            assertThat(response["browserAgent"].asText()).isEqualTo("test agent")
-            assertThat(response["versions"]["naomi"].asText()).isEqualTo("v1")
-            assertThat(response["versions"]["hintr"].asText()).isEqualTo("v2")
-            assertThat(response["versions"]["rrq"].asText()).isEqualTo("v3")
-            assertThat(response["versions"]["traduire"].asText()).isEqualTo("v4")
-            assertThat(response["versions"]["hint"].asText()).isEqualTo("v5")
-            assertThat(response["timeStamp"].asText()).isEqualTo("2021-10-12T14:07:22.759Z")
-        })
     }
 
     private fun testFlowClient(response: ResponseEntity<String>): ResponseEntity<String>


### PR DESCRIPTION
## Description

Intermittent test failures appeared to be caused by the ErrorReportController unit test `can serialize request body`, because it mocks the FuelManager client instance, and this mock is not cleared for subsequent tests (see ticket mrc-3111). 

To avoid this, I moved the serialization test from ErrorReportControllerTests to a new unit test class for the FuelFlowClient, since that is where the serialization actually happens. Essentially, we just want to test that the client serializes the ErrorReport object to the expected json. The remaining ErrorReportControllerTests already implicitly check that `notifyTeams` is invoked from the controller, in the set-up of testFlowClient: https://github.com/mrc-ide/hint/blob/master/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ErrorReportControllerTests.kt#L122 

The client's basic functionality is tested already in an integration test class, so this test is just checking the serialization part implemented within the `notifyTeams` method, not that the json is subsequently posted as expected. 

My first idea was to spy on the sut's `postJson` method and check that it called that method on itself with the expected json string. However, because the method is protected, spy will not work. So instead I created a subclass of the client class for testing purposes, which overrides the `postJson` method and captures the parameters which can then be verified. 

To enable this, I had to mark `postJson` in the client class as `open` - I think this is less of a code smell than opening it up from protected to public in order to test. 


## Type of version change
_Delete as appropriate_

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
