### PR TITLE
Add google analytics to main page and data exploration

### DIFF
--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -6,12 +6,18 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <!-- inject:css -->
     <!-- endinject -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-JPYDD02750');
+    var host = window.location.hostname;
+    if(host != "localhost")
+    {
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-JPYDD02750');
+        </script>
+    }
     </script>
 </head>
 <body>

--- a/src/app/static/templates/data-exploration.ftl
+++ b/src/app/static/templates/data-exploration.ftl
@@ -6,6 +6,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <!-- inject:css -->
     <!-- endinject -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JPYDD02750');
+    </script>
 </head>
 <body>
 <div id="app" :class="language">

--- a/src/app/static/templates/index.ftl
+++ b/src/app/static/templates/index.ftl
@@ -6,12 +6,18 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <!-- inject:css -->
     <!-- endinject -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-JPYDD02750');
+    var host = window.location.hostname;
+    if(host != "localhost")
+    {
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-JPYDD02750');
+        </script>
+    }
     </script>
 </head>
 <body>

--- a/src/app/static/templates/index.ftl
+++ b/src/app/static/templates/index.ftl
@@ -6,6 +6,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <!-- inject:css -->
     <!-- endinject -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JPYDD02750"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JPYDD02750');
+    </script>
 </head>
 <body>
 <div id="app" :class="language">


### PR DESCRIPTION
## Description

Add google analytics

This is a very basic impl, it will send info about users accessing main naomi site and the data exploration. These show up in the dashboard as
![Screenshot_20221114_164232](https://user-images.githubusercontent.com/39248272/201716346-a57da048-8dc9-475d-8cc7-b25e623b8c80.png)

I've given admin access to the dashboard to you @EmmaLRussell, @LekanAnni if you pm me your google account (or set one up for your imperial email) I will share with you too.

My plan with this is I will give Ian admin access and he can configure the reports how he wants. 

One potential issue is this will report back for all instances (prod, staging, preview, and dev). I have ignored localhost but all other systems will upload to google analytics, I think that is probably fine but let me know if you guys think otherwise.


## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
