### PR TITLE
Mrc 3073 - HINT endpoints for comparison report

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.97.0
+
+* HINT endpoints for comparison report
+
 # hint 1.96.0
 
 * Display warnings from input validation 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -40,6 +40,7 @@ interface HintrAPIClient
     fun downloadOutputStatus(id: String): ResponseEntity<String>
     fun downloadOutputResult(id: String): ResponseEntity<StreamingResponseBody>
     fun getUploadMetadata(id: String): ResponseEntity<String>
+    fun downloadComparisonResult(id: String): ResponseEntity<StreamingResponseBody>
 }
 
 @Component
@@ -211,5 +212,12 @@ class HintrFuelAPIClient(
                 mapOf("data" to files))
 
         return postJson("chart-data/input-time-series/$type", json)
+    }
+
+    override fun downloadComparisonResult(id: String): ResponseEntity<StreamingResponseBody>
+    {
+        return "$baseUrl/submit/status/result/${id}"
+                .httpDownload()
+                .getStreamingResponseEntity(::head)
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/DownloadController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/DownloadController.kt
@@ -30,4 +30,11 @@ class DownloadController(val apiClient: HintrAPIClient)
     {
         return apiClient.downloadOutputResult(id)
     }
+
+    @GetMapping("/submit/status/result/{id}")
+    @ResponseBody
+    fun getComparisonResult(@PathVariable("id") id: String): ResponseEntity<StreamingResponseBody>
+    {
+        return apiClient.downloadComparisonResult(id)
+    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
@@ -88,8 +88,7 @@ class DownloadTests : SecureIntegrationTests()
     {
         val modelId = waitForModelRunResult()
         val calibrateId = waitForCalibrationResult(modelId)
-        val responseId = waitForSubmitDownloadOutput(calibrateId, "spectrum")
-        val responseEntity = testRestTemplate.getForEntity<ByteArray>("/download/submit/status/result/$responseId")
+        val responseEntity = testRestTemplate.getForEntity<ByteArray>("/download/submit/status/result/$calibrateId")
         assertSuccess(responseEntity)
         assertResponseHasExpectedDownloadHeaders(responseEntity)
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DownloadTests.kt
@@ -83,6 +83,17 @@ class DownloadTests : SecureIntegrationTests()
         assertSuccess(responseEntity, "DownloadStatusResponse")
     }
 
+    @Test
+    fun `can download comparison result`()
+    {
+        val modelId = waitForModelRunResult()
+        val calibrateId = waitForCalibrationResult(modelId)
+        val responseId = waitForSubmitDownloadOutput(calibrateId, "spectrum")
+        val responseEntity = testRestTemplate.getForEntity<ByteArray>("/download/submit/status/result/$responseId")
+        assertSuccess(responseEntity)
+        assertResponseHasExpectedDownloadHeaders(responseEntity)
+    }
+
     fun assertResponseHasExpectedDownloadHeaders(response: ResponseEntity<ByteArray>)
     {
         val headers = response.headers

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DownloadControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DownloadControllerTests.kt
@@ -76,4 +76,18 @@ class DownloadControllerTests
         val result = sut.getDownloadOutputResult("id1")
         Assertions.assertThat(result).isSameAs(mockResponse)
     }
+
+    @Test
+    fun `can get comparison result`()
+    {
+        val mockResponse = mock<ResponseEntity<StreamingResponseBody>>()
+        val mockApiClient = mock<HintrAPIClient>
+        {
+            on { downloadComparisonResult("id1") } doReturn mockResponse
+        }
+
+        val sut = DownloadController(mockApiClient)
+        val result = sut.getComparisonResult("id1")
+        Assertions.assertThat(result).isSameAs(mockResponse)
+    }
 }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "1.96.0";
+export const currentHintVersion = "1.97.0";

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-master
+mrc-3072


### PR DESCRIPTION
This PR adds GET /download/submit/status/result/{calibrateId} endpoint for comparison result

## Type of version change
Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
