### PR TITLE
mrc-3872 Save serialized profile for OAuth2 users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.30.1
+
+* Save profiles for new OAuth2 users
+
 # hint 2.30.0
 
 * Improve comparison plot usability

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/UserRepository.kt
@@ -1,5 +1,6 @@
 package org.imperial.mrc.hint.db
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.imperial.mrc.hint.db.Tables.ADR_KEY
 import org.imperial.mrc.hint.db.tables.Users.USERS
 import org.imperial.mrc.hint.exceptions.UserException
@@ -78,6 +79,24 @@ class JooqUserRepository(private val dsl: DSLContext) : UserRepository
         dsl.insertInto(USERS)
             .set(USERS.ID, email)
             .set(USERS.USERNAME, email)
+            .set(USERS.SERIALIZEDPROFILE, getOAuth2UserSerializedProfile(email))
             .execute()
+    }
+
+    private fun getOAuth2UserSerializedProfile(email: String): String
+    {
+        return ObjectMapper().writeValueAsString(
+            mapOf(
+                "id" to email,
+                "attributes" to mapOf("username" to email),
+                "authenticationAttributes" to mapOf<String, Any>(),
+                "isRemembered" to false,
+                "roles" to arrayOf<Any>(),
+                "permissions" to arrayOf<Any>(),
+                "clientName" to null,
+                "linkedId" to null,
+                "canAttributesBeMerged" to true
+            )
+        )
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -119,7 +119,7 @@ class UserRepositoryTests
         val user = dsl.selectFrom(USERS)
                 .fetchOne()
         assertThat(user?.get(USERS.ID)).isEqualTo(testEmail)
-        assertThat(user?.get(USERS.USERNAME).isEqualTo(testEmail)
+        assertThat(user?.get(USERS.USERNAME)).isEqualTo(testEmail)
         val expectedProfile = """{"id":"james@example.com","attributes":{"username":"james@example.com"},"authenticationAttributes":{},"isRemembered":false,"roles":[],"permissions":[],"clientName":null,"linkedId":null,"canAttributesBeMerged":true}""";
         assertThat(user?.get(USERS.SERIALIZEDPROFILE)).isEqualTo(expectedProfile)
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.database
 import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.caseInsensitiveEmail
 import org.imperial.mrc.hint.db.Tables.ADR_KEY
+import org.imperial.mrc.hint.db.Tables.USERS
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.exceptions.HintException
 import org.imperial.mrc.hint.helpers.TranslationAssert
@@ -109,6 +110,18 @@ class UserRepositoryTests
             .find { caseInsensitiveEmail(testEmail).matches(it) }
 
         assertEquals(testEmail, "test@test.com")
+    }
+
+    @Test
+    fun `can save serialized profile for oauth2 user`()
+    {
+        sut.addOAuth2User(testEmail)
+        val user = dsl.selectFrom(USERS)
+                .fetchOne()
+        assertThat(user?.get(USERS.ID)).isEqualTo(testEmail)
+        assertThat(user?.get(USERS.USERNAME).isEqualTo(testEmail)
+        val expectedProfile = """{"id":"james@example.com","attributes":{"username":"james@example.com"},"authenticationAttributes":{},"isRemembered":false,"roles":[],"permissions":[],"clientName":null,"linkedId":null,"canAttributesBeMerged":true}""";
+        assertThat(user?.get(USERS.SERIALIZEDPROFILE)).isEqualTo(expectedProfile)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/UserRepositoryTests.kt
@@ -117,10 +117,11 @@ class UserRepositoryTests
     {
         sut.addOAuth2User(testEmail)
         val user = dsl.selectFrom(USERS)
+                .where(USERS.ID.eq(testEmail))
                 .fetchOne()
         assertThat(user?.get(USERS.ID)).isEqualTo(testEmail)
         assertThat(user?.get(USERS.USERNAME)).isEqualTo(testEmail)
-        val expectedProfile = """{"id":"james@example.com","attributes":{"username":"james@example.com"},"authenticationAttributes":{},"isRemembered":false,"roles":[],"permissions":[],"clientName":null,"linkedId":null,"canAttributesBeMerged":true}""";
+        val expectedProfile = """{"id":"test@test.com","attributes":{"username":"test@test.com"},"authenticationAttributes":{},"isRemembered":false,"roles":[],"permissions":[],"clientName":null,"linkedId":null,"canAttributesBeMerged":true}""";
         assertThat(user?.get(USERS.SERIALIZEDPROFILE)).isEqualTo(expectedProfile)
     }
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.30.0";
+export const currentHintVersion = "2.30.1";


### PR DESCRIPTION
## Description

This branch adds saving `serializedProfile` information to the database for new OAuth2 users - this is required so that sharing of projects works. (We need the profile to be saved so that pac4j recognises the user.) Possibly not all these fields are strictly required, but we know this format works!

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
