### PR TITLE
Add delay to closing the dialog so link can be opened

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ app/static/coverage/**
 app/static/public/js/**
 app/static/public/css/**
 .DS_Store
+.vscode

--- a/src/app/static/src/app/components/header/HintrVersionMenu.vue
+++ b/src/app/static/src/app/components/header/HintrVersionMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <drop-down :text="`v${hintrVersions.naomi}`" :right="true" style="flex: none">
+    <drop-down :text="`v${hintrVersions.naomi}`" :right="true" :delay="true" style="flex: none">
         <a class="dropdown-item"
            href="https://naomi.unaids.org/news"
            target="_blank"

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.26.3";
+export const currentHintVersion = "2.26.4";


### PR DESCRIPTION
## Description

Noticed the new News link doesn't work! :facepalm: this fixes it by adding a delay to dropdown closing so that the link can actually be opened

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
