### PR TITLE
mrc-3297 Fix bug backwards compatibility calibrate options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.1.2
+
+* Bug: Fix bug backwards compatibility calibrate options
+
 # hint 2.1.1
 
 * Bug: hint tries to pull resources it does not have access to

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.1.1";
+export const currentHintVersion = "2.1.2";

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -89,9 +89,9 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
     },
 
     async updateStoreState({commit, dispatch, state}, savedState) {
-        //File hashes have now been set for session in backend so we save the state from the file we're loading into local
+        //File hashes have now been set for session in backend, so we save the state from the file we're loading into local
         //storage then reload the page, to follow exactly the same fetch and reload procedure as session page refresh
-        //NB load state is not included in the saved state so we will default back to NotLoading on page reload.
+        //NB load state is not included in the saved state, so we will default back to NotLoading on page reload.
 
         // Backwards compatibility fix: projects which calibrated before bug fix in mrc-3126 have empty calibrate options
         const {modelCalibrate} = savedState

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -9,7 +9,7 @@ import {router} from "../../router";
 import {currentHintVersion} from "../../hintVersion";
 import {initialStepperState} from "../stepper/stepper";
 import {ModelCalibrateState} from "../modelCalibrate/modelCalibrate";
-import {DynamicFormData} from "@reside-ic/vue-dynamic-form";
+import {DynamicControlGroup, DynamicControlSection, DynamicFormData} from "@reside-ic/vue-dynamic-form";
 
 export type LoadActionTypes = "SettingFiles" | "UpdatingState" | "LoadSucceeded" | "ClearLoadError"
 export type LoadErrorActionTypes = "LoadFailed"
@@ -93,8 +93,9 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
         //storage then reload the page, to follow exactly the same fetch and reload procedure as session page refresh
         //NB load state is not included in the saved state so we will default back to NotLoading on page reload.
 
+        // Backwards compatibility fix: projects which calibrated before bug fix in mrc-3126 have empty calibrate options
         const {modelCalibrate} = savedState
-        if (modelCalibrate && Object.keys(modelCalibrate.options).length === 0) {
+        if (modelCalibrate && Object.keys(modelCalibrate.options).length === 0 && modelCalibrate.result) {
             savedState = {
                 ...savedState,
                 modelCalibrate: {...modelCalibrate, options: getCalibrateOptions(modelCalibrate)}
@@ -127,13 +128,15 @@ async function getFilesAndLoad(context: ActionContext<LoadState, RootState>, fil
 // getCalibrateOptions extracts calibrate options from Dynamic Form, this allows
 // backward compatibility supports for calibrate option bug
 const getCalibrateOptions = (modelCalibrate: ModelCalibrateState): DynamicFormData => {
-    const section = modelCalibrate.optionsFormMeta.controlSections.find(section => section.controlGroups)
-    return section?.controlGroups
-        .reduce((options: DynamicFormData, option): DynamicFormData => {
-            option.controls.forEach(option => {
-                const name = option.name
-                options[name] = option.value || null
-            })
-            return options
-        }, {}) || {}
+    const allControlGroups = flatMapControlSection(modelCalibrate.optionsFormMeta.controlSections);
+    return allControlGroups.reduce<DynamicFormData>((options, option): DynamicFormData => {
+        option.controls.forEach(option => {
+            options[option.name] = option.value || null
+        })
+        return options
+    }, {}) || {}
+}
+
+const flatMapControlSection = (sections: DynamicControlSection[]) => {
+    return sections.reduce<DynamicControlGroup[]>((groups, group) => groups.concat(group.controlGroups), [])
 }

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -134,7 +134,7 @@ const getCalibrateOptions = (modelCalibrate: ModelCalibrateState): DynamicFormDa
             options[option.name] = option.value || null
         })
         return options
-    }, {}) || {}
+    }, {})
 }
 
 const flatMapControlSection = (sections: DynamicControlSection[]) => {

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -92,7 +92,6 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
         //File hashes have now been set for session in backend so we save the state from the file we're loading into local
         //storage then reload the page, to follow exactly the same fetch and reload procedure as session page refresh
         //NB load state is not included in the saved state so we will default back to NotLoading on page reload.
-        //let states: Partial<RootState> = {}
 
         const {modelCalibrate} = savedState
         if (modelCalibrate && Object.keys(modelCalibrate.options).length === 0) {
@@ -104,7 +103,6 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
 
         localStorageManager.savePartialState(savedState, false);
         location.reload();
-
     },
 
     async clearLoadState({commit}) {

--- a/src/app/static/src/app/store/load/actions.ts
+++ b/src/app/static/src/app/store/load/actions.ts
@@ -95,7 +95,7 @@ export const actions: ActionTree<LoadState, RootState> & LoadActions = {
 
         // Backwards compatibility fix: projects which calibrated before bug fix in mrc-3126 have empty calibrate options
         const {modelCalibrate} = savedState
-        if (modelCalibrate && Object.keys(modelCalibrate.options).length === 0 && modelCalibrate.result) {
+        if (modelCalibrate?.result && Object.keys(modelCalibrate.options).length === 0) {
             savedState = {
                 ...savedState,
                 modelCalibrate: {...modelCalibrate, options: getCalibrateOptions(modelCalibrate)}

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -59,7 +59,7 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
                 id: rootState.modelRun.modelRunId
             },
             calibrate: {
-                options: getCalibrateOptions(rootState.modelCalibrate) || {},
+                options: rootState.modelCalibrate.options || {},
                 id: rootState.modelCalibrate.calibrateId
             },
             version: rootState.hintrVersion.hintrVersion as VersionInfo
@@ -120,20 +120,3 @@ const allReviewInputsWarnings = (state: RootState) => {
     return [...sapWarnings, ...genericChartWarnings]
 }
 
-// getCalibrateOptions extracts calibrate options from Dynamic Form, this allows
-// backward compatibility supports with for rehydrating of calibrate option
-const getCalibrateOptions = (modelCalibrate: ModelCalibrateState): DynamicFormData => {
-    if (Object.keys(modelCalibrate.options).length) {
-        return modelCalibrate.options
-    }
-
-    const section = modelCalibrate.optionsFormMeta.controlSections.find(section => section.controlGroups)
-    return section?.controlGroups
-        .reduce((options: DynamicFormData, option): DynamicFormData => {
-            option.controls.forEach(option => {
-                const name = option.name
-                options[name] = option.value || null
-            })
-            return options
-        }, {}) || {}
-}

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -123,22 +123,22 @@ const allReviewInputsWarnings = (state: RootState) => {
 // getCalibrateOptions extracts calibrate options from Dynamic Form, this allows
 // backward compatibility supports with for rehydrating of calibrate option
 const getCalibrateOptions = (modelCalibrate: ModelCalibrateState): DynamicFormData => {
-    const section = modelCalibrate.optionsFormMeta.controlSections.find(section => section.controlGroups)
-
-    if (!section) {
+    if (Object.keys(modelCalibrate.options).length) {
         return modelCalibrate.options
     }
 
-    const extractedOptions = section.controlGroups
+    const section = modelCalibrate.optionsFormMeta.controlSections.find(section => section.controlGroups)
+
+    if (!section) {
+        return {}
+    }
+
+    return section.controlGroups
         .reduce((options: DynamicFormData, option): DynamicFormData => {
             option.controls.forEach(option => {
                 const name = option.name
-                if (name) {
-                    options[name] = option.value || null
-                }
+                options[name] = option.value || null
             })
             return options
         }, {})
-
-    return Object.keys(modelCalibrate.options).length ? modelCalibrate.options : extractedOptions
 }

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -128,17 +128,12 @@ const getCalibrateOptions = (modelCalibrate: ModelCalibrateState): DynamicFormDa
     }
 
     const section = modelCalibrate.optionsFormMeta.controlSections.find(section => section.controlGroups)
-
-    if (!section) {
-        return {}
-    }
-
-    return section.controlGroups
+    return section?.controlGroups
         .reduce((options: DynamicFormData, option): DynamicFormData => {
             option.controls.forEach(option => {
                 const name = option.name
                 options[name] = option.value || null
             })
             return options
-        }, {})
+        }, {}) || {}
 }

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -1,12 +1,12 @@
 import Vuex, {Store} from "vuex";
-import {mockError, mockModelCalibrateState, mockRootState} from "../../mocks";
+import {mockError, mockModelCalibrateState, mockOptionsFormMeta, mockRootState} from "../../mocks";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {RootState} from "../../../app/root";
 import {ModelCalibrateState} from "../../../app/store/modelCalibrate/modelCalibrate";
 import {mount, shallowMount} from "@vue/test-utils";
 import ModelCalibrate from "../../../app/components/modelCalibrate/ModelCalibrate.vue";
 import CalibrationResults from "../../../app/components/modelCalibrate/CalibrationResults.vue";
-import {DynamicControlType, DynamicForm} from "@reside-ic/vue-dynamic-form";
+import {DynamicForm} from "@reside-ic/vue-dynamic-form";
 import LoadingSpinner from "../../../app/components/LoadingSpinner.vue";
 import {expectTranslated} from "../../testHelpers";
 import Tick from "../../../app/components/Tick.vue";
@@ -41,22 +41,6 @@ describe("Model calibrate component", () => {
         return shallowMount(ModelCalibrate, {store});
     };
 
-    const mockOptionsFormMeta = {
-        controlSections: [{
-            label: "Test Section",
-            description: "Just a test section",
-            controlGroups: [{
-                controls: [{
-                    name: "TestValue",
-                    type: "number" as DynamicControlType,
-                    required: false,
-                    min: 0,
-                    max: 10,
-                    value: 5
-                }]
-            }]
-        }]
-    };
 
     it("renders as expected when loading", () => {
         const store = getStore({fetching: true});
@@ -79,7 +63,7 @@ describe("Model calibrate component", () => {
     });
 
     it("renders options as expected", () => {
-        const store = getStore({optionsFormMeta: mockOptionsFormMeta});
+        const store = getStore({optionsFormMeta: mockOptionsFormMeta()});
         const wrapper = mount(ModelCalibrate, {store});
 
         expect(wrapper.find(LoadingSpinner).exists()).toBe(false);
@@ -150,7 +134,7 @@ describe("Model calibrate component", () => {
 
     it("setting options value commits update mutation", () => {
         const mockUpdate = jest.fn();
-        const store = getStore({optionsFormMeta: mockOptionsFormMeta}, jest.fn(), jest.fn(), mockUpdate);
+        const store = getStore({optionsFormMeta: mockOptionsFormMeta()}, jest.fn(), jest.fn(), mockUpdate);
         const wrapper = mount(ModelCalibrate, {store});
 
         wrapper.find(DynamicForm).find("input").setValue("6");
@@ -161,7 +145,7 @@ describe("Model calibrate component", () => {
 
     it("clicking Calibrate button invokes submit calibrate action", () => {
         const mockSubmit = jest.fn();
-        const store = getStore({optionsFormMeta: mockOptionsFormMeta}, jest.fn(), mockSubmit);
+        const store = getStore({optionsFormMeta: mockOptionsFormMeta()}, jest.fn(), mockSubmit);
         const wrapper = mount(ModelCalibrate, {store});
         wrapper.find("button").trigger("click");
         expect(mockSubmit.mock.calls.length).toBe(1);

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -1,5 +1,5 @@
 import {
-    mockAxios,
+    mockAxios, mockCalibrateResultResponse,
     mockError,
     mockFailure,
     mockLoadState, mockModelCalibrateState,
@@ -410,6 +410,7 @@ describe("Load actions", () => {
 
         const testState = mockRootState({
             modelCalibrate: mockModelCalibrateState({
+                result: mockCalibrateResultResponse(),
                 optionsFormMeta: mockOptionsFormMeta({
                     controlSections: [{
                         label: "Test Section",
@@ -443,6 +444,52 @@ describe("Load actions", () => {
 
         const root = mockSaveToLocalStorage.mock.calls[0][0] as RootState
         expect(root.modelCalibrate.options).toStrictEqual({"TestValue": 5, "TestValue2": 6});
+        expect(mockLocationReload.mock.calls.length).toBe(1);
+    });
+
+    it("does not extracts calibrate options from dynamicFormMeta if model has not been calibrated", async () => {
+        const mockSaveToLocalStorage = jest.fn();
+        localStorageManager.savePartialState = mockSaveToLocalStorage;
+
+        const mockLocationReload = jest.fn();
+        delete window.location;
+        window.location = {reload: mockLocationReload} as any;
+
+        const testState = mockRootState({
+            modelCalibrate: mockModelCalibrateState({
+                optionsFormMeta: mockOptionsFormMeta({
+                    controlSections: [{
+                        label: "Test Section",
+                        description: "Just a test section",
+                        controlGroups: [{
+                            controls: [
+                                {
+                                    name: "TestValue",
+                                    type: "number" as DynamicControlType,
+                                    required: false,
+                                    min: 0,
+                                    max: 10,
+                                    value: 5
+                                },
+                                {
+                                    name: "TestValue2",
+                                    type: "number" as DynamicControlType,
+                                    required: false,
+                                    min: 0,
+                                    max: 10,
+                                    value: 6
+                                }
+                            ]
+                        }]
+                    }]
+                })
+            })
+        });
+
+        await actions.updateStoreState({rootState} as any, testState);
+
+        const root = mockSaveToLocalStorage.mock.calls[0][0] as RootState
+        expect(root.modelCalibrate.options).toStrictEqual({});
         expect(mockLocationReload.mock.calls.length).toBe(1);
     });
 

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -45,6 +45,7 @@ import {ADRUploadState, initialADRUploadState} from "../app/store/adrUpload/adrU
 import {DownloadResultsState, initialDownloadResultsState} from "../app/store/downloadResults/downloadResults";
 import {GenericChartState, initialGenericChartState} from "../app/store/genericChart/genericChart";
 import {DataExplorationState, initialDataExplorationState} from "../app/store/dataExploration/dataExploration";
+import {DynamicControlType, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 export const mockAxios = new MockAdapter(axios);
 
@@ -478,3 +479,23 @@ export const mockProjectOutputState = (props: Partial<ProjectState> = {}) => {
         ...props
     }
 }
+
+export const mockOptionsFormMeta = (props: Partial<DynamicFormMeta> = {}) => {
+    return {
+        controlSections: [{
+            label: "Test Section",
+            description: "Just a test section",
+            controlGroups: [{
+                controls: [{
+                    name: "TestValue",
+                    type: "number" as DynamicControlType,
+                    required: false,
+                    min: 0,
+                    max: 10,
+                    value: 5
+                }]
+            }]
+        }],
+        ...props
+    }
+};

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -467,11 +467,7 @@ describe("root getters", () => {
                         calibrateId: "calibrateId",
                         options: {},
                         optionsFormMeta: mockOptionsFormMeta({
-                            controlSections: [{
-                                label: "Test Section",
-                                description: "Just a test section",
-                                controlGroups: []
-                            }]
+                            controlSections: []
                         })
                     })
                 }

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -400,23 +400,7 @@ describe("root getters", () => {
 
     it(`can get serialized project states`, () => {
         const projectStates = () => {
-            return mockRootState({
-                baseline: mockBaselineState({
-                        pjnz: {filename: "pjnz", hash: "pjnzHash"} as any,
-                        population: {filename: "population", hash: "populationHash"} as any,
-                        shape: {filename: "shape", hash: "shapeHash"} as any
-                    }),
-                surveyAndProgram: mockSurveyAndProgramState({
-                    warnings: surveyAndProgramWarnings,
-                    anc: {filename: "anc", hash: "ancHash"} as any,
-                    program: {filename: "program", hash: "programHash"} as any,
-                    survey: {filename: "survey", hash: "surveyHash"} as any
-                }),
-                modelOptions: mockModelOptionsState({options: {"test": "options"}}),
-                modelRun: mockModelRunState({modelRunId: "modelRunId"}),
-                modelCalibrate: mockModelCalibrateState({calibrateId: "calibrateId", options: {"test": "options"}}),
-                hintrVersion: mockHintrVersionState({hintrVersion: {hintr: "1.0.0", naomi: "2.0.0", rrq: "1.1.1"}})
-            })
+            return mockRootState(projectStateTestData())
         }
         const rootState = projectStates()
 
@@ -426,52 +410,40 @@ describe("root getters", () => {
 
     it(`can extract calibrate option from dynamic form meta`, () => {
         const projectStates = () => {
-            return mockRootState({
-                baseline: mockBaselineState({
-                    pjnz: {filename: "pjnz", hash: "pjnzHash"} as any,
-                    population: {filename: "population", hash: "populationHash"} as any,
-                    shape: {filename: "shape", hash: "shapeHash"} as any
-                }),
-                surveyAndProgram: mockSurveyAndProgramState({
-                    warnings: surveyAndProgramWarnings,
-                    anc: {filename: "anc", hash: "ancHash"} as any,
-                    program: {filename: "program", hash: "programHash"} as any,
-                    survey: {filename: "survey", hash: "surveyHash"} as any
-                }),
-                modelOptions: mockModelOptionsState({options: {"test": "options"}}),
-                modelRun: mockModelRunState({modelRunId: "modelRunId"}),
-                modelCalibrate: mockModelCalibrateState({
-                    calibrateId: "calibrateId",
-                    options: {},
-                    optionsFormMeta: mockOptionsFormMeta({
-                        controlSections: [{
-                            label: "Test Section",
-                            description: "Just a test section",
-                            controlGroups: [{
-                                controls: [
-                                    {
-                                        name: "TestValue",
-                                        type: "number" as DynamicControlType,
-                                        required: false,
-                                        min: 0,
-                                        max: 10,
-                                        value: 5
-                                    },
-                                    {
-                                        name: "TestValue2",
-                                        type: "number" as DynamicControlType,
-                                        required: false,
-                                        min: 0,
-                                        max: 10,
-                                        value: 6
-                                    }
-                                ]
-                            }]
-                        }],
+            return mockRootState(projectStateTestData(
+                {
+                    modelCalibrate: mockModelCalibrateState({
+                        calibrateId: "calibrateId",
+                        options: {},
+                        optionsFormMeta: mockOptionsFormMeta({
+                            controlSections: [{
+                                label: "Test Section",
+                                description: "Just a test section",
+                                controlGroups: [{
+                                    controls: [
+                                        {
+                                            name: "TestValue",
+                                            type: "number" as DynamicControlType,
+                                            required: false,
+                                            min: 0,
+                                            max: 10,
+                                            value: 5
+                                        },
+                                        {
+                                            name: "TestValue2",
+                                            type: "number" as DynamicControlType,
+                                            required: false,
+                                            min: 0,
+                                            max: 10,
+                                            value: 6
+                                        }
+                                    ]
+                                }]
+                            }],
+                        })
                     })
-                }),
-                hintrVersion: mockHintrVersionState({hintrVersion: {hintr: "1.0.0", naomi: "2.0.0", rrq: "1.1.1"}})
-            })
+                }
+            ))
         }
         const rootState = projectStates()
 
@@ -486,4 +458,58 @@ describe("root getters", () => {
             }
         }))
     })
+
+    it(`returns empty object if there are no options to extract from dynamic form meta`, () => {
+        const projectStates = () => {
+            return mockRootState(projectStateTestData(
+                {
+                    modelCalibrate: mockModelCalibrateState({
+                        calibrateId: "calibrateId",
+                        options: {},
+                        optionsFormMeta: mockOptionsFormMeta({
+                            controlSections: [{
+                                label: "Test Section",
+                                description: "Just a test section",
+                                controlGroups: [{
+                                    controls: []
+                                }]
+                            }],
+                        })
+                    })
+                }
+            ))
+        }
+        const rootState = projectStates()
+
+        const result = getters.projectState(rootState, null, projectStates() as any, null)
+
+        expect(result).toEqual(mockProjectOutputState({
+                calibrate: {"id": "calibrateId", "options": {}}
+            })
+        )
+    })
 })
+
+const projectStateTestData = (props: Partial<any> = {}) => {
+    const surveyAndProgramWarnings: Warning[] = [
+        {text: "survey and program test", locations: ["review_inputs"]}
+    ]
+    return {
+        baseline: mockBaselineState({
+            pjnz: {filename: "pjnz", hash: "pjnzHash"} as any,
+            population: {filename: "population", hash: "populationHash"} as any,
+            shape: {filename: "shape", hash: "shapeHash"} as any
+        }),
+        surveyAndProgram: mockSurveyAndProgramState({
+            warnings: surveyAndProgramWarnings,
+            anc: {filename: "anc", hash: "ancHash"} as any,
+            program: {filename: "program", hash: "programHash"} as any,
+            survey: {filename: "survey", hash: "surveyHash"} as any
+        }),
+        modelOptions: mockModelOptionsState({options: {"test": "options"}}),
+        modelRun: mockModelRunState({modelRunId: "modelRunId"}),
+        modelCalibrate: mockModelCalibrateState({calibrateId: "calibrateId", options: {"test": "options"}}),
+        hintrVersion: mockHintrVersionState({hintrVersion: {hintr: "1.0.0", naomi: "2.0.0", rrq: "1.1.1"}}),
+        ...props
+    }
+}

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -470,10 +470,8 @@ describe("root getters", () => {
                             controlSections: [{
                                 label: "Test Section",
                                 description: "Just a test section",
-                                controlGroups: [{
-                                    controls: []
-                                }]
-                            }],
+                                controlGroups: []
+                            }]
                         })
                     })
                 }

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -10,7 +10,7 @@ import {
     mockMetadataState,
     mockModelCalibrateState,
     mockModelOptionsState,
-    mockModelRunState, mockOptionsFormMeta, mockProjectOutputState, mockProjectsState,
+    mockModelRunState, mockProjectOutputState, mockProjectsState,
     mockRootState, mockSurveyAndProgramState
 } from "../mocks";
 import {RootState} from "../../app/root";
@@ -18,7 +18,6 @@ import {initialDownloadResults} from "../../app/store/downloadResults/downloadRe
 import {Warning} from "../../app/generated";
 import {extractErrors} from "../../app/utils";
 import {expectArraysEqual} from "../testHelpers";
-import {DynamicControlType} from "@reside-ic/vue-dynamic-form";
 
 describe("root getters", () => {
 
@@ -406,81 +405,6 @@ describe("root getters", () => {
 
         const result = getters.projectState(rootState, null, projectStates() as any, null)
         expect(result).toEqual(mockProjectOutputState())
-    })
-
-    it(`can extract calibrate option from dynamic form meta`, () => {
-        const projectStates = () => {
-            return mockRootState(projectStateTestData(
-                {
-                    modelCalibrate: mockModelCalibrateState({
-                        calibrateId: "calibrateId",
-                        options: {},
-                        optionsFormMeta: mockOptionsFormMeta({
-                            controlSections: [{
-                                label: "Test Section",
-                                description: "Just a test section",
-                                controlGroups: [{
-                                    controls: [
-                                        {
-                                            name: "TestValue",
-                                            type: "number" as DynamicControlType,
-                                            required: false,
-                                            min: 0,
-                                            max: 10,
-                                            value: 5
-                                        },
-                                        {
-                                            name: "TestValue2",
-                                            type: "number" as DynamicControlType,
-                                            required: false,
-                                            min: 0,
-                                            max: 10,
-                                            value: 6
-                                        }
-                                    ]
-                                }]
-                            }],
-                        })
-                    })
-                }
-            ))
-        }
-        const rootState = projectStates()
-
-        const result = getters.projectState(rootState, null, projectStates() as any, null)
-        expect(result).toEqual(mockProjectOutputState({
-            calibrate: {
-                "id": "calibrateId",
-                "options": {
-                    "TestValue": 5,
-                    "TestValue2": 6
-                }
-            }
-        }))
-    })
-
-    it(`returns empty object if there are no options to extract from dynamic form meta`, () => {
-        const projectStates = () => {
-            return mockRootState(projectStateTestData(
-                {
-                    modelCalibrate: mockModelCalibrateState({
-                        calibrateId: "calibrateId",
-                        options: {},
-                        optionsFormMeta: mockOptionsFormMeta({
-                            controlSections: []
-                        })
-                    })
-                }
-            ))
-        }
-        const rootState = projectStates()
-
-        const result = getters.projectState(rootState, null, projectStates() as any, null)
-
-        expect(result).toEqual(mockProjectOutputState({
-                calibrate: {"id": "calibrateId", "options": {}}
-            })
-        )
     })
 })
 


### PR DESCRIPTION
## Description

This PR checks if modelCalibrate option exists in the state, if not it extracts options from dynamicFormMeta. 

## Type of version change
_Delete as appropriate_

Patches 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
