### PR TITLE
Add link to project news site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,18 @@
+# hint 2.26.3
+
+* Add link to news site from version number drop down and update styling of version drop down
+
 # hint 2.26.2
 
 * Bug: Comparison barchart error bars display incorrectly
 
 # hint 2.26.1
 
-* Bug: prevent spamming when creating a new project during model 
+* Bug: prevent spamming when creating a new project during model
 
-# hint 2.26.0 
+# hint 2.26.0
 
-* Remove fixed disaggregate value from xAxis options in vue-charts 
+* Remove fixed disaggregate value from xAxis options in vue-charts
 
 # hint 2.25.0
 

--- a/src/app/static/src/app/components/header/FileMenu.vue
+++ b/src/app/static/src/app/components/header/FileMenu.vue
@@ -11,7 +11,7 @@
                    style="display: none;" ref="loadZip"
                    @change="loadZip" accept=".zip">
 
-            <a class="dropdown-item" v-on:mousedown="save">
+            <a class="dropdown-item" tabindex="0" v-on:mousedown="save">
                 <span><span class="pr-1" v-translate="'save'"></span>JSON</span>
                 <download-icon size="20" class="icon"></download-icon>
             </a>

--- a/src/app/static/src/app/components/header/HintrVersionMenu.vue
+++ b/src/app/static/src/app/components/header/HintrVersionMenu.vue
@@ -6,11 +6,11 @@
            v-translate="'newsSite'">
         </a>
         <hr class="dropdown-divider">
-        <span class="dropdown-item dropdown-item-inactive"> naomi    : v{{ hintrVersions.naomi }} </span>
-        <span class="dropdown-item dropdown-item-inactive"> hintr    : v{{ hintrVersions.hintr }} </span>
-        <span class="dropdown-item dropdown-item-inactive"> rrq      : v{{ hintrVersions.rrq }} </span>
-        <span class="dropdown-item dropdown-item-inactive"> traduire : v{{ hintrVersions.traduire }}</span>
-        <span class="dropdown-item dropdown-item-inactive"> hint : v{{ hintVersion }}</span>
+        <span class="dropdown-item disabled"> naomi    : v{{ hintrVersions.naomi }} </span>
+        <span class="dropdown-item disabled"> hintr    : v{{ hintrVersions.hintr }} </span>
+        <span class="dropdown-item disabled"> rrq      : v{{ hintrVersions.rrq }} </span>
+        <span class="dropdown-item disabled"> traduire : v{{ hintrVersions.traduire }}</span>
+        <span class="dropdown-item disabled"> hint : v{{ hintVersion }}</span>
     </drop-down>
 </template>
 

--- a/src/app/static/src/app/components/header/HintrVersionMenu.vue
+++ b/src/app/static/src/app/components/header/HintrVersionMenu.vue
@@ -1,10 +1,16 @@
 <template>
     <drop-down :text="`v${hintrVersions.naomi}`" :right="true" style="flex: none">
-        <span class="dropdown-item" style="cursor: default;"> naomi    : v{{ hintrVersions.naomi }} </span>
-        <span class="dropdown-item" style="cursor: default;"> hintr    : v{{ hintrVersions.hintr }} </span>
-        <span class="dropdown-item" style="cursor: default;"> rrq      : v{{ hintrVersions.rrq }} </span>
-        <span class="dropdown-item" style="cursor: default;"> traduire : v{{ hintrVersions.traduire }}</span>
-        <span class="dropdown-item" style="cursor: default;"> hint : v{{ hintVersion }}</span>
+        <a class="dropdown-item"
+           href="https://naomi.unaids.org/news"
+           target="_blank"
+           v-translate="'newsSite'">
+        </a>
+        <hr class="dropdown-divider">
+        <span class="dropdown-item dropdown-item-inactive"> naomi    : v{{ hintrVersions.naomi }} </span>
+        <span class="dropdown-item dropdown-item-inactive"> hintr    : v{{ hintrVersions.hintr }} </span>
+        <span class="dropdown-item dropdown-item-inactive"> rrq      : v{{ hintrVersions.rrq }} </span>
+        <span class="dropdown-item dropdown-item-inactive"> traduire : v{{ hintrVersions.traduire }}</span>
+        <span class="dropdown-item dropdown-item-inactive"> hint : v{{ hintVersion }}</span>
     </drop-down>
 </template>
 

--- a/src/app/static/src/app/components/header/OnlineSupportMenu.vue
+++ b/src/app/static/src/app/components/header/OnlineSupportMenu.vue
@@ -8,6 +8,7 @@
             </a>
             <a class="dropdown-item"
                @click="toggleErrorReportModal"
+               tabindex="0"
                v-translate="'troubleshootingRequest'">
             </a>
             <router-link id="accessibility-link"

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.26.2";
+export const currentHintVersion = "2.26.3";

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -977,7 +977,7 @@ const pt: Partial<Translations> = {
     "                   <li>Algumas páginas poderão não ter a opção de ignorar um passo e saltar para outro conteúdo</li>",
     axeWhatHeading: "O que fazemos relativamente aos problemas conhecidos",
     axeWhatContent: "Tentamos atingir e manter o padrão das <a href=\"https://www.w3.org/TR/WCAG21/\" target='_blank' rel='noopener noreferrer'> WCAG 2.1 AA </a>,\n" +
-        "                mas nem sempre é possível que todos os nossos\n" +
+    "                mas nem sempre é possível que todos os nossos\n" +
     "                conteúdos estejam acessíveis. Sempre que um conteúdo não está acessível, indicamos a razão, avisamos os\n"+
     "                utilizadores e oferecemos alternativas.",
     axeTechnicalHeading: "Informações técnicas sobre a acessibilidade deste sítio web",

--- a/src/app/static/src/app/store/translations/locales.ts
+++ b/src/app/static/src/app/store/translations/locales.ts
@@ -172,6 +172,7 @@ export interface Translations {
     missingError: string,
     modelOptions: string,
     newPassword: string,
+    newsSite: string,
     nextPage: string,
     noData: string,
     noChartData: string,
@@ -489,6 +490,7 @@ const en: Translations = {
     missingError: "API response failed but did not contain any error information. Please contact support.",
     modelOptions: "Model options",
     newPassword: "New password",
+    newsSite: "News",
     nextPage: "Next page",
     noData: "No data are available for these selections.",
     noChartData: "No data are available for the selected combination. Please review the combination of filter values selected.",
@@ -811,6 +813,7 @@ const fr: Partial<Translations> = {
     missingError: "La réponse de l'API a échoué mais ne contenait aucune information d'erreur. Veuillez contacter le support.",
     modelOptions: "Options des modèles",
     newPassword: "Nouveau mot de passe",
+    newsSite: "Nouvelles",
     nextPage: "Page suivante",
     noData: "Aucune donnée n'est disponible pour ces sélections.",
     noChartData: "Aucune donnée n'est disponible pour la combinaison sélectionnée. Veuillez examiner la combinaison de valeurs de filtre sélectionnée.",
@@ -974,7 +977,7 @@ const pt: Partial<Translations> = {
     "                   <li>Algumas páginas poderão não ter a opção de ignorar um passo e saltar para outro conteúdo</li>",
     axeWhatHeading: "O que fazemos relativamente aos problemas conhecidos",
     axeWhatContent: "Tentamos atingir e manter o padrão das <a href=\"https://www.w3.org/TR/WCAG21/\" target='_blank' rel='noopener noreferrer'> WCAG 2.1 AA </a>,\n" +
-    "                mas nem sempre é possível que todos os nossos\n" +
+        "                mas nem sempre é possível que todos os nossos\n" +
     "                conteúdos estejam acessíveis. Sempre que um conteúdo não está acessível, indicamos a razão, avisamos os\n"+
     "                utilizadores e oferecemos alternativas.",
     axeTechnicalHeading: "Informações técnicas sobre a acessibilidade deste sítio web",
@@ -1132,6 +1135,7 @@ const pt: Partial<Translations> = {
     missingError: "A resposta da API falhou mas não continha qualquer informação de erro. Por favor, contacte o apoio.",
     modelOptions: "Opções de modelos",
     newPassword: "Nova palavra-passe",
+    newsSite: "Notícias",
     nextPage: "Próxima página",
     noData: "Não existem dados disponíveis para estas seleções.",
     noChartData: "Não existem dados disponíveis para a combinação selecionada. Por favor, reveja a combinação dos valores de filtro selecionados.",

--- a/src/app/static/src/scss/partials/header.scss
+++ b/src/app/static/src/scss/partials/header.scss
@@ -41,15 +41,29 @@ header {
 }
 
 .dropdown-item {
-  color: $theme-red !important;
+  color: $theme-red;
   cursor: pointer;
 
   &:focus {
-    outline: none !important;
+    outline: none;
   }
 
   &:hover, &.active, :active {
     background-color: $gray-200;
+  }
+}
+
+.dropdown-item-inactive {
+  color: $gray-600;
+  cursor: default;
+
+  &:focus {
+    outline: unset;
+  }
+
+  &:hover, &.active, :active {
+    background-color: unset;
+    color: $gray-600;
   }
 }
 

--- a/src/app/static/src/scss/partials/header.scss
+++ b/src/app/static/src/scss/partials/header.scss
@@ -53,20 +53,6 @@ header {
   }
 }
 
-.dropdown-item-inactive {
-  color: $gray-600;
-  cursor: default;
-
-  &:focus {
-    outline: unset;
-  }
-
-  &:hover, &.active, :active {
-    background-color: unset;
-    color: $gray-600;
-  }
-}
-
 .navbar-header-secondary {
  @include navbar-header-mixin($theme-green)
 }

--- a/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
+++ b/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
@@ -1,5 +1,6 @@
 import {shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
+import {expectTranslated} from "../testHelpers";
 import HintrVersionMenu from "../../../app/components/header/HintrVersionMenu.vue";
 import DropDown from "../../../app/components/header/DropDown.vue";
 import registerTranslations from "../../../app/store/translations/registerTranslations";

--- a/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
+++ b/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
@@ -2,6 +2,7 @@ import {shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import HintrVersionMenu from "../../../app/components/header/HintrVersionMenu.vue";
 import DropDown from "../../../app/components/header/DropDown.vue";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
 import { mockHintrVersionState } from "../../mocks";
 import { emptyState } from "../../../app/root";
 import {currentHintVersion} from "../../../app/hintVersion";
@@ -22,6 +23,7 @@ describe("Hintr Menu Version", () => {
                 }
             }
         });
+        registerTranslations(store);
         return store;
     }
 
@@ -32,6 +34,19 @@ describe("Hintr Menu Version", () => {
         });
 
         expect(wrapper.findAll("span").length).toBe(5);
+    });
+
+    it("hintr version menu displays link to news site", async() => {
+        const store = createStore();
+        const wrapper = shallowMount(HintrVersionMenu, {
+            store
+        });
+
+        const links = wrapper.findAll("a");
+        expect(links.length).toBe(1);
+        const link = links.at(0);
+        expect(link.attributes("href")).toBe("https://naomi.unaids.org/news");
+        expect(link.attributes("target")).toBe("_blank");
     });
 
     it("hintr version menu displays current hint version", async() => {

--- a/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
+++ b/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
@@ -1,6 +1,6 @@
 import {shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
-import {expectTranslated} from "../testHelpers";
+import {expectTranslated} from "../../testHelpers";
 import HintrVersionMenu from "../../../app/components/header/HintrVersionMenu.vue";
 import DropDown from "../../../app/components/header/DropDown.vue";
 import registerTranslations from "../../../app/store/translations/registerTranslations";

--- a/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
+++ b/src/app/static/src/tests/components/header/hintrVersionMenu.test.ts
@@ -45,6 +45,7 @@ describe("Hintr Menu Version", () => {
         const links = wrapper.findAll("a");
         expect(links.length).toBe(1);
         const link = links.at(0);
+        expectTranslated(link, "News", "Nouvelles", "Notícias", store);
         expect(link.attributes("href")).toBe("https://naomi.unaids.org/news");
         expect(link.attributes("target")).toBe("_blank");
     });


### PR DESCRIPTION
## Description

This PR will add a link to the news site into the version number drop down and updates the styling of the version drop down to make it clearer that the version numbers themselves are not clickable

For the styling here I removed the `!important` attribute on the dropdown-item styling which then meant the non href and non  tabindex drop down items lost their styling (troubleshooting request and save json). I added tabindex attribute to these as from reading around it "indicates that its element can be focused" which makes sense as they are clickable actions. Let me know if this approach is not the ideal one though, my CSS & SASS knowledge is pretty bad

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
