### PR TITLE
mrc-3205 Bug fix - app timeout when using large dataset before completing a request.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 1.99.1
+
+* Bug fix - app timeout when using large dataset before completing a request.
+
 # hint 1.99.0
 
 * Download comparison report

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -15,7 +15,7 @@ abstract class FuelClient(protected val baseUrl: String)
 
     companion object
     {
-        private const val TIMEOUT = 60000
+        private const val TIMEOUT = 120000
     }
 
     abstract fun standardHeaders(): Map<String, Any>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,2 +1,2 @@
 
-export const currentHintVersion = "1.99.0";
+export const currentHintVersion = "1.99.1";


### PR DESCRIPTION
## Description

This PR increases timeout from 1min to 2 mins. Nigeria HIV estimates 2022 dataset now loads successfully. 

## Type of version change

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
