### PR TITLE
mrc-3871 Make refresh button realtime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.31.2
+
+* Make refresh button realtime
+
 # hint 2.31.1
 
 * Setup Playwright and add Browser test for data exploration login

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.31.1";
+export const currentHintVersion = "2.31.2";

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -111,14 +111,14 @@ export const actions: ActionTree<BaselineState, DataExplorationState> & Baseline
                 .then((response) => {
                     if (response) {
                         const metadata = response.data;
-                        const availableResource = rootGetters ? rootGetters["baseline/selectedDatasetAvailableResources"] : {}
+                        const availableResources = rootGetters ? rootGetters["baseline/selectedDatasetAvailableResources"] : {}
                         const exceptions = { // where DatasetResource keys do not match ADRSchemas keys
                             pop: "population",
                             program: "programme"
                         }
                         const resources: { [k in keyof DatasetResourceSet]?: DatasetResource | null } = {}
 
-                        Object.entries(availableResource).forEach(([key, value]) => {
+                        Object.entries(availableResources).forEach(([key, value]) => {
                             // If an available resource has a value, find the resource (using the alternate schema key where needed)
                             // and add it to the committed object under the original key
                             const schemaKey = key in exceptions ? exceptions[key as "pop" || "program"] : key

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -4,11 +4,10 @@ import {api} from "../../apiService";
 import {PjnzResponse, PopulationResponse, ShapeResponse, ValidateBaselineResponse} from "../../generated";
 import {BaselineMutation} from "./mutations";
 import qs from "qs";
-import {datasetFromMetadata, findResource, getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
+import {findResource, getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
 import { DatasetResourceSet, DatasetResource, ADRSchemas } from "../../types";
 import {DataExplorationState} from "../dataExploration/dataExploration";
 import {initialChorplethSelections} from "../plottingSelections/plottingSelections";
-import {ADRMutation} from "../adr/mutations";
 
 export interface BaselineActions {
     refreshDatasetMetadata: (store: ActionContext<BaselineState, DataExplorationState>) => void

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -607,7 +607,7 @@ describe("Baseline actions", () => {
         });
     });
 
-    it("refreshDatasetMetadata does not attempt to retrieve resources not found in selectedDatasetAvailableResources getter", async () => {
+    it("refreshDatasetMetadata attempts to retrieve all available resources", async () => {
 
         mockAxios.onGet("/adr/datasets/1234")
             .reply(200, mockSuccess({
@@ -623,6 +623,15 @@ describe("Baseline actions", () => {
             anc: null
         }
 
+        const expectResources = {
+            shape: availableResources.shape,
+            pjnz: availableResources.pjnz,
+            pop: availableResources.pop,
+            survey: availableResources.survey,
+            program: availableResources.program,
+            anc: availableResources.anc
+        }
+
         const commit = jest.fn();
         const state = mockBaselineState({
             selectedDataset: mockDataset({ id: "1234" })
@@ -635,7 +644,7 @@ describe("Baseline actions", () => {
         await actions.refreshDatasetMetadata({ commit, rootState, state, rootGetters } as any);
 
         expect(commit.mock.calls[0][0]).toBe(BaselineMutation.UpdateDatasetResources);
-        expect(commit.mock.calls[0][1]).toEqual(resources);
+        expect(commit.mock.calls[0][1]).toEqual(expectResources);
     });
 
     it("refreshDatasetMetadata takes release into account", async () => {


### PR DESCRIPTION
## Description

At the moment when resources are deleted from ADR and re-uploaded hint does not detect changes. This PR finds all resources and make changes. Instead of checking if resources have values we check if the key exists. I am unclear why the values are checked in the first place but I believe we can get rid of the checks all together, let me know your opinion.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
