### PR TITLE
mrc-3557 Barchart uncertainty ranges (error bars) are greyed out on first rend…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.23.0
+
+* Barchart uncertainty ranges (error bars) are greyed out on first rendering
+
 # hint 2.22.0
 
 * Bug: Fix download status errors

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -40,7 +40,7 @@
                 </div>
             </div>
 
-            <div id="barchart-container" :class="selectedTab==='bar' ? 'col-md-12' : 'd-none'">
+            <div v-if="selectedTab==='bar'" id="barchart-container" class="col-md-12">
                 <bar-chart-with-filters
                     :chart-data="chartdata"
                     :filter-config="barchartFilterConfig"
@@ -83,15 +83,13 @@
                                            :countryAreaFilterOption="countryAreaFilterOption"
                                            :indicators="filteredBubblePlotIndicators"
                                            :selections="bubblePlotSelections"
-
                                            :selectedFilterOptions="bubblePlotSelections.selectedFilterOptions"
                     ></area-indicators-table>
                 </div>
             </div>
 
-            <div id="comparison-container" :class="selectedTab==='comparison' ? 'col-md-12' : 'd-none'">
+            <div v-if="selectedTab==='comparison'" id="comparison-container" class="col-md-12">
                 <bar-chart-with-filters
-                    v-if="comparisonPlotIndicators.length"
                     :chart-data="comparisonPlotData"
                     :filter-config="comparisonPlotFilterConfig"
                     :disaggregate-by-config="{ fixed: true, hideFilter: true }"
@@ -147,7 +145,6 @@
     import {BaselineState} from "../../store/baseline/baseline";
     import {Language, Translations} from "../../store/translations/locales";
     import {inactiveFeatures} from "../../main";
-    import {switches} from "../../featureSwitches";
     import {RootState} from "../../root";
     import {LevelLabel} from "../../types";
     import {ChoroplethIndicatorMetadata,} from "../../generated";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.22.0";
+export const currentHintVersion = "2.23.0";

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.23.0";
+export const currentHintVersion = "2.24.0";

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -82,7 +82,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 if (switches.modelCalibratePlot) {
                     dispatch("getCalibratePlot");
                 }
-                dispatch("getComparisonPlot");
+                await dispatch("getComparisonPlot");
             }
         }
         commit(ModelCalibrateMutation.Ready);

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -170,8 +170,8 @@ describe("ModelOutput component", () => {
         const wrapper = shallowMount(ModelOutput, {localVue, store});
         const vm = wrapper.vm as any;
 
-        expect(wrapper.findAll(BarChartWithFilters).length).toBe(2);
-        const comparisonPlot = wrapper.findAll(BarChartWithFilters).at(1);
+        expect(wrapper.findAll(BarChartWithFilters).length).toBe(1);
+        const comparisonPlot = wrapper.find(BarChartWithFilters);
         expect(comparisonPlot.props().chartData).toStrictEqual(["TEST COMPARISON DATA"]);
         expect(comparisonPlot.props().filterConfig).toBe(vm.comparisonPlotFilterConfig);
         expect(comparisonPlot.props().indicators).toStrictEqual(["TEST COMPARISON INDICATORS"]);
@@ -219,8 +219,8 @@ describe("ModelOutput component", () => {
         expect(wrapper.find(".nav-link.active").text()).toBe("Map");
         expect(wrapper.findAll("choropleth-stub").length).toBe(1);
 
-        expect(wrapper.find("#barchart-container").classes()).toEqual(["d-none"]);
-        expect(wrapper.find("#comparison-container").classes()).toEqual(["d-none"]);
+        expect(wrapper.find("#barchart-container").exists()).toBe(false);
+        expect(wrapper.find("#comparison-container").exists()).toBe(false);
 
         expect(wrapper.findAll("#bubble-plot-container").length).toBe(0);
         expect(wrapper.findAll("bubble-plot-stub").length).toBe(0);
@@ -233,8 +233,8 @@ describe("ModelOutput component", () => {
         expect(wrapper.findAll("choropleth-stub").length).toBe(0);
 
         expect(wrapper.find("#barchart-container").classes()).toEqual(["col-md-12"]);
-        expect(wrapper.findAll(BarChartWithFilters).length).toBe(2);
-        expect(wrapper.find("#comparison-container").classes()).toEqual(["d-none"]);
+        expect(wrapper.findAll(BarChartWithFilters).length).toBe(1);
+        expect(wrapper.find("#comparison-container").exists()).toBe(false);
 
         expect(wrapper.findAll("#bubble-plot-container").length).toBe(0);
         expect(wrapper.findAll("bubble-plot-stub").length).toBe(0);
@@ -245,8 +245,8 @@ describe("ModelOutput component", () => {
         expect(wrapper.findAll("choropleth-filters-stub").length).toBe(0);
         expect(wrapper.findAll("choropleth-stub").length).toBe(0);
 
-        expect(wrapper.find("#barchart-container").classes()).toEqual(["d-none"]);
-        expect(wrapper.find("#comparison-container").classes()).toEqual(["d-none"]);
+        expect(wrapper.find("#barchart-container").exists()).toBe(false);
+        expect(wrapper.find("#comparison-container").exists()).toBe(false);
 
         expect(wrapper.findAll("#bubble-plot-container").length).toBe(1);
         expect(wrapper.findAll("bubble-plot-stub").length).toBe(1);
@@ -257,9 +257,9 @@ describe("ModelOutput component", () => {
         expect(wrapper.findAll("choropleth-filters-stub").length).toBe(0);
         expect(wrapper.findAll("choropleth-stub").length).toBe(0);
 
-        expect(wrapper.find("#barchart-container").classes()).toEqual(["d-none"]);
+        expect(wrapper.find("#barchart-container").exists()).toBe(false);
         expect(wrapper.find("#comparison-container").classes()).toEqual(["col-md-12"]);
-        expect(wrapper.findAll(BarChartWithFilters).length).toBe(2);
+        expect(wrapper.findAll(BarChartWithFilters).length).toBe(1);
 
         expect(wrapper.findAll("#bubble-plot-container").length).toBe(0);
         expect(wrapper.findAll("bubble-plot-stub").length).toBe(0);
@@ -455,7 +455,7 @@ describe("ModelOutput component", () => {
         const wrapper = shallowMount(ModelOutput, {store, localVue});
         const currentComparisonPlotSelections = store.state.plottingSelections.comparisonPlot
 
-        const comparisonPlot = wrapper.findAll(BarChartWithFilters).at(1);
+        const comparisonPlot = wrapper.find(BarChartWithFilters);
         const comparisonPlotSelections = {
             selectedFilterOptions: {
                 region: [
@@ -735,7 +735,7 @@ describe("ModelOutput component", () => {
         const store = getStore({selectedTab: "bubble"});
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().filters).toStrictEqual(["TEST BUBBLE FILTERS"]);
         expect(table.props().selections).toStrictEqual({test: "TEST BUBBLE SELECTIONS"});
@@ -763,7 +763,7 @@ describe("ModelOutput component", () => {
             });
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().selections).toStrictEqual({
             colorIndicatorId: "art_coverage",
             sizeIndicatorId: "current_art"
@@ -830,7 +830,7 @@ describe("ModelOutput component", () => {
         const store = getStore({selectedTab: "comparison"});
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        const table = wrapper.find(AreaIndicatorsTable);
         expect(table.props().areaFilterId).toBe("area");
         expect(table.props().filters).toStrictEqual(["TEST COMPARISON FILTERS"]);
         expect(table.props().selections).toStrictEqual({
@@ -861,7 +861,7 @@ describe("ModelOutput component", () => {
             });
         const wrapper = shallowMount(ModelOutput, {localVue, store});
 
-        const table = wrapper.findAll(AreaIndicatorsTable).at(1);
+        const table = wrapper.find(AreaIndicatorsTable)
         expect(table.props().selections).toStrictEqual({indicatorId: "art_coverage"});
         expect(table.props().indicators).toStrictEqual(
             [


### PR DESCRIPTION
## Description

This PR Fixes greyed out error bars and awaits comparison data before attempting to plot bar chart. The image below shows the grey out and the expected error bars.

* The issue was caused because display class property was used to display chart. This affected the reactivity of the chart props and could not listen to change events on chart data.  There was also a delay in rendering the chart with both bar and comparison vue-charts. Upon a page refresh, chart config and chart were not displayed immediately, took a few seconds to display.

<img width="763" alt="Screenshot 2022-10-11 at 17 18 45" src="https://user-images.githubusercontent.com/4240748/195146067-2ac4aab8-4d5a-438b-b9e2-a8333e00e430.png">
<img width="762" alt="Screenshot 2022-10-11 at 17 18 37" src="https://user-images.githubusercontent.com/4240748/195146074-ecebe41c-5403-4c77-b6b1-b165e18e18b2.png">



Please describe your changes here

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
