### PR TITLE
Mrc 3192 Input data warnings are not persisted/displayed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hint 2.0.0
+# hint 1.99.1
 
 * Input data warnings are not persisted/displayed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.0.0
+
+* Input data warnings are not persisted/displayed
+
 # hint 1.99.0
 
 * Download comparison report

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,1 @@
-
-export const currentHintVersion = "1.99.1";
+export const currentHintVersion = "1.99.2";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "2.0.0";
+export const currentHintVersion = "1.99.1";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.99.0";
+export const currentHintVersion = "2.0.0";

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -12,7 +12,10 @@ export const serialiseState = (state: DataExplorationState): Partial<RootState> 
         selectedDataset: state.baseline.selectedDataset,
         selectedRelease: state.baseline.selectedRelease
     } as any;
-    const surveyAndProgram = {selectedDataType: state.surveyAndProgram.selectedDataType} as any;
+    const surveyAndProgram = {
+        selectedDataType: state.surveyAndProgram.selectedDataType,
+        warnings: state.surveyAndProgram.warnings
+    } as any;
     const metadata =  {...state.metadata, plottingMetadataError: null};
     const plottingSelections = state.plottingSelections;
     if (state.dataExplorationMode) {

--- a/src/app/static/src/tests/components/header/fileMenu.test.ts
+++ b/src/app/static/src/tests/components/header/fileMenu.test.ts
@@ -7,7 +7,7 @@ import {
     mockError,
     mockFile,
     mockLoadState,
-    mockMetadataState, mockModelCalibrateState,
+    mockMetadataState,
     mockModelRunState,
     mockPJNZResponse,
     mockPopulationResponse,
@@ -116,7 +116,7 @@ describe("File menu", () => {
                 modelRun: mockModelRunState(),
                 modelCalibrate: {result: null, calibratePlotResult: null},
                 metadata: mockMetadataState(),
-                surveyAndProgram: {selectedDataType: null},
+                surveyAndProgram: {selectedDataType: null, warnings: []},
                 language: Language.en
             },
             files: {

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -89,7 +89,10 @@ describe("LocalStorageManager", () => {
             stepper: mockStepperState(),
             metadata: mockMetadataState({plottingMetadataError: mockError("metadataError")}),
             plottingSelections: mockPlottingSelections(),
-            surveyAndProgram: mockSurveyAndProgramState({selectedDataType: DataType.Survey}),
+            surveyAndProgram: mockSurveyAndProgramState({
+                selectedDataType: DataType.Survey,
+                warnings: [{text: "test warning", locations: ["review_inputs"]}]
+            }),
             projects: mockProjectsState(),
             hintrVersion: mockHintrVersionState(),
             errors: mockErrorsState(),
@@ -110,7 +113,10 @@ describe("LocalStorageManager", () => {
             stepper: mockStepperState(),
             metadata: mockMetadataState(),
             plottingSelections: mockPlottingSelections(),
-            surveyAndProgram: {selectedDataType: DataType.Survey},
+            surveyAndProgram: {
+                selectedDataType: DataType.Survey,
+                warnings: [{text: "test warning", locations: ["review_inputs"]}]
+            },
             hintrVersion: mockHintrVersionState(),
             language: Language.en
         });
@@ -134,7 +140,10 @@ describe("LocalStorageManager", () => {
                 selectedRelease: release
             }) ,
             metadata: mockMetadataState(),
-            surveyAndProgram: {selectedDataType: DataType.Survey},
+            surveyAndProgram: {
+                selectedDataType: DataType.Survey,
+                warnings: [{text: "test warning", locations: ["review_inputs"]}]
+            },
             plottingSelections: mockPlottingSelections(),
             errors: mockErrorsState(),
             stepper: mockStepperState()
@@ -148,7 +157,10 @@ describe("LocalStorageManager", () => {
             },
             metadata: mockMetadataState(),
             plottingSelections: mockPlottingSelections(),
-            surveyAndProgram: {selectedDataType: DataType.Survey},
+            surveyAndProgram: {
+                selectedDataType: DataType.Survey,
+                warnings: [{text: "test warning", locations: ["review_inputs"]}]
+            },
             hintrVersion: mockHintrVersionState(),
             stepper: mockStepperState(),
             language: Language.en


### PR DESCRIPTION
PR persist Input Review warnings in local storage.

Test
* Reload page, warnings are still displayed.

## Type of version change

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
