### PR TITLE
Mrc 3945 Fix project load issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.32.2
+
+* fix project load
+
 # hint 2.32.1
 
 * As a user I can see ADR source URL in output zip for input data so I know the source of the files

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -75,7 +75,7 @@ class LocalFileManager(
         originalFilename: String,
         type: FileType,
         fromADR: Boolean,
-        resourceUrl: String? = "",
+        resourceUrl: String? = null,
     ): VersionFileWithPath
     {
         val md = MessageDigest.getInstance("MD5")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/VersionFileWithPath.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/VersionFileWithPath.kt
@@ -7,7 +7,7 @@ data class VersionFile(
     val filename: String,
     val fromAdr: Boolean,
     @field:JsonProperty("resource_url")
-    val resourceUrl: String? = "")
+    val resourceUrl: String? = null)
 {
     fun toVersionFileWithPath(pathDirectory: String): VersionFileWithPath
     {
@@ -20,5 +20,5 @@ data class VersionFileWithPath(
     val filename: String,
     val fromADR: Boolean,
     @field:JsonProperty("resource_url")
-    val resourceUrl: String? = ""
+    val resourceUrl: String? = null
 )

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/VersionRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/VersionRepositoryTests.kt
@@ -516,6 +516,21 @@ class VersionRepositoryTests
     }
 
     @Test
+    fun `can get version file with nullable resourceUrl`()
+    {
+        setUpVersionAndHash()
+        sut.saveVersionFile(
+            versionId,
+            FileType.PJNZ,
+            "newhash",
+            "original.pjnz",
+            true
+        )
+        val result = sut.getVersionFile(versionId, FileType.PJNZ)!!
+        assertThat(result.resourceUrl).isEqualTo("")
+    }
+
+    @Test
     fun `can get all version file hashes`()
     {
         setUpVersionAndHash()

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -15593,7 +15593,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         }
       }
@@ -15606,7 +15606,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "lodash.memoize": {
@@ -18776,7 +18776,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         }
       }
@@ -19326,7 +19326,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -19482,7 +19482,7 @@
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -19494,7 +19494,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -19513,13 +19513,13 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -19546,7 +19546,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.32.1";
+export const currentHintVersion = "2.32.2";

--- a/src/app/static/src/tests/integration/load.itest.ts
+++ b/src/app/static/src/tests/integration/load.itest.ts
@@ -61,7 +61,7 @@ describe("load actions", () => {
                     hash: shape.hash,
                     filename: shape.filename,
                     fromAdr: false,
-                    resource_url: ""
+                    resource_url: null
                 }
             });
             expect(dispatch.mock.calls[0][1]).toStrictEqual({
@@ -166,7 +166,7 @@ describe("load actions", () => {
                             hash: shape.hash,
                             filename: shape.filename,
                             fromAdr: false,
-                            resource_url: ""
+                            resource_url: null
                         }
                 });
             expect(mockSaveToLocalStorage.mock.calls[0][0].baseline).toBe("TEST BASELINE");


### PR DESCRIPTION
## Description

This PR adds test to the changes made in hintr regarding resourceUrl. Initial implementation does not allow null value, resource_url has must contain data. However, this causes validation issue when loading legacy projects. This is now fixed and tests are added to this effect.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
