### PR TITLE
mrc-3649 Update hint to work with options schema changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.13.0
+
+* Update hint to work with options schema changes
+
 # hint 2.12.0
 
 * Update backend logging for new log structure

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -29,7 +29,7 @@ interface HintrAPIClient
     fun getResult(id: String): ResponseEntity<String>
     fun getPlottingMetadata(iso3: String): ResponseEntity<String>
     fun getModelRunOptions(files: Map<String, VersionFileWithPath>): ResponseEntity<String>
-    fun getModelCalibrationOptions(): ResponseEntity<String>
+    fun getModelCalibrationOptions(iso3: String): ResponseEntity<String>
     fun calibrateSubmit(runId: String, calibrationOptions: ModelOptions): ResponseEntity<String>
     fun getCalibrateStatus(id: String): ResponseEntity<String>
     fun getCalibrateResult(id: String): ResponseEntity<String>
@@ -172,9 +172,9 @@ class HintrFuelAPIClient(
         return postJson("model/options", json)
     }
 
-    override fun getModelCalibrationOptions(): ResponseEntity<String>
+    override fun getModelCalibrationOptions(iso3: String): ResponseEntity<String>
     {
-        return postEmpty("calibrate/options")
+        return postEmpty("calibrate/options/${iso3}")
     }
 
     override fun validateBaselineCombined(files: Map<String, VersionFileWithPath?>): ResponseEntity<String>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ModelRunController.kt
@@ -57,11 +57,11 @@ class ModelRunController(val fileManager: FileManager, val apiClient: HintrAPICl
         return apiClient.getModelRunOptions(allFiles)
     }
 
-    @GetMapping("/calibrate/options/")
+    @GetMapping("/calibrate/options/{iso3}")
     @ResponseBody
-    fun calibrationOptions(): ResponseEntity<String>
+    fun calibrationOptions(@PathVariable("iso3") iso3: String): ResponseEntity<String>
     {
-        return apiClient.getModelCalibrationOptions()
+        return apiClient.getModelCalibrationOptions(iso3)
     }
 
     @PostMapping("/calibrate/submit/{id}")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ModelRunTests.kt
@@ -47,7 +47,7 @@ class ModelRunTests : SecureIntegrationTests()
     @Test
     fun `can get model calibration options`()
     {
-        val responseEntity = testRestTemplate.getForEntity<String>("/model/calibrate/options/")
+        val responseEntity = testRestTemplate.getForEntity<String>("/model/calibrate/options/MWI")
         assertSuccess(responseEntity, "ModelRunOptions")
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -139,7 +139,7 @@ class HintrApiClientTests
     fun `can get model calibration options`()
     {
         val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val result = sut.getModelCalibrationOptions()
+        val result = sut.getModelCalibrationOptions("MWI")
         assertThat(result.statusCodeValue).isEqualTo(200)
         JSONValidator().validateSuccess(result.body!!, "ModelRunOptions")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ModelRunControllerTests.kt
@@ -10,6 +10,7 @@ import org.imperial.mrc.hint.controllers.ModelRunController
 import org.imperial.mrc.hint.models.ModelOptions
 import org.imperial.mrc.hint.models.VersionFileWithPath
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.springframework.http.ResponseEntity
 
 class ModelRunControllerTests
@@ -170,10 +171,10 @@ class ModelRunControllerTests
     fun `can get calibration options`()
     {
         val mockAPIClient = mock<HintrAPIClient> {
-            on { getModelCalibrationOptions() } doReturn mockResponse
+            on { getModelCalibrationOptions(anyString()) } doReturn mockResponse
         }
         val sut = ModelRunController(mock(), mockAPIClient)
-        val result = sut.calibrationOptions()
+        val result = sut.calibrationOptions("MWI")
         assertThat(result).isSameAs(mockResponse)
     }
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.12.0";
+export const currentHintVersion = "2.13.0";

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -22,12 +22,12 @@ export interface ModelCalibrateActions {
 export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrateActions = {
 
     async fetchModelCalibrateOptions(context) {
-        const {commit} = context;
+        const {commit, rootState} = context;
         commit(ModelCalibrateMutation.FetchingModelCalibrateOptions);
         const response = await api<ModelCalibrateMutation, ModelCalibrateMutation>(context)
             .withSuccess(ModelCalibrateMutation.ModelCalibrateOptionsFetched)
             .ignoreErrors()
-            .get<DynamicFormMeta>("model/calibrate/options/");
+            .get<DynamicFormMeta>(`model/calibrate/options/${rootState.baseline.iso3}`);
 
         if (response) {
             commit({type: ModelCalibrateMutation.SetModelCalibrateOptionsVersion, payload: response.version});

--- a/src/app/static/src/tests/integration/modelCalibrate.itest.ts
+++ b/src/app/static/src/tests/integration/modelCalibrate.itest.ts
@@ -8,7 +8,12 @@ describe("model calibrate actions integration", () => {
     it("can get model calibrate options", async () => {
         const commit = jest.fn();
 
-        await actions.fetchModelCalibrateOptions({commit, rootState} as any);
+        const root = {
+            ...rootState,
+            baseline: {iso3: "MWI"}
+        }
+
+        await actions.fetchModelCalibrateOptions({commit, rootState:root} as any);
         expect(commit.mock.calls[1][0]["type"]).toBe("ModelCalibrateOptionsFetched");
         const payload = commit.mock.calls[1][0]["payload"];
         expect(isDynamicFormMeta(payload)).toBe(true);

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -1,5 +1,5 @@
 import {
-    mockAxios,
+    mockAxios, mockBaselineState,
     mockError,
     mockFailure,
     mockModelCalibrateState,
@@ -27,10 +27,14 @@ describe("ModelCalibrate actions", () => {
 
     it("fetchModelCalibrateOptions fetches options and commits mutations", async () => {
         const commit = jest.fn();
+        const root = {
+            ...rootState,
+            baseline: mockBaselineState({iso3: "MWI"})
+        }
         const state = mockModelCalibrateState();
-        mockAxios.onGet("/model/calibrate/options/").reply(200, mockSuccess("TEST", "v1"));
+        mockAxios.onGet("/model/calibrate/options/MWI").reply(200, mockSuccess("TEST", "v1"));
 
-        await actions.fetchModelCalibrateOptions({commit, state, rootState} as any);
+        await actions.fetchModelCalibrateOptions({commit, state, rootState: root} as any);
 
         expect(commit.mock.calls.length).toBe(3);
         expect(commit.mock.calls[0][0]).toBe(ModelCalibrateMutation.FetchingModelCalibrateOptions);

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-master
+mrc-3215-redo

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-mrc-3215-redo
+master


### PR DESCRIPTION
This PR updates calibrate option endpoint, updated with changes made in hintr https://github.com/mrc-ide/hintr/pull/405#issuecomment-1253592332. 

New changes now corresponds with options schema as seen here https://github.com/mrc-ide/hintr/pull/405/files#diff-6bd8a7b93ff7c312277151e42ef21432985c55b46dc4c46d27046e3bef94246fR40-R48

## Type of version change

Minor

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
