### PR TITLE
mrc-3540 Prevent comparison plot data being saved in local storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
+# hint 2.11.2
+
+* Prevent comparison plot data being saved in local storage
+
 # hint 2.11.1
 
 * fix broken request password mailer
-
-# hint 2.11.1
-
-* Prevent comparison plot data being saved in local storage
 
 # hint 2.11.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * fix broken request password mailer
 
+# hint 2.11.1
+
+* Prevent comparison plot data being saved in local storage
+
 # hint 2.11.0
 
 * Table for comparison barchart

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.11.1";
+export const currentHintVersion = "2.11.2";

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -49,7 +49,8 @@ export const serialiseState = (state: DataExplorationState): Partial<RootState> 
             modelCalibrate: {
                 ...rootState.modelCalibrate,
                 result: null,
-                calibratePlotResult: null
+                calibratePlotResult: null,
+                comparisonPlotResult: null
             },
             stepper: rootState.stepper,
             hintrVersion: state.hintrVersion,

--- a/src/app/static/src/tests/components/header/fileMenu.test.ts
+++ b/src/app/static/src/tests/components/header/fileMenu.test.ts
@@ -114,7 +114,7 @@ describe("File menu", () => {
             state: {
                 baseline: {selectedDataset: null, selectedRelease: null},
                 modelRun: mockModelRunState(),
-                modelCalibrate: {result: null, calibratePlotResult: null},
+                modelCalibrate: {result: null, calibratePlotResult: null, comparisonPlotResult: null},
                 metadata: mockMetadataState(),
                 surveyAndProgram: {selectedDataType: null, warnings: []},
                 language: Language.en

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -17,7 +17,8 @@ import {
     mockProjectsState,
     mockRelease,
     mockStepperState,
-    mockSurveyAndProgramState
+    mockSurveyAndProgramState,
+    mockComparisonPlotResponse
 } from "./mocks";
 import {localStorageManager, serialiseState} from "../app/localStorageManager";
 import {RootState} from "../app/root";
@@ -86,7 +87,8 @@ describe("LocalStorageManager", () => {
             modelOutput: mockModelOutputState(),
             modelCalibrate: mockModelCalibrateState({
                 result: mockCalibrateResultResponse(),
-                calibratePlotResult: {data: "test calibrate plot result"}
+                calibratePlotResult: {data: "test calibrate plot result"},
+                comparisonPlotResult: mockComparisonPlotResponse()
             }),
             stepper: mockStepperState(),
             metadata: mockMetadataState({plottingMetadataError: mockError("metadataError")}),


### PR DESCRIPTION
## Description

This is to prevent the occasional console error due to local storage limits being exceeded.

## Type of version change
Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
