### PR TITLE
mrc-3486 Table for comparison barchart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.9.0
+
+* Table for comparison barchart
+
 # hint 2.8.0
 
 * Comparison barchart in review output step

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -99,6 +99,19 @@
                     :formatFunction="formatBarchartValue"
                     :showRangesInTooltips="true"
                     @update="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
+                <div class="row mt-2">
+                    <div class="col-md-3"></div>
+                    <area-indicators-table class="col-md-9"
+                                        :table-data="comparisonPlotData"
+                                        :area-filter-id="areaFilterId"
+                                        :filters="comparisonPlotFilters"
+                                        :countryAreaFilterOption="countryAreaFilterOption"
+                                        :indicators="filteredComparisonPlotIndicators"
+                                        :selections="comparisonPlotSelections"
+
+                                        :selectedFilterOptions="comparisonPlotSelections.selectedFilterOptions"
+                    ></area-indicators-table>
+                </div>
             </div>
         </div>
     </div>
@@ -169,6 +182,7 @@
         choroplethFilters: Filter[],
         countryAreaFilterOption: FilterOption,
         barchartIndicators: BarchartIndicator[],
+        comparisonPlotIndicators: BarchartIndicator[],
         chartdata: any,
         comparisonPlotData: any
         barchartSelections: BarchartSelections,
@@ -188,6 +202,7 @@
         filteredChoroplethIndicators: ChoroplethIndicatorMetadata[],
         filteredBarchartIndicators: BarchartIndicator[],
         filteredBubblePlotIndicators: ChoroplethIndicatorMetadata[],
+        filteredComparisonPlotIndicators: BarchartIndicator[],
         barchartFlattenedXAxisFilterOptionIds: string[]
         comparisonPlotFlattenedXAxisFilterOptionIds: string[]
     }
@@ -245,6 +260,9 @@
                     ...this.bubblePlotIndicators.filter((val: ChoroplethIndicatorMetadata) => val.indicator === this.bubblePlotSelections.colorIndicatorId),
                     ...this.bubblePlotIndicators.filter((val: ChoroplethIndicatorMetadata) => val.indicator === this.bubblePlotSelections.sizeIndicatorId)
                 ]
+            },
+            filteredComparisonPlotIndicators() {
+                return this.comparisonPlotIndicators.filter((val: BarchartIndicator) => val.indicator === this.comparisonPlotSelections.indicatorId)
             },
             selectedTab: mapStateProp<ModelOutputState, string>("modelOutput", state => state.selectedTab),
             chartdata: mapStateProp<ModelCalibrateState, any>("modelCalibrate", state => {

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -109,7 +109,7 @@
                                         :countryAreaFilterOption="countryAreaFilterOption"
                                         :indicators="filteredComparisonPlotIndicators"
                                         :selections="comparisonPlotSelections"
-
+                                        :translate-filter-labels="false"
                                         :selectedFilterOptions="comparisonPlotSelections.selectedFilterOptions"
                     ></area-indicators-table>
                 </div>

--- a/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
+++ b/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
@@ -40,6 +40,7 @@
         filters: Filter[],
         countryAreaFilterOption: NestedFilterOption,
         areaFilterId: string
+        translateFilterLabels: boolean
     }
 
     interface DisplayRow {
@@ -80,6 +81,10 @@
         },
         selections: {
             type: Object
+        },
+        translateFilterLabels: {
+            type: Boolean,
+            default: true
         }
     }
 
@@ -172,7 +177,7 @@
                 this.filtersToDisplay.forEach(value => {
                     const field: Dict<any> = {};
                     field.key = value.id
-                    field.label = i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage})
+                    field.label = this.translateFilterLabels ? i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage}) : field.label
                     fields.push(field)
                 })
                 this.indicators.forEach(value => {

--- a/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
+++ b/src/app/static/src/app/components/plots/table/AreaIndicatorsTable.vue
@@ -177,7 +177,7 @@
                 this.filtersToDisplay.forEach(value => {
                     const field: Dict<any> = {};
                     field.key = value.id
-                    field.label = this.translateFilterLabels ? i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage}) : field.label
+                    field.label = this.translateFilterLabels ? i18next.t(value.label.toLowerCase(), {lng: this.currentLanguage}) : value.label
                     fields.push(field)
                 })
                 this.indicators.forEach(value => {

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.8.0";
+export const currentHintVersion = "2.9.0";

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -124,14 +124,16 @@ export function stripNamespace(name: string) {
 
 const flattenToIdArray = (filterOption: NestedFilterOption): string[] => {
     let result: string[] = [];
-    result.push(filterOption.id);
-    if (filterOption.children) {
-        filterOption.children.forEach(o =>
-            result = [
-                ...result,
-                ...flattenToIdArray(o as NestedFilterOption)
-            ]);
-
+    if (filterOption?.id) {
+        result.push(filterOption.id);
+        if (filterOption.children) {
+            filterOption.children.forEach(o =>
+                result = [
+                    ...result,
+                    ...flattenToIdArray(o as NestedFilterOption)
+                ]);
+    
+        }
     }
     return result;
 };

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -810,6 +810,50 @@ describe("ModelOutput component", () => {
         );
     });
 
+    it("renders comparison plot table", () => {
+        const store = getStore({selectedTab: "comparison"});
+        const wrapper = shallowMount(ModelOutput, {localVue, store});
+
+        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        expect(table.props().areaFilterId).toBe("area");
+        expect(table.props().filters).toStrictEqual(["TEST COMPARISON FILTERS"]);
+        expect(table.props().selections).toStrictEqual({
+            indicatorId: "TestIndicator",
+            xAxisId: "age",
+            disaggregateById: "source",
+            selectedFilterOptions: {
+                region: [{id: "r1", label: "region 1"}],
+                age: [{id: "a1", label: "0-4"}]
+            }
+        });
+        expect(table.props().tableData).toStrictEqual(["TEST COMPARISON DATA"]);
+        expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
+        expect(table.props().translateLabels).toBe(undefined);
+    });
+
+    it("renders comparison plot table with correct indicator props", () => {
+        const store = getStore({selectedTab: "comparison"}, {
+            comparisonPlotIndicators: jest.fn().mockReturnValue(
+                [
+                    {"indicator": "prevalence", "indicator_value": "2"},
+                    {"indicator": "art_coverage", "indicator_value": "4"}
+                ]
+            )
+        },
+            {
+                comparisonPlot: {indicatorId: "art_coverage"}
+            });
+        const wrapper = shallowMount(ModelOutput, {localVue, store});
+
+        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        expect(table.props().selections).toStrictEqual({indicatorId: "art_coverage"});
+        expect(table.props().indicators).toStrictEqual(
+            [
+                {"indicator": "art_coverage", "indicator_value": "4"}
+            ]
+        );
+    });
+
     it("formatBarchartValue formats value", () => {
         const store = getStore();
         const wrapper = shallowMount(ModelOutput, {store, localVue});

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -713,7 +713,6 @@ describe("ModelOutput component", () => {
         expect(table.props().indicators).toStrictEqual(["TEST CHORO INDICATORS"]);
         expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
-        expect(table.props().translateLabels).toBe(undefined);
     });
 
     it("renders choropleth table with correct indicator props", () => {
@@ -746,7 +745,6 @@ describe("ModelOutput component", () => {
         expect(table.props().indicators).toStrictEqual(["TEST BUBBLE INDICATORS", "TEST BUBBLE INDICATORS"]);
         expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
-        expect(table.props().translateLabels).toBe(undefined);
     });
 
     it("renders bubble plot table with correct indicator props", () => {
@@ -805,7 +803,7 @@ describe("ModelOutput component", () => {
         });
         expect(table.props().tableData).toStrictEqual(["TEST DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
-        expect(table.props().translateLabels).toBe(undefined);
+        expect(table.props().translateFilterLabels).toBe(true);
     });
 
     it("renders barchart table with correct indicator props", () => {
@@ -849,7 +847,7 @@ describe("ModelOutput component", () => {
         });
         expect(table.props().tableData).toStrictEqual(["TEST COMPARISON DATA"]);
         expect(table.props().countryAreaFilterOption).toStrictEqual({TEST: "TEST countryAreaFilterOption"});
-        expect(table.props().translateLabels).toBe(undefined);
+        expect(table.props().translateFilterLabels).toBe(false);
     });
 
     it("renders comparison plot table with correct indicator props", () => {

--- a/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
+++ b/src/app/static/src/tests/components/plots/table/areaIndicatorsTable.test.ts
@@ -87,6 +87,37 @@ describe("areaIndicatorsTable", () => {
         expect(table.props("fields")).toStrictEqual(expectedFields);
     });
 
+
+    it('renders Table with correct fields when translateFilterLabels is false', () => {
+        const wrapper = getWrapper({
+            translateFilterLabels: false,
+            filters: [
+                testData.filters[0],
+                {
+                    id: "age",
+                    label: "Age (already translated)",
+                    column_id: "age",
+                    options: [{id: "0:15", label: "0-15"}, {id: "15:30", label: "15-30"}]
+                },
+                {
+                    id: "sex",
+                    label: "Sex (already translated)",
+                    column_id: "sex",
+                    options: [{id: "female", label: "Female"}, {id: "male", label: "Male"}]
+                }
+            ]
+        });
+        const table = wrapper.find(Table);
+
+        const expectedFields = [
+            {key: "areaLabel", label: "Area", sortable: true, sortByFormatted: true},
+            {key: "age", label: "Age (already translated)", sortable: true, sortByFormatted: true},
+            {key: "sex", label: "Sex (already translated)", sortable: true, sortByFormatted: true},
+            {key: "prevalence", label: "HIV prevalence", sortable: true, sortByFormatted: true}
+        ];
+        expect(table.props("fields")).toStrictEqual(expectedFields);
+    });
+
     it('renders Table with correct data', () => {
         const wrapper = getWrapper();
         const table = wrapper.find(Table);


### PR DESCRIPTION
## Description

Adds a table for the comparison plot on the review output step. To view visit http://localhost:8080/?comparisonPlot=1 Data type column header is coming through oddly (lower case and only translated for French), likely due to still pulling from the dummy endpoint currently.

## Type of version change
Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
