### PR TITLE
mrc-3520 get projects only when user is logged in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.7.2
+
+* Fix guest login issue
+
 # hint 2.7.1
 
 * Fix docker run entrypoint issue and update pac4j

--- a/src/app/static/src/app/components/load/UploadNewProject.vue
+++ b/src/app/static/src/app/components/load/UploadNewProject.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts">
     import Modal from "../Modal.vue";
-    import {mapActionByName, mapMutationByName, mapStateProps} from "../../utils";
+    import {mapActionByName, mapGetterByName, mapMutationByName, mapStateProps} from "../../utils";
     import UploadProgress from "./UploadProgress.vue";
     import {LoadingState, LoadState} from "../../store/load/state";
     import LoadErrorModal from "./LoadErrorModal.vue";
@@ -67,6 +67,7 @@
 
     interface Computed extends  LoadComputed{
         disableCreate: boolean
+        isGuest: boolean
     }
 
     export default ProjectsMixin.extend<Data, Methods, Computed, Props>({
@@ -95,7 +96,8 @@
             }),
             disableCreate() {
                 return !this.uploadProjectName || this.invalidName(this.uploadProjectName)
-            }
+            },
+            isGuest: mapGetterByName(null,"isGuest")
         },
         components: {
             Modal,
@@ -108,7 +110,9 @@
             }
         },
         mounted() {
-            this.getProjects();
+            if (!this.isGuest) {
+                this.getProjects();
+            }
         }
     })
 </script>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.7.1";
+export const currentHintVersion = "2.7.2";

--- a/src/app/static/src/tests/components/header/fileMenu.test.ts
+++ b/src/app/static/src/tests/components/header/fileMenu.test.ts
@@ -31,6 +31,10 @@ describe("File menu", () => {
     const testProjects = [{id: 2, name: "proj1", versions: []}];
     const mockGetProjects = jest.fn();
 
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
     const storeModules = {
         baseline: {
             namespaced: true,
@@ -331,11 +335,22 @@ describe("File menu", () => {
         expect(projectModal.props().openModal).toBe(false)
         projectModal.find(".btn").trigger("click");
         expect(mockLoadAction.mock.calls.length).toBe(1);
-        expect(mockGetProjects).toHaveBeenCalled()
         expect(projectModal.props().openModal).toBe(false)
     });
 
-    it("can open upload project modal as guest when file is uploaded", () => {
+    it("can get projects when user is logged in when file is uploaded", () => {
+        const store = createStore({
+            load: {
+                namespaced: true,
+                state: mockLoadState()
+            }
+        }, false);
+        const projectModal = openUploadNewProject(store, "#upload-zip", "application/zip")
+        projectModal.find(".btn").trigger("click");
+        expect(mockGetProjects).toHaveBeenCalled()
+    });
+
+    it("can open upload project modal and does not get projects as guest when file is uploaded", () => {
         const mockPreparingRehydrate = jest.fn()
         const store = createStore({
             load: {
@@ -348,7 +363,7 @@ describe("File menu", () => {
         });
         const projectModal = openUploadNewProject(store, "#upload-zip", "application/zip")
         projectModal.find(".btn").trigger("click");
-        expect(mockGetProjects).toHaveBeenCalled()
+        expect(mockGetProjects).not.toHaveBeenCalled()
         expect(mockPreparingRehydrate.mock.calls.length).toBe(1);
         expect(projectModal.props().openModal).toBe(false)
     });

--- a/src/app/static/src/tests/components/load/uploadNewProject.test.ts
+++ b/src/app/static/src/tests/components/load/uploadNewProject.test.ts
@@ -1,5 +1,5 @@
 import {mount} from "@vue/test-utils";
-import {mockError, mockLoadState, mockProjectsState} from "../../mocks";
+import {mockError, mockLoadState, mockProjectsState, mockRootState} from "../../mocks";
 import Vue from "vue";
 import UploadNewProject from "../../../app/components/load/UploadNewProject.vue"
 import Vuex, {Store} from "vuex";
@@ -32,9 +32,12 @@ describe("uploadNewProject", () => {
 
     const testProjects = [{id: 2, name: "proj1", versions: []}];
 
-    const getStore = (loadState: Partial<LoadState> = {}) => {
+    const getStore = (loadState: Partial<LoadState> = {}, isGuest = false) => {
         const store = new Vuex.Store({
             state: emptyState,
+            getters: {
+                isGuest: () => isGuest
+            },
             modules: {
                 load: {
                     namespaced: true,
@@ -229,5 +232,19 @@ describe("uploadNewProject", () => {
         expect(wrapper.find(UploadProgress).props("openModal")).toBe(true)
         wrapper.find(UploadProgress).find("button").trigger("click")
         expect(mockMutations.RehydrateCancel.mock.calls.length).toBe(1)
+    })
+
+    it("does not get projects when user is not logged in", () => {
+        const store = getStore({}, true)
+        const wrapper = getWrapper({}, store)
+
+        expect(wrapper.find(".modal").exists()).toBe(true)
+        expect(wrapper.find(".modal").attributes()).toEqual({
+            "class": "modal",
+            "style": "display: none;"
+        })
+        const uploadProject = wrapper.find("#load-project-name");
+        expect(uploadProject.exists()).toBe(true)
+        expect(mockGetProjects).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Description

This PR fixes login issue. Issues caused by calling getProjects when user is not logged in.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
