### PR TITLE
mrc-3870 - fix spectrum file validation issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.30.1
+
+* Fix spectrum file validation issue.
+
 # hint 2.30.0
 
 * Improve comparison plot usability

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.30.0";
+export const currentHintVersion = "2.30.1";

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -47,9 +47,9 @@ async function uploadOrImportPJNZ(context: ActionContext<BaselineState, DataExpl
         .freezeResponse()
         .postAndReturn<PjnzResponse>(options.url, options.payload)
         .then((response) => {
+            uploadCallback(dispatch, response);
             if (response) {
                 dispatch('metadata/getPlottingMetadata', state.iso3, {root: true});
-                dispatch('validate');
             } else {
                 commit({type: BaselineMutation.PJNZErroredFile, payload: filename});
             }

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -7,7 +7,6 @@ import {
     mockError,
     mockFailure,
     mockMetadataState,
-    mockPlottingMetadataResponse,
     mockPopulationResponse,
     mockRootState,
     mockShapeResponse,
@@ -193,20 +192,19 @@ describe("Baseline actions", () => {
     const checkPJNZImportUpload = (commit: Mock, dispatch: Mock) => {
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: BaselineMutation.PJNZUpdated, payload: null});
-
         expectEqualsFrozen(commit.mock.calls[1][0], {
             type: BaselineMutation.PJNZUpdated,
             payload: {data: {country: "Malawi", iso3: "MWI"}}
         });
 
-        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls.length).toBe(3);
 
-        expect(dispatch.mock.calls[0][0]).toBe("metadata/getPlottingMetadata");
-        expect(dispatch.mock.calls[0][1]).toBe("MWI");
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
-
-        expect(dispatch.mock.calls[1].length).toBe(1);
-        expect(dispatch.mock.calls[1][0]).toBe("validate");
+        expect(dispatch.mock.calls[1].length).toBe(3);
+        expect(dispatch.mock.calls[0][0]).toBe("validate");
+        expect(dispatch.mock.calls[1][0]).toBe("metadata/getPlottingMetadata");
+        expect(dispatch.mock.calls[1][1]).toBe("MWI");
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][0]).toBe("surveyAndProgram/validateSurveyAndProgramData");
     }
 
     it("upload PJNZ does not fetch plotting metadata or validate if error occurs", async () => {
@@ -218,7 +216,8 @@ describe("Baseline actions", () => {
         const dispatch = jest.fn();
         await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, mockFormData as any);
 
-        expect(dispatch.mock.calls.length).toBe(0);
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/validateSurveyAndProgramData")
     });
 
     it("import PJNZ does not fetch plotting metadata or validate if error occurs", async () => {
@@ -230,7 +229,8 @@ describe("Baseline actions", () => {
         const dispatch = jest.fn();
         await actions.importPJNZ({commit, state, dispatch, rootState} as any, "some-url/some-file.txt");
 
-        expect(dispatch.mock.calls.length).toBe(0);
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/validateSurveyAndProgramData")
 
         expect(commit.mock.calls.length).toBe(3);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "PJNZUpdated", payload: null});


### PR DESCRIPTION
## Description

When a user deletes spectrum file, survey and program datasets errored. Upon uploading spectrum file manually, the error does not get erased. This PR fixes the issue.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
