### PR TITLE
mrc-3081 Persist user selections for comparison barchart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.23.0
+
+* Persist user selections for comparison barchart
+
 # hint 2.22.0
 
 * Bug: Fix download status errors

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.22.0";
+export const currentHintVersion = "2.23.0";

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -77,7 +77,11 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 commit({type: ModelCalibrateMutation.CalibrateResultFetched, payload: data});
                 commit({type: ModelCalibrateMutation.WarningsFetched, payload: data.warnings});
 
-                selectFilterDefaults(data, commit, PlottingSelectionsMutations.updateBarchartSelections)
+                const barChartPlotSelections = context.rootState.plottingSelections.barchart
+                // barchart reverts to default selections if selection does not exist in the state.
+                if (!barChartPlotSelections) {
+                    selectFilterDefaults(data, commit, PlottingSelectionsMutations.updateBarchartSelections)
+                }
                 commit(ModelCalibrateMutation.Calibrated);
                 if (switches.modelCalibratePlot) {
                     dispatch("getCalibratePlot");
@@ -116,7 +120,9 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
             .get<ModelResultResponse>(`model/comparison/plot/${calibrateId}`);
 
         if (response) {
-            if (response.data){
+            const comparisonPlotSelections = context.rootState.plottingSelections.comparisonPlot
+            // comparison bar chart revert to default selections if selection does not exist in the state.
+            if (response.data && !comparisonPlotSelections) {
                 selectFilterDefaults(response.data, commit, PlottingSelectionsMutations.updateComparisonPlotSelections)
             }
             commit(ModelCalibrateMutation.SetComparisonPlotData, response.data);


### PR DESCRIPTION
## Description

This PR ensure persisted selections take precedence over default selections. I am unsure why the whole thing is setup this way, default not being persisted or updated but `comparisonPlotSelection` hence the confusion.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
