### PR TITLE
Make PJNZ and survey data not required for data exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ apt-get install adoptopenjdk-11-hotspot -y
 
 1. Clone this repo
 1. Run `npm install` from `src/app/static`
-1. Run `./scripts/run-development-dependencies.sh` to start docker instances of [hint-db](https://github.com/mrc-ide/hint-db/) 
+1. Run `./scripts/run-development-dependencies.sh` to start docker instances of [hint-db](https://github.com/mrc-ide/hint-db/)
 and [hintr](https://github.com/mrc-ide/hintr) and add a test user with username `test.user@example.com`
  and password `password`.
 1. Run `npm run build` from `src/app/static` to compile front-end dependencies.
@@ -61,14 +61,22 @@ Versions should follow the [semantic versioning](https://semver.org/) format, so
 - PATCH version when you make backwards compatible bug fixes.
 
 This may cause relatively frequently conflicts since more than one person is likely to be working on a new version at a
-time. In this case, you should give your branch its own new version number, rather than rolling your changes into the same 
-version number as changes from another branch. 
+time. In this case, you should give your branch its own new version number, rather than rolling your changes into the same
+version number as changes from another branch.
 
 ### Distribution
 A docker image containing the app is created as part of the BuildKite build. To create such an image locally,
-run `./buildkite/make-build-env.sh` followed by `./buildkite/build.sh`. A CLI image is also created as part of 
+run `./buildkite/make-build-env.sh` followed by `./buildkite/build.sh`. A CLI image is also created as part of
 the BuildKite build, using `./buildkite/build-cli.sh`.
 
-Run `docker run -p 8080:8080 --name hint mrcide/hint:branch_name` to run a built image. The app will not start until 
-config is provided at `/etc/hint/config.properties`. This config is added during deployment with 
+Run `docker run -p 8080:8080 --name hint mrcide/hint:branch_name` to run a built image. The app will not start until
+config is provided at `/etc/hint/config.properties`. This config is added during deployment with
 [hint-deploy](https://github.com/mrc-ide/hint-deploy)
+
+### Generate types
+Types are generated automatically from JSON schema in hintr. To regenerate types
+
+```
+cd src/app/static
+./scripts/generate-types.sh
+```

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -20,7 +20,6 @@ interface HintrAPIClient
         file: VersionFileWithPath,
         shapePath: String?,
         type: FileType,
-        pjnzPath: String?,
         strict: Boolean
     ): ResponseEntity<String>
 
@@ -89,13 +88,11 @@ class HintrFuelAPIClient(
     override fun validateSurveyAndProgramme(file: VersionFileWithPath,
                                             shapePath: String?,
                                             type: FileType,
-                                            pjnzPath: String?,
                                             strict: Boolean): ResponseEntity<String>
     {
 
         val json = objectMapper.writeValueAsString(
                 mapOf("type" to type.toString().lowercase(),
-                        "pjnz" to pjnzPath.orEmpty(),
                         "file" to file,
                         "shape" to shapePath.orEmpty()))
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HintrController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/HintrController.kt
@@ -59,7 +59,7 @@ open class HintrController(protected val fileManager: FileManager,
             {
                 val files = fileManager.getFiles(FileType.PJNZ, FileType.Shape)
 
-                if (files[FileType.PJNZ.toString()]?.path.isNullOrBlank())
+                if (strict && files[FileType.PJNZ.toString()]?.path.isNullOrBlank())
                 {
                     throw HintException("missingPjnzFile",
                             HttpStatus.BAD_REQUEST)
@@ -71,10 +71,9 @@ open class HintrController(protected val fileManager: FileManager,
                             HttpStatus.BAD_REQUEST)
                 }
 
-                val pjnzPath = files[FileType.PJNZ.toString()]?.path
                 val shapePath = files[FileType.Shape.toString()]?.path
 
-                apiClient.validateSurveyAndProgramme(file, shapePath, type, pjnzPath, strict)
+                apiClient.validateSurveyAndProgramme(file, shapePath, type, strict)
             }
         }
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -50,7 +50,7 @@ class HintrApiClientTests
     {
         val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
         val file = VersionFileWithPath("fakepath", "hash", "filename", false)
-        val result = sut.validateSurveyAndProgramme(file, "fakepath", FileType.ANC, "pjnz-path",true)
+        val result = sut.validateSurveyAndProgramme(file, "fakepath", FileType.ANC, true)
         assertThat(result.statusCodeValue).isEqualTo(400)
         JSONValidator().validateError(result.body!!, "INVALID_FILE")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -414,7 +414,7 @@ class ADRControllerTests : HintrControllerTests()
         verify(mockApiClient)
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.Survey, "pjnz-path", true)
+                        "shape-path", FileType.Survey, true)
     }
 
     @Test
@@ -430,7 +430,7 @@ class ADRControllerTests : HintrControllerTests()
         verify(mockApiClient)
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.Survey, "pjnz-path",false)
+                        "shape-path", FileType.Survey, false)
     }
 
     @Test
@@ -446,7 +446,7 @@ class ADRControllerTests : HintrControllerTests()
         verify(mockApiClient)
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.Survey, "pjnz-path", true)
+                        "shape-path", FileType.Survey, true)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DiseaseControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DiseaseControllerTests.kt
@@ -167,7 +167,7 @@ class DiseaseControllerTests : HintrControllerTests()
         verify(mockApiClient, Times(2))
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.ANC, "pjnz-path", true)
+                        "shape-path", FileType.ANC, true)
     }
 
     @Test
@@ -185,7 +185,7 @@ class DiseaseControllerTests : HintrControllerTests()
         verify(mockApiClient, Times(2))
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.ANC, "pjnz-path", false)
+                        "shape-path", FileType.ANC, false)
     }
 
     @Test
@@ -203,6 +203,6 @@ class DiseaseControllerTests : HintrControllerTests()
         verify(mockApiClient, Times(2))
                 .validateSurveyAndProgramme(
                         VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                        "shape-path", FileType.ANC, "pjnz-path", true)
+                        "shape-path", FileType.ANC, true)
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/HintrControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/HintrControllerTests.kt
@@ -64,7 +64,7 @@ abstract class HintrControllerTests
     {
         return mock {
             on { validateBaselineIndividual(argWhere { it.path == "test-path" }, eq(type)) } doReturn ResponseEntity("VALIDATION_RESPONSE", HttpStatus.OK)
-            on { validateSurveyAndProgramme(argWhere { it.path == "test-path" }, eq("shape-path"), eq(type), eq("pjnz-path"), any()) } doReturn
+            on { validateSurveyAndProgramme(argWhere { it.path == "test-path" }, eq("shape-path"), eq(type), any()) } doReturn
                     ResponseEntity("VALIDATION_RESPONSE", HttpStatus.OK)
         }
     }
@@ -95,7 +95,7 @@ abstract class HintrControllerTests
             else -> verify(mockApiClient)
                     .validateSurveyAndProgramme(
                             VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                            "shape-path", fileType, "pjnz-path",true)
+                            "shape-path", fileType, true)
         }
     }
 
@@ -119,7 +119,7 @@ abstract class HintrControllerTests
                             VersionFileWithPath("test-path", "hash", "some-file-name.csv", false), fileType)
             else -> verify(mockApiClient)
                     .validateSurveyAndProgramme(VersionFileWithPath("test-path", "hash", "some-file-name.csv", false),
-                            "shape-path", fileType, "pjnz-path",true)
+                            "shape-path", fileType, true)
         }
     }
 

--- a/src/app/static/generateTypes.js
+++ b/src/app/static/generateTypes.js
@@ -1,5 +1,5 @@
 'use strict';
-// This file is executed by ./generate-types.sh
+// This file is executed by ./scripts/generate-types.sh
 
 const schemaToTs = require('json-schema-to-typescript');
 const fs = require('fs');

--- a/src/app/static/src/app/components/uploadInputs/UploadInputs.vue
+++ b/src/app/static/src/app/components/uploadInputs/UploadInputs.vue
@@ -4,7 +4,7 @@
             <div class="col-sm-6 col-md-8">
                 <form>
                     <manage-file label="PJNZ"
-                                 :required="true"
+                                 :required="!dataExplorationMode"
                                  :valid="pjnz.valid"
                                  :fromADR="pjnz.fromADR"
                                  :error="pjnz.error || plottingMetadataError"
@@ -39,7 +39,7 @@
                                  name="population">
                     </manage-file>
                     <manage-file label="survey"
-                                 :required="true"
+                                 :required="!dataExplorationMode"
                                  :valid="survey.valid"
                                  :fromADR="survey.fromADR"
                                  :error="survey.error"

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -791,14 +791,29 @@ export interface ControlSection {
 }
 export interface ControlGroup {
   label?: string;
-  controls: (SelectControl | NumberControl)[];
+  controls: (SelectControl | MultiselectControl | NumberControl)[];
 }
 export interface SelectControl {
   name: string;
   label?: string;
-  type: "select" | "multiselect";
+  type: "select";
   required: boolean;
   value?: string;
+  helpText?: string;
+  options?: {
+    id: string;
+    label: string;
+    children?: {
+      [k: string]: any;
+    }[];
+  }[];
+}
+export interface MultiselectControl {
+  name: string;
+  label?: string;
+  type: "multiselect";
+  required: boolean;
+  value?: string[] | string;
   helpText?: string;
   options?: {
     id: string;
@@ -1459,7 +1474,6 @@ export interface ValidateSurveyAndProgrammeRequest {
     fromADR?: boolean;
   };
   shape: string | null;
-  pjnz: string | null;
 }
 export interface VersionInfo {
   hintr: string;

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.29.2";
+export const currentHintVersion = "2.29.3";

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -52,8 +52,7 @@ async function uploadOrImportPJNZ(context: ActionContext<BaselineState, DataExpl
                 dispatch('validate');
             } else {
                 commit({type: BaselineMutation.PJNZErroredFile, payload: filename});
-            }
-            dispatch('surveyAndProgram/validateSurveyAndProgramData', {}, {root: true});
+            };
         });
 }
 

--- a/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
+++ b/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
@@ -92,7 +92,7 @@ describe("UploadInputs upload component", () => {
 
     it("does not show required text in front of pjnz upload label when on data exploration mode", () => {
         const store = createSut();
-        expectFileIsRequired(store, 0)
+        expectFileIsNotRequired(store, 0)
     });
 
     it("shows required text in front of pjnz upload label when not on data exploration mode", () => {
@@ -122,7 +122,7 @@ describe("UploadInputs upload component", () => {
 
     it("does not show required text in front of survey upload label when on data exploration mode", () => {
         const store = createSut();
-        expectFileIsRequired(store, 3)
+        expectFileIsNotRequired(store, 3)
     });
 
     it("shows required text in front of survey upload label when not on data exploration mode", () => {
@@ -318,7 +318,7 @@ describe("UploadInputs upload component", () => {
         expectDeleteToDispatchAction(2, () => actions.deletePopulation, done);
     });
 
-    it("can return true when fromADR", async () => { 
+    it("can return true when fromADR", async () => {
         const store = createSut({
             pjnz: {
                 "fromADR": true,
@@ -344,10 +344,10 @@ describe("UploadInputs upload component", () => {
         expect(wrapper.findAll("manage-file-stub").at(0).props().fromADR).toBe(true);
         expect(wrapper.findAll("manage-file-stub").at(1).props().fromADR).toBe(true);
         expect(wrapper.findAll("manage-file-stub").at(2).props().fromADR).toBe(true);
-        
+
     });
 
-    it("can return false when not fromADR", async () => { 
+    it("can return false when not fromADR", async () => {
         const store = createSut({
             pjnz: {
                 "fromADR": "",
@@ -373,7 +373,7 @@ describe("UploadInputs upload component", () => {
         expect(wrapper.findAll("manage-file-stub").at(0).props().fromADR).toBe(false);
         expect(wrapper.findAll("manage-file-stub").at(1).props().fromADR).toBe(false);
         expect(wrapper.findAll("manage-file-stub").at(2).props().fromADR).toBe(false);
-        
+
     });
 
     it("passes survey response existing file name to manage file", () => {

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-master
+mrc-3853


### PR DESCRIPTION
## Description

This PR will
* Not send PJNZ file to programme & survey validation as it is no longer required (since https://github.com/mrc-ide/hintr/pull/432)
* Stop PJNZ and survey data being required for data exploration mode

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
