### PR TITLE
Mrc 3510 - revert userCLI target to master

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.7.2
+
+* Change userCLI target to master
+
 # hint 2.7.1
 
 * Fix docker run entrypoint issue and update pac4j

--- a/scripts/add-guest-user.sh
+++ b/scripts/add-guest-user.sh
@@ -4,7 +4,7 @@ NETWORK=hint_nw
 HERE=$(realpath "$(dirname $0)")
 TEST_CONFIG=$HERE/../src/app/static/scripts/test.properties
 
-image=mrcide/hint-user-cli:mrc-3507
+image=mrcide/hint-user-cli:master
 docker pull $image
 docker run --network=hint_nw \
 		-v $TEST_CONFIG:/etc/hint/config.properties \

--- a/scripts/add-test-user.sh
+++ b/scripts/add-test-user.sh
@@ -4,7 +4,7 @@ NETWORK=hint_nw
 HERE=$(realpath "$(dirname $0)")
 TEST_CONFIG=$HERE/../src/app/static/scripts/test.properties
 
-image=mrcide/hint-user-cli:mrc-3507
+image=mrcide/hint-user-cli:master
 docker pull $image
 docker run --network=hint_nw \
 		-v $TEST_CONFIG:/etc/hint/config.properties \

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.7.1";
+export const currentHintVersion = "2.7.2";


### PR DESCRIPTION
## Description

PR targets master docker image for userCLI

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
