### PR TITLE
mrc-3644 - Bug: Fix download status errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.20.1
+
+* Bug: Fix download status errors
+
 # hint 2.20.0
 
 * Add a new login page for displaying Auth0 login button in hint

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.20.0";
+export const currentHintVersion = "2.20.1";

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -8,7 +8,7 @@ import {
     SurveyAndProgramState,
 } from "./store/surveyAndProgram/surveyAndProgram";
 import {initialModelRunState, modelRun, ModelRunState} from "./store/modelRun/modelRun";
-import {initialStepperState, stepper, StepperState} from "./store/stepper/stepper";
+import {initialStepperState, stepper} from "./store/stepper/stepper";
 import {initialLoadState, LoadState} from "./store/load/state";
 import {load} from "./store/load/load";
 import {initialModelOutputState, modelOutput, ModelOutputState} from "./store/modelOutput/modelOutput";
@@ -44,6 +44,7 @@ import {ModelCalibrateMutation, ModelCalibrateUpdates} from "./store/modelCalibr
 import {GenericChartState, initialGenericChartState, genericChart} from "./store/genericChart/genericChart";
 import {Warning} from "./generated";
 import {DataExplorationState} from "./store/dataExploration/dataExploration";
+import {DownloadResultsMutation} from "./store/downloadResults/mutations";
 
 export interface RootState extends DataExplorationState {
     version: string,
@@ -119,6 +120,9 @@ const resetState = (store: Store<RootState>): void => {
             }
 
             if (type[0] == "modelCalibrate" && ModelCalibrateUpdates.includes(type[1] as ModelCalibrateMutation)) {
+                store.commit(
+                    {type: `downloadResults/${DownloadResultsMutation.ResetIds}`},
+                    {root: true});
                 store.commit(RootMutation.ResetDownload);
             }
         }

--- a/src/app/static/src/app/store/language/actions.ts
+++ b/src/app/static/src/app/store/language/actions.ts
@@ -33,7 +33,7 @@ export const ChangeLanguageAction = async (context: ActionContext<DataExploratio
         actions.push(dispatch("metadata/getPlottingMetadata", rootState.baseline.iso3));
     }
 
-    if (isRoot(rootState) && rootState.modelCalibrate.status.done) {
+    if (isRoot(rootState) && rootState.modelCalibrate.status.done && rootState.stepper.activeStep != 7) {
         actions.push(dispatch("modelCalibrate/getResult"));
     }
 

--- a/src/app/static/src/app/store/language/actions.ts
+++ b/src/app/static/src/app/store/language/actions.ts
@@ -33,7 +33,7 @@ export const ChangeLanguageAction = async (context: ActionContext<DataExploratio
         actions.push(dispatch("metadata/getPlottingMetadata", rootState.baseline.iso3));
     }
 
-    if (isRoot(rootState) && rootState.modelCalibrate.status.done && rootState.stepper.activeStep != 7) {
+    if (isRoot(rootState) && rootState.modelCalibrate.status.done) {
         actions.push(dispatch("modelCalibrate/getResult"));
     }
 

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -187,8 +187,9 @@ describe("App", () => {
         const spy = jest.spyOn(store, "commit");
         store.commit(prefixNamespace("modelCalibrate", ModelCalibrateMutation.Calibrated));
 
-        expect(spy.mock.calls[1][0]).toBe(RootMutation.ResetDownload);
-        expect(spy).toBeCalledTimes(2);
+        expect(spy.mock.calls[1][0].type).toBe("downloadResults/ResetIds");
+        expect(spy.mock.calls[2][0]).toBe(RootMutation.ResetDownload);
+        expect(spy).toBeCalledTimes(3);
     });
 
     it("resets outputs if modelRun ClearResult mutation is called and state is ready", () => {


### PR DESCRIPTION
## Description

PR fixes bug that appears on download page when language gets changed.

The issue appears when requesting calibrate result. When a user changes language, it calls some endpoints, including calibrate results. However, calibrate result calling causes error to appear on the page. The fix I added is artificial, it's to avoid call the endpoint when on download page. However, a more flush solution will be from hintr. I suspect redis is getting confused with fetching result `id` when requesting calibrate result id while download is in progress, it does not know which id.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
