### PR TITLE
mrc-3559 Display comparison plot error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.10.0
+
+* Display comparison plot error message
+
 # hint 2.9.0
 
 * Comparison barchart in review output step

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -100,7 +100,7 @@
                     :formatFunction="formatBarchartValue"
                     :showRangesInTooltips="true"
                     @update="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
-                <error-alert v-if="hasComparisonPlotError" :error="comparisonPlotError"></error-alert>
+                <error-alert v-if="!!comparisonPlotError" :error="comparisonPlotError"></error-alert>
             </div>
         </div>
     </div>
@@ -195,7 +195,6 @@
         barchartFlattenedXAxisFilterOptionIds: string[]
         comparisonPlotFlattenedXAxisFilterOptionIds: string[]
         comparisonPlotError: Error | null
-        hasComparisonPlotError: boolean
     }
 
     export default Vue.extend<Data, Methods, Computed, unknown>({
@@ -241,8 +240,7 @@
                 }
             ),
             ...mapStateProps<ModelCalibrateState, keyof Computed>("modelCalibrate", {
-                comparisonPlotError: state => state.comparisonPlotError,
-                hasComparisonPlotError: state => !!state.comparisonPlotError,
+                comparisonPlotError: state => state.comparisonPlotError
             }),
             filteredChoroplethIndicators() {
                 return this.choroplethIndicators.filter((val: ChoroplethIndicatorMetadata) => val.indicator === this.choroplethSelections.indicatorId)

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -101,6 +101,7 @@
                     :showRangesInTooltips="true"
                     @update="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
                 <error-alert v-if="hasComparisonPlotError" :error="comparisonPlotError"></error-alert>
+                <!-- <error-alert v-if="true" :error="{error: 'OTHER_ERROR', detail: 'message'}"></error-alert> -->
             </div>
         </div>
     </div>
@@ -194,6 +195,8 @@
         filteredBubblePlotIndicators: ChoroplethIndicatorMetadata[],
         barchartFlattenedXAxisFilterOptionIds: string[]
         comparisonPlotFlattenedXAxisFilterOptionIds: string[]
+        comparisonPlotError: Error | null
+        hasComparisonPlotError: boolean
     }
 
     export default Vue.extend<Data, Methods, Computed, unknown>({
@@ -297,6 +300,7 @@
         },
         mounted() {
             this.prepareOutputDownloads();
+            // console.log("errors", this.hasComparisonPlotError, this.comparisonPlotError)
         },
         components: {
             BarChartWithFilters,

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -101,7 +101,6 @@
                     :showRangesInTooltips="true"
                     @update="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
                 <error-alert v-if="hasComparisonPlotError" :error="comparisonPlotError"></error-alert>
-                <!-- <error-alert v-if="true" :error="{error: 'OTHER_ERROR', detail: 'message'}"></error-alert> -->
             </div>
         </div>
     </div>
@@ -300,7 +299,6 @@
         },
         mounted() {
             this.prepareOutputDownloads();
-            // console.log("errors", this.hasComparisonPlotError, this.comparisonPlotError)
         },
         components: {
             BarChartWithFilters,

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -100,6 +100,7 @@
                     :formatFunction="formatBarchartValue"
                     :showRangesInTooltips="true"
                     @update="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
+                <error-alert v-if="hasComparisonPlotError" :error="comparisonPlotError"></error-alert>
             </div>
         </div>
     </div>
@@ -112,6 +113,7 @@
     import AreaIndicatorsTable from "../plots/table/AreaIndicatorsTable.vue";
     import {BarchartIndicator, Filter, FilterConfig, FilterOption} from "@reside-ic/vue-charts/src/bar/types";
     import {BarChartWithFilters} from "@reside-ic/vue-charts";
+    import ErrorAlert from "../ErrorAlert.vue";
 
     import {
         mapGettersByNames,
@@ -236,6 +238,10 @@
                     featureLevels: state => state.shape!.filters.level_labels || []
                 }
             ),
+            ...mapStateProps<ModelCalibrateState, keyof Computed>("modelCalibrate", {
+                comparisonPlotError: state => state.comparisonPlotError,
+                hasComparisonPlotError: state => !!state.comparisonPlotError,
+            }),
             filteredChoroplethIndicators() {
                 return this.choroplethIndicators.filter((val: ChoroplethIndicatorMetadata) => val.indicator === this.choroplethSelections.indicatorId)
             },
@@ -296,7 +302,8 @@
             BarChartWithFilters,
             BubblePlot,
             Choropleth,
-            AreaIndicatorsTable
+            AreaIndicatorsTable,
+            ErrorAlert
         }
     })
 </script>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.9.0";
+export const currentHintVersion = "2.10.0";

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -112,7 +112,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
         commit(ModelCalibrateMutation.ComparisonPlotStarted);
 
         const response = await api<ModelCalibrateMutation, ModelCalibrateMutation>(context)
-            .withError(ModelCalibrateMutation.SetError)
+            .withError(ModelCalibrateMutation.SetComparisonPlotError)
             .ignoreSuccess()
             .freezeResponse()
             .get<ModelResultResponse>(`model/comparison/plot/${calibrateId}`);

--- a/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
+++ b/src/app/static/src/app/store/modelCalibrate/modelCalibrate.ts
@@ -22,6 +22,7 @@ export interface ModelCalibrateState extends ReadyState, WarningsState {
     result: CalibrateResultResponse | null
     version: VersionInfo
     error: Error | null
+    comparisonPlotError: Error | null
 }
 
 export const initialModelCalibrateState = (): ModelCalibrateState => {
@@ -41,6 +42,7 @@ export const initialModelCalibrateState = (): ModelCalibrateState => {
         result: null,
         version: {hintr: "unknown", naomi: "unknown", rrq: "unknown"},
         error: null,
+        comparisonPlotError: null,
         warnings: []
     }
 };

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -22,6 +22,7 @@ export enum ModelCalibrateMutation {
     Calibrated = "Calibrated",
     SetOptionsData = "SetOptionsData",
     SetError = "SetError",
+    SetComparisonPlotError = "SetComparisonPlotError",
     PollingForStatusStarted = "PollingForStatusStarted",
     Ready = "Ready",
     CalibrationPlotStarted = "CalibrationPlotStarted",
@@ -90,7 +91,7 @@ export const mutations: MutationTree<ModelCalibrateState> = {
 
     [ModelCalibrateMutation.ComparisonPlotStarted](state: ModelCalibrateState) {
         state.comparisonPlotResult = null;
-        state.error = null;
+        state.comparisonPlotError = null;
     },
 
     [ModelCalibrateMutation.SetPlotData](state: ModelCalibrateState, action: PayloadWithType<any>) {
@@ -117,6 +118,10 @@ export const mutations: MutationTree<ModelCalibrateState> = {
         if (state.statusPollId > -1) {
             stopPolling(state);
         }
+    },
+
+    [ModelCalibrateMutation.SetComparisonPlotError](state: ModelCalibrateState, action: PayloadWithType<Error>) {
+        state.comparisonPlotError = action.payload;
     },
 
     [ModelCalibrateMutation.PollingForStatusStarted](state: ModelCalibrateState, action: PayloadWithType<number>) {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -7,6 +7,7 @@ import {
     mockComparisonPlotResponse,
     mockModelCalibrateState,
     mockShapeResponse,
+    mockError
 } from "../../mocks";
 import {mutations as modelOutputMutations} from "../../../app/store/modelOutput/mutations";
 import {mutations as plottingSelectionMutations} from "../../../app/store/plottingSelections/mutations";
@@ -21,10 +22,11 @@ import {expectTranslated} from "../../testHelpers";
 import {BarchartIndicator, Filter} from "../../../app/types";
 import AreaIndicatorsTable from "../../../app/components/plots/table/AreaIndicatorsTable.vue";
 import {switches} from "../../../app/featureSwitches";
+import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 
 const localVue = createLocalVue();
 
-function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGetters = {}, partialSelections = {}, barchartFilters: any = ["TEST BAR FILTERS"], comparisonPlotFilters: any = ["TEST COMPARISON FILTERS"]) {
+function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGetters = {}, partialSelections = {}, barchartFilters: any = ["TEST BAR FILTERS"], comparisonPlotFilters: any = ["TEST COMPARISON FILTERS"], comparisonPlotError: any = null) {
     const store = new Vuex.Store({
         state: emptyState(),
         modules: {
@@ -46,7 +48,8 @@ function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGette
                 state: mockModelCalibrateState(
                     {
                         result: mockCalibrateResultResponse({data: ["TEST DATA"] as any}),
-                        comparisonPlotResult: mockComparisonPlotResponse({data: ["TEST COMPARISON DATA"] as any})
+                        comparisonPlotResult: mockComparisonPlotResponse({data: ["TEST COMPARISON DATA"] as any}),
+                        comparisonPlotError
                     }
                 )
             },
@@ -177,6 +180,14 @@ describe("ModelOutput component", () => {
         expect(comparisonPlot.props().formatFunction).toBe(vm.formatBarchartValue);
         expect(comparisonPlot.props().showRangesInTooltips).toBe(true);
         expect(comparisonPlot.props().disaggregateByConfig).toStrictEqual({fixed: true, hideFilter: true});
+    });
+
+    it("renders comparison plot error", () => {
+        const error = mockError("comparison plot error occurred")
+        const store = getStore({selectedTab: "comparison"}, {}, {}, [], [], error);
+        const wrapper = shallowMount(ModelOutput, {localVue, store});
+        expect(wrapper.findAll(ErrorAlert).length).toBe(1);
+        expect(wrapper.find(ErrorAlert).props().error).toBe(error);
     });
 
     it("does not render comparison plot if no there are no comparison plot indicators", () => {

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -96,7 +96,7 @@ describe("model calibrate actions integration", () => {
 
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toBe("ComparisonPlotStarted");
-        expect(commit.mock.calls[1][0]["type"]).toBe("SetError");
+        expect(commit.mock.calls[1][0]["type"]).toBe("SetComparisonPlotError");
         expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     });
 });

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -40,6 +40,7 @@ describe("LocalStorageManager", () => {
     const modelCalibrateResponse = {
         calibrateId: "",
         calibratePlotResult: null,
+        comparisonPlotError: null,
         calibrating: false,
         complete: false,
         error: null,

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -418,7 +418,7 @@ describe("ModelCalibrate actions", () => {
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toStrictEqual("ComparisonPlotStarted");
         expect(commit.mock.calls[1][0]).toStrictEqual({
-            type: "SetError",
+            type: "SetComparisonPlotError",
             payload: mockError("Test Error")
         });
         expect(mockAxios.history.get.length).toBe(1);

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -104,6 +104,14 @@ describe("ModelCalibrate mutations", () => {
         expect(state.calibrating).toBe(false);
     });
 
+    it("sets comparisonPlotError", () => {
+        const state = mockModelCalibrateState();
+        const error = mockError("TEST ERROR");
+        mutations[ModelCalibrateMutation.SetComparisonPlotError](state, {payload: error});
+        expect(state.comparisonPlotError).toBe(error);
+        expect(state.calibrating).toBe(false);
+    });
+
     it("SetError stops polling", () => {
         const state = mockModelCalibrateState({statusPollId: 99});
         const error = mockError("TEST ERROR");
@@ -152,10 +160,10 @@ describe("ModelCalibrate mutations", () => {
     });
 
     it("sets comparison plot started and resets error and previous plot", () => {
-        const state = mockModelCalibrateState({error: mockError("TEST ERROR"), comparisonPlotResult: {} as ComparisonPlotResponse});
+        const state = mockModelCalibrateState({comparisonPlotError: mockError("TEST ERROR"), comparisonPlotResult: {} as ComparisonPlotResponse});
         mutations[ModelCalibrateMutation.ComparisonPlotStarted](state);
         expect(state.comparisonPlotResult).toBe(null);
-        expect(state.error).toBe(null);
+        expect(state.comparisonPlotError).toBe(null);
     });
 
     it("sets comparison plot data", () => {


### PR DESCRIPTION
## Description

Separates comparison plot errors from calibrate errors in the store and displays them in the model output.

## Type of version change
Minor

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
