### PR TITLE
mrc-3921 User doesn't have perms over a resource when the dataset refreshes

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/Extensions.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/Extensions.kt
@@ -23,6 +23,8 @@ import java.io.*
 import java.security.DigestInputStream
 import java.security.MessageDigest
 import jakarta.xml.bind.DatatypeConverter
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
 
 fun httpStatusFromCode(code: Int): HttpStatus
 {
@@ -165,3 +167,12 @@ fun caseInsensitiveEmail(email: String): Regex
 {
     return Regex("(?i)${email}")
 }
+
+fun getUri(url: String): URI
+{
+    return UriComponentsBuilder
+        .fromHttpUrl(url)
+        .build()
+        .toUri()
+}
+

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -12,7 +12,9 @@ import java.io.InputStream
 import java.security.DigestInputStream
 import java.security.MessageDigest
 import jakarta.xml.bind.DatatypeConverter
+import org.imperial.mrc.hint.exceptions.AdrException
 import org.imperial.mrc.hint.models.*
+import org.springframework.http.HttpStatus
 import org.springframework.web.util.UriComponentsBuilder
 
 enum class FileType
@@ -65,9 +67,14 @@ class LocalFileManager(
 
         val resourceUrl = getResourceUrl(data, originalFilename)
 
-        val inputStream = adr.getInputStream(data.url)
+        val response = adr.getInputStream(data.url)
 
-        return saveFile(inputStream, originalFilename, type, true, resourceUrl)
+        if (response.statusCode() != 200)
+        {
+            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), response.uri())
+        }
+
+        return saveFile(response.body(), originalFilename, type, true, resourceUrl)
     }
 
     private fun saveFile(

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -75,16 +75,16 @@ class LocalFileManager(
              * When a user is unauthenticated or lack required permission, the user gets redirected
              * to auth0 login page. handleAdrException handles permission and unexpected ADR errors
              */
-            if (response.uri().host.contains("eu.auth0.com"))
+            if (response.statusCode() == 302)
             {
                 throw AdrException(
                     "noPermissionToAccessResource",
                     HttpStatus.valueOf(response.statusCode()),
-                    data.url
+                    arrayOf(data.url)
                 )
             }
 
-            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), data.url)
+            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), arrayOf(data.url))
         }
 
         return saveFile(response.body(), originalFilename, type, true, resourceUrl)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -69,13 +69,13 @@ class LocalFileManager(
 
         val response = adr.getInputStream(data.url)
 
-        if (response.statusCode() != 200)
+        if (response.statusCode() != HttpStatus.OK.value())
         {
             /**
              * When a user is unauthenticated or lack required permission, the user gets redirected
              * to auth0 login page. handleAdrException handles permission and unexpected ADR errors
              */
-            if (response.statusCode() == 302)
+            if (response.statusCode() == HttpStatus.TEMPORARY_REDIRECT.value())
             {
                 throw AdrException(
                     "noPermissionToAccessResource",

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -71,7 +71,20 @@ class LocalFileManager(
 
         if (response.statusCode() != 200)
         {
-            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), response.uri())
+            /**
+             * When a user is unauthenticated or lack required permission, the user gets redirected
+             * to auth0 login page. handleAdrException handles permission and unexpected ADR errors
+             */
+            if (response.uri().host.contains("eu.auth0.com"))
+            {
+                throw AdrException(
+                    "noPermissionToAccessResource",
+                    HttpStatus.valueOf(response.statusCode()),
+                    data.url
+                )
+            }
+
+            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), data.url)
         }
 
         return saveFile(response.body(), originalFilename, type, true, resourceUrl)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -75,7 +75,7 @@ class LocalFileManager(
              * When a user is unauthenticated or lack required permission, the user gets redirected
              * to auth0 login page. handleAdrException handles permission and unexpected ADR errors
              */
-            if (response.statusCode() == HttpStatus.TEMPORARY_REDIRECT.value())
+            if (response.statusCode() == HttpStatus.FOUND.value())
             {
                 throw AdrException(
                     "noPermissionToAccessResource",

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/FileManager.kt
@@ -80,11 +80,11 @@ class LocalFileManager(
                 throw AdrException(
                     "noPermissionToAccessResource",
                     HttpStatus.valueOf(response.statusCode()),
-                    arrayOf(data.url)
+                    data.url
                 )
             }
 
-            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), arrayOf(data.url))
+            throw AdrException("adrResourceError", HttpStatus.valueOf(response.statusCode()), data.url)
         }
 
         return saveFile(response.body(), originalFilename, type, true, resourceUrl)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -9,10 +9,9 @@ import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import java.io.BufferedInputStream
 import java.io.File
-import java.net.URL
-import java.net.URLConnection
+import java.io.InputStream
+import java.net.http.HttpResponse
 
 @Component
 class ADRClientBuilder(val appProperties: AppProperties,
@@ -33,7 +32,7 @@ class ADRClientBuilder(val appProperties: AppProperties,
 
 interface ADRClient
 {
-    fun getInputStream(url: String): BufferedInputStream
+    fun getInputStream(url: String): HttpResponse<InputStream>
     fun get(url: String): ResponseEntity<String>
     fun post(url: String, params: List<Pair<String, String>>): ResponseEntity<String>
     fun postFile(url: String, parameters: List<Pair<String, Any?>>, file: Pair<String, File>): ResponseEntity<String>
@@ -68,10 +67,8 @@ class ADRFuelClient(appProperties: AppProperties,
         return mapOf("Authorization" to apiKey)
     }
 
-    override fun getInputStream(url: String): BufferedInputStream
+    override fun getInputStream(url: String): HttpResponse<InputStream>
     {
-        val urlConn: URLConnection = URL(url).openConnection()
-        urlConn.setRequestProperty("Authorization", apiKey)
-        return logADRRequestDuration({ BufferedInputStream(urlConn.getInputStream()) }, logger)
+        return logADRRequestDuration({ getFile(url) }, logger)
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -43,6 +43,8 @@ class ADRFuelClient(appProperties: AppProperties,
                     private val logger: GenericLogger)
     : FuelClient(appProperties.adrUrl + "api/3/action"), ADRClient
 {
+    private val header = Pair("Authorization", apiKey)
+
     override fun get(url: String): ResponseEntity<String>
     {
         return logADRRequestDuration({ super.get(url) }, logger)
@@ -64,11 +66,16 @@ class ADRFuelClient(appProperties: AppProperties,
 
     override fun standardHeaders(): Map<String, Any>
     {
-        return mapOf("Authorization" to apiKey)
+        return mapOf(header.first to header.second)
+    }
+
+    override fun httpRequestHeaders(): Array<String>
+    {
+        return arrayOf(header.first, header.second)
     }
 
     override fun getInputStream(url: String): HttpResponse<InputStream>
     {
-        return logADRRequestDuration({ getFile(getUri(url)) }, logger)
+        return logADRRequestDuration({ getStream(getUri(url)) }, logger)
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -9,6 +9,7 @@ import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 import java.io.File
 import java.io.InputStream
 import java.net.http.HttpResponse
@@ -69,6 +70,6 @@ class ADRFuelClient(appProperties: AppProperties,
 
     override fun getInputStream(url: String): HttpResponse<InputStream>
     {
-        return logADRRequestDuration({ getFile(url) }, logger)
+        return logADRRequestDuration({ getFile(getUri(url)) }, logger)
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -9,7 +9,6 @@ import org.imperial.mrc.hint.security.Encryption
 import org.imperial.mrc.hint.security.Session
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import org.springframework.web.util.UriComponentsBuilder
 import java.io.File
 import java.io.InputStream
 import java.net.http.HttpResponse

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -26,6 +26,8 @@ abstract class FuelClient(protected val baseUrl: String)
 
     abstract fun standardHeaders(): Map<String, Any>
 
+    abstract fun httpRequestHeaders(): Array<String>
+
     open fun get(url: String): ResponseEntity<String>
     {
         return "$baseUrl/$url".httpGet()
@@ -96,12 +98,10 @@ abstract class FuelClient(protected val baseUrl: String)
 
     private fun getRequest(uri: URI): HttpRequest
     {
-        val entry = standardHeaders().entries.first()
-
         return HttpRequest
             .newBuilder()
             .uri(uri)
-            .header(entry.key, entry.value.toString())
+            .headers(*httpRequestHeaders())
             .GET()
             .build()
     }
@@ -113,7 +113,7 @@ abstract class FuelClient(protected val baseUrl: String)
             .followRedirects(HttpClient.Redirect.ALWAYS)
     }
 
-    protected fun getFile(uri: URI): HttpResponse<InputStream>
+    protected fun getStream(uri: URI): HttpResponse<InputStream>
     {
         return this.clientBuilder()
             .build()

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -8,9 +8,9 @@ import com.github.kittinunf.fuel.httpPost
 import com.github.kittinunf.fuel.httpUpload
 import org.imperial.mrc.hint.asResponseEntity
 import org.springframework.http.ResponseEntity
-import org.springframework.web.util.UriComponentsBuilder
 import java.io.File
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpClient.Builder
 import java.net.http.HttpRequest
@@ -94,18 +94,13 @@ abstract class FuelClient(protected val baseUrl: String)
                 .asResponseEntity()
     }
 
-    private fun getRequest(url: String): HttpRequest
+    private fun getRequest(uri: URI): HttpRequest
     {
         val entry = standardHeaders().entries.first()
 
-        val uriBuilder = UriComponentsBuilder
-            .fromHttpUrl(url)
-            .build()
-            .toUri()
-
         return HttpRequest
             .newBuilder()
-            .uri(uriBuilder)
+            .uri(uri)
             .header(entry.key, entry.value.toString())
             .GET()
             .build()
@@ -118,10 +113,10 @@ abstract class FuelClient(protected val baseUrl: String)
             .followRedirects(HttpClient.Redirect.ALWAYS)
     }
 
-    protected fun getFile(url: String): HttpResponse<InputStream>
+    protected fun getFile(uri: URI): HttpResponse<InputStream>
     {
         return this.clientBuilder()
             .build()
-            .send(this.getRequest(url), HttpResponse.BodyHandlers.ofInputStream())
+            .send(this.getRequest(uri), HttpResponse.BodyHandlers.ofInputStream())
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelClient.kt
@@ -8,7 +8,13 @@ import com.github.kittinunf.fuel.httpPost
 import com.github.kittinunf.fuel.httpUpload
 import org.imperial.mrc.hint.asResponseEntity
 import org.springframework.http.ResponseEntity
+import org.springframework.web.util.UriComponentsBuilder
 import java.io.File
+import java.io.InputStream
+import java.net.http.HttpClient
+import java.net.http.HttpClient.Builder
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 abstract class FuelClient(protected val baseUrl: String)
 {
@@ -86,5 +92,36 @@ abstract class FuelClient(protected val baseUrl: String)
                 .response()
                 .second
                 .asResponseEntity()
+    }
+
+    private fun getRequest(url: String): HttpRequest
+    {
+        val entry = standardHeaders().entries.first()
+
+        val uriBuilder = UriComponentsBuilder
+            .fromHttpUrl(url)
+            .build()
+            .toUri()
+
+        return HttpRequest
+            .newBuilder()
+            .uri(uriBuilder)
+            .header(entry.key, entry.value.toString())
+            .GET()
+            .build()
+    }
+
+    private fun clientBuilder(): Builder
+    {
+        return HttpClient
+            .newBuilder()
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+    }
+
+    protected fun getFile(url: String): HttpResponse<InputStream>
+    {
+        return this.clientBuilder()
+            .build()
+            .send(this.getRequest(url), HttpResponse.BodyHandlers.ofInputStream())
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelFlowClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/FuelFlowClient.kt
@@ -23,6 +23,11 @@ class FuelFlowClient(
         return emptyMap()
     }
 
+    override fun httpRequestHeaders(): Array<String>
+    {
+        return emptyArray()
+    }
+
     override fun notifyTeams(data: ErrorReport): ResponseEntity<String>
     {
         return postJson(null, objectMapper.writeValueAsString(data))

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -74,6 +74,11 @@ class HintrFuelAPIClient(
         return mapOf("Accept-Language" to getAcceptLanguage())
     }
 
+    override fun httpRequestHeaders(): Array<String>
+    {
+        return emptyArray()
+    }
+
     override fun validateBaselineIndividual(file: VersionFileWithPath,
                                             type: FileType): ResponseEntity<String>
     {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
@@ -1,6 +1,5 @@
 package org.imperial.mrc.hint.exceptions
 
 import org.springframework.http.HttpStatus
-import java.net.URI
 
-class AdrException(key: String, status: HttpStatus, uri: URI) : HintException(key, status, uri)
+class AdrException(key: String, status: HttpStatus, url: String) : HintException(key, status, url)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
@@ -5,5 +5,5 @@ import org.springframework.http.HttpStatus
 class AdrException(
     key: String,
     status: HttpStatus,
-    url: Array<String> = arrayOf("")
-) : HintException(key, status, url)
+    url: String
+) : HintException(key, status, arrayOf(url))

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
@@ -2,4 +2,8 @@ package org.imperial.mrc.hint.exceptions
 
 import org.springframework.http.HttpStatus
 
-class AdrException(key: String, status: HttpStatus, url: String) : HintException(key, status, url)
+class AdrException(
+    key: String,
+    status: HttpStatus,
+    url: Array<String> = arrayOf("")
+) : HintException(key, status, url)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/AdrException.kt
@@ -1,0 +1,6 @@
+package org.imperial.mrc.hint.exceptions
+
+import org.springframework.http.HttpStatus
+import java.net.URI
+
+class AdrException(key: String, status: HttpStatus, uri: URI) : HintException(key, status, uri)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
@@ -1,10 +1,9 @@
 package org.imperial.mrc.hint.exceptions
 
 import org.springframework.http.HttpStatus
-import java.net.URI
 
 open class HintException(
         val key: String,
         val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
-        val adrUri: String? = null
+        val args: Array<String> = arrayOf("")
 ) : Exception("HintException with key $key")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
@@ -6,5 +6,5 @@ import java.net.URI
 open class HintException(
         val key: String,
         val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
-        val adrUri: URI? = null
+        val adrUri: String? = null
 ) : Exception("HintException with key $key")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintException.kt
@@ -1,6 +1,10 @@
 package org.imperial.mrc.hint.exceptions
 
 import org.springframework.http.HttpStatus
+import java.net.URI
 
-open class HintException(val key: String, val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR) :
-        Exception("HintException with key $key")
+open class HintException(
+        val key: String,
+        val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+        val adrUri: URI? = null
+) : Exception("HintException with key $key")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.exceptions
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.logging.GenericLogger
 import org.imperial.mrc.hint.models.ErrorDetail
+import org.imperial.mrc.hint.models.ErrorDetail.Companion.defaultError
 import org.springframework.beans.TypeMismatchException
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
@@ -102,7 +103,7 @@ class HintExceptionHandler(private val errorCodeGenerator: ErrorCodeGenerator,
         val formatter = MessageFormat(message)
         message = formatter.format(args)
 
-        return ErrorDetail(status, message).toResponseEntity()
+        return ErrorDetail(status, message, defaultError).toResponseEntity()
     }
 
     private fun translatedError(key: String, status: HttpStatus, request: HttpServletRequest): ResponseEntity<Any>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
@@ -75,6 +75,23 @@ class HintExceptionHandler(private val errorCodeGenerator: ErrorCodeGenerator,
         return translatedError(error.key, error.httpStatus, request)
     }
 
+    /**
+     * When a user is unauthenticated or lack required permission, the user gets redirected
+     * to auth0 login page. handleAdrException handles permission and unexpected ADR errors
+     */
+    @ExceptionHandler(AdrException::class)
+    fun handleAdrException(error: AdrException, request: HttpServletRequest): ResponseEntity<Any>
+    {
+        logger.error(request, error)
+
+        if (error.adrUri != null && error.adrUri.host.contains(".eu.auth0.com"))
+        {
+            return translatedError("noPermissionToAccessResource", HttpStatus.UNAUTHORIZED, request)
+        }
+
+        return translatedError(error.key, error.httpStatus, request)
+    }
+
     private fun getBundle(request: HttpServletRequest): ResourceBundle
     {
         val language = request.getHeader("Accept-Language") ?: "en"

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
@@ -80,9 +80,7 @@ class HintExceptionHandler(private val errorCodeGenerator: ErrorCodeGenerator,
     {
         logger.error(request, error)
 
-        val messageArguments = arrayOf(error.adrUri ?: "")
-
-        return translatedErrorArgs(error.key, messageArguments, error.httpStatus, request)
+        return translatedErrorArgs(error.key, error.args, error.httpStatus, request)
     }
 
     private fun getBundle(request: HttpServletRequest): ResourceBundle

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
@@ -95,7 +95,7 @@ class HintExceptionHandler(private val errorCodeGenerator: ErrorCodeGenerator,
         key: String,
         args: Array<String>,
         status: HttpStatus,
-        request: HttpServletRequest,
+        request: HttpServletRequest
     ): ResponseEntity<Any>
     {
         val resourceBundle = getBundle(request)

--- a/src/app/src/main/resources/ErrorMessageBundle.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle.properties
@@ -12,5 +12,5 @@ missingPjnzFile=You must upload a Spectrum file before uploading survey or progr
 invalidToken=Token is not valid.
 invalidPasswordLength=Password must be at least 6 characters long.
 unknownInputTimeSeriesType=Unknown input time series type.
-noPermissionToAccessResource=You do not have ADR permission to load this resource.
-adrResourceError=Unable to load this resource, check if resource is available in ADR.
+noPermissionToAccessResource=You do not have permission to load this resource from ADR. Contact dataset admin for permission.
+adrResourceError=Unable to load resource, check resource in ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle.properties
@@ -12,3 +12,5 @@ missingPjnzFile=You must upload a Spectrum file before uploading survey or progr
 invalidToken=Token is not valid.
 invalidPasswordLength=Password must be at least 6 characters long.
 unknownInputTimeSeriesType=Unknown input time series type.
+noPermissionToAccessResource=You do not have ADR permission to load this resource.
+adrResourceError=Unable to load this resource, check if resource is available in ADR.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -12,5 +12,6 @@ unexpectedError=Une erreur inattendue s''est produite. \
 userDoesNotExist=L'utilisateur n'existe pas.
 userExists=L'utilisateur existe dÃ©jÃ .
 unknownInputTimeSeriesType=Type de sÃ©rie temporelle d'entrÃ©e inconnu
-noPermissionToAccessResource=Vous n'avez pas l'autorisation ADR pour charger cette ressource.
-adrResourceError=Impossible de charger cette ressource, vérifiez si la ressource est disponible dans ADR.
+noPermissionToAccessResource=Vous nêtes pas autorisé à charger cette ressource à partir dADR. \
+  Contactez ladministrateur de lensemble de données pour obtenir lautorisation
+adrResourceError=Impossible de charger la ressource, vérifiez la ressource dans ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -12,3 +12,5 @@ unexpectedError=Une erreur inattendue s''est produite. \
 userDoesNotExist=L'utilisateur n'existe pas.
 userExists=L'utilisateur existe déjà.
 unknownInputTimeSeriesType=Type de série temporelle d'entrée inconnu
+noPermissionToAccessResource=Vous n'avez pas l'autorisation ADR pour charger cette ressource.
+adrResourceError=Impossible de charger cette ressource, v�rifiez si la ressource est disponible dans ADR.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -12,6 +12,6 @@ unexpectedError=Une erreur inattendue s''est produite. \
 userDoesNotExist=L'utilisateur n'existe pas.
 userExists=L'utilisateur existe d√©j√†.
 unknownInputTimeSeriesType=Type de s√©rie temporelle d'entr√©e inconnu
-noPermissionToAccessResource=Vous nÍtes pas autorisÈ ‡ charger cette ressource ‡ partir dADR. \
-  Contactez ladministrateur de lensemble de donnÈes pour obtenir lautorisation
-adrResourceError=Impossible de charger la ressource, vÈrifiez la ressource dans ADR {0}.
+noPermissionToAccessResource=Vous n√™tes pas autoris√© √† charger cette ressource √† partir dADR. Contactez ladministrateur \
+  de lensemble de donn√©es pour obtenir lautorisation.
+adrResourceError=Impossible de charger la ressource, v√©rifiez la ressource dans ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -12,6 +12,6 @@ unexpectedError=Une erreur inattendue s''est produite. \
 userDoesNotExist=L'utilisateur n'existe pas.
 userExists=L'utilisateur existe déjà.
 unknownInputTimeSeriesType=Type de série temporelle d'entrée inconnu
-noPermissionToAccessResource=Vous nêtes pas autorisé à charger cette ressource à partir dADR. Contactez ladministrateur \
-  de lensemble de données pour obtenir lautorisation.
+noPermissionToAccessResource=Vous n'êtes pas autorisé à charger cette ressource à partir d'ADR. Contacter \
+  l'administrateur de l'ensemble de données pour obtenir l'autorisation
 adrResourceError=Impossible de charger la ressource, vérifiez la ressource dans ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -12,6 +12,6 @@ unexpectedError=Une erreur inattendue s''est produite. \
 userDoesNotExist=L'utilisateur n'existe pas.
 userExists=L'utilisateur existe déjà.
 unknownInputTimeSeriesType=Type de série temporelle d'entrée inconnu
-noPermissionToAccessResource=Vous n'êtes pas autorisé à charger cette ressource à partir d'ADR. Contacter \
-  l'administrateur de l'ensemble de données pour obtenir l'autorisation
+noPermissionToAccessResource=Vous n''êtes pas autorisé à charger cette ressource à partir d''ADR. \
+  Contacter l''administrateur de l''ensemble de données pour obtenir l''autorisation
 adrResourceError=Impossible de charger la ressource, vérifiez la ressource dans ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle_pt.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_pt.properties
@@ -12,6 +12,5 @@ unexpectedError=Um erro inesperado ocorreu. \
 userDoesNotExist=Usu√°rio n√£o existe.
 userExists=Usu√°rio j√° existe.
 unknownInputTimeSeriesType=Tipo de s√©rie temporal de entrada desconhecido
-noPermissionToAccessResource=VocÍ n„o tem permiss„o para carregar este recurso do ADR. Entre em contato \
-  com o administrador do conjunto de dados para obter permiss„o.
-adrResourceError=N„o È possÌvel carregar o recurso, verifique o recurso no ADR {0}.
+noPermissionToAccessResource=Voc√™ n√£o tem permiss√£o para carregar este recurso do ADR. Entre em contato com o administrador do conjunto de dados para obter permiss√£o.
+adrResourceError=N√£o √© poss√≠vel carregar o recurso, verifique o recurso no ADR {0}.

--- a/src/app/src/main/resources/ErrorMessageBundle_pt.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_pt.properties
@@ -12,3 +12,5 @@ unexpectedError=Um erro inesperado ocorreu. \
 userDoesNotExist=Usu√°rio n√£o existe.
 userExists=Usu√°rio j√° existe.
 unknownInputTimeSeriesType=Tipo de s√©rie temporal de entrada desconhecido
+noPermissionToAccessResource=VocÍ n„o tem permiss„o ADR para carregar este recurso.
+adrResourceError=N„o È possÌvel carregar este recurso, verifique se o recurso est· disponÌvel no ADR.

--- a/src/app/src/main/resources/ErrorMessageBundle_pt.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_pt.properties
@@ -12,5 +12,6 @@ unexpectedError=Um erro inesperado ocorreu. \
 userDoesNotExist=UsuÃ¡rio nÃ£o existe.
 userExists=UsuÃ¡rio jÃ¡ existe.
 unknownInputTimeSeriesType=Tipo de sÃ©rie temporal de entrada desconhecido
-noPermissionToAccessResource=Você não tem permissão ADR para carregar este recurso.
-adrResourceError=Não é possível carregar este recurso, verifique se o recurso está disponível no ADR.
+noPermissionToAccessResource=Você não tem permissão para carregar este recurso do ADR. Entre em contato \
+  com o administrador do conjunto de dados para obter permissão.
+adrResourceError=Não é possível carregar o recurso, verifique o recurso no ADR {0}.

--- a/src/app/src/main/resources/application.properties
+++ b/src/app/src/main/resources/application.properties
@@ -15,3 +15,4 @@ server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javasc
 server.compression.min-response-size=1024
 server.servlet.session.timeout=120m
 logging.config=classpath:logback-spring.xml
+spring.messages.encoding=UTF-8

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/helpers/Helpers.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/helpers/Helpers.kt
@@ -46,3 +46,7 @@ fun getJsonEntity(payload: Map<String, Any>): HttpEntity<String>
     val jsonString = ObjectMapper().writeValueAsString(payload)
     return HttpEntity(jsonString, headers)
 }
+
+enum class Language {
+    FR, EN, PT
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -104,7 +104,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
         expectTranslatedAdrException(
             "noPermissionToAccessResource",
             "Vous nêtes pas autorisé à charger cette ressource à partir dADR. Contactez ladministrateur " +
-                    "de lensemble de données pour obtenir lautorisation",
+                    "de lensemble de données pour obtenir lautorisation.",
             Language.FR,
         )
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -31,7 +31,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
 
     private val mockLogger = mock<GenericLogger>()
 
-    private val adrUrl = "https://adr-resource-server.com"
+    private val errorArgs = arrayOf("https://adr-resource-server.com")
 
     @Test
     fun `route not found errors are correctly formatted`()
@@ -63,7 +63,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Unable to load resource, check resource in ADR $adrUrl.",
+            "Unable to load resource, check resource in ADR ${errorArgs.first()}.",
             Language.EN,
         )
     }
@@ -74,7 +74,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
             "adrResourceError",
             "Unable to load resource, check resource in ADR .",
             Language.EN,
-            ""
+            arrayOf("")
         )
     }
 
@@ -83,7 +83,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Impossible de charger la ressource, vérifiez la ressource dans ADR $adrUrl.",
+            "Impossible de charger la ressource, vérifiez la ressource dans ADR ${errorArgs.first()}.",
             Language.FR
         )
     }
@@ -93,7 +93,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Não é possível carregar o recurso, verifique o recurso no ADR $adrUrl.",
+            "Não é possível carregar o recurso, verifique o recurso no ADR ${errorArgs.first()}.",
             Language.PT
         )
     }
@@ -113,8 +113,8 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "noPermissionToAccessResource",
-            "Vous nêtes pas autorisé à charger cette ressource à partir dADR. Contactez ladministrateur " +
-                    "de lensemble de données pour obtenir lautorisation.",
+            "Vous n'êtes pas autorisé à charger cette ressource à partir d'ADR. Contacter l'administrateur " +
+                    "de l'ensemble de données pour obtenir l'autorisation",
             Language.FR,
         )
     }
@@ -254,7 +254,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
         key: String,
         expectedMessage: String,
         lang: Language,
-        adrUrl: String = this.adrUrl,
+        args: Array<String> = this.errorArgs,
     )
     {
         val mockProperties = mock<AppProperties>()
@@ -269,7 +269,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
             AdrException(
                 key,
                 HttpStatus.SERVICE_UNAVAILABLE,
-                adrUrl
+                args
             ), mockRequest
         )
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -113,8 +113,8 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "noPermissionToAccessResource",
-            "Vous n'êtes pas autorisé à charger cette ressource à partir d'ADR. Contacter l'administrateur " +
-                    "de l'ensemble de données pour obtenir l'autorisation",
+            "Vous nêtes pas autorisé à charger cette ressource à partir dADR. " +
+                    "Contacter ladministrateur de lensemble de données pour obtenir lautorisation",
             Language.FR,
         )
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -6,11 +6,9 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.ConfiguredAppProperties
-import org.imperial.mrc.hint.exceptions.ErrorCodeGenerator
-import org.imperial.mrc.hint.exceptions.HintException
-import org.imperial.mrc.hint.exceptions.HintExceptionHandler
-import org.imperial.mrc.hint.exceptions.RandomErrorCodeGenerator
+import org.imperial.mrc.hint.exceptions.*
 import org.imperial.mrc.hint.helpers.JSONValidator
+import org.imperial.mrc.hint.helpers.Language
 import org.imperial.mrc.hint.helpers.tmpUploadDirectory
 import org.imperial.mrc.hint.helpers.unexpectedErrorRegex
 import org.imperial.mrc.hint.logging.GenericLogger
@@ -32,6 +30,8 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     private val mockException = mock<HttpMessageNotWritableException>()
 
     private val mockLogger = mock<GenericLogger>()
+
+    private val fakeResourceUrl = "https://resource-server.com"
 
     @Test
     fun `route not found errors are correctly formatted`()
@@ -56,6 +56,68 @@ class ExceptionHandlerTests : SecureIntegrationTests()
 
         Assertions.assertThat(entity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         Assertions.assertThat(entity.body).contains("404 Error Page")
+    }
+
+    @Test
+    fun `adr resource error are correctly formatted in English`()
+    {
+        expectTranslatedAdrException(
+            "adrResourceError",
+            "Unable to load resource, check resource in ADR $fakeResourceUrl.",
+            Language.EN,
+        )
+    }
+
+    @Test
+    fun `adr resource error are correctly formatted in French`()
+    {
+        expectTranslatedAdrException(
+            "adrResourceError",
+            "Impossible de charger la ressource, vérifiez la ressource dans ADR $fakeResourceUrl.",
+            Language.FR
+        )
+    }
+
+    @Test
+    fun `adr resource error are correctly formatted in Portuguese`()
+    {
+        expectTranslatedAdrException(
+            "adrResourceError",
+            "Não é possível carregar o recurso, verifique o recurso no ADR $fakeResourceUrl.",
+            Language.PT
+        )
+    }
+
+    @Test
+    fun `adr no permission to load resource error are correctly formatted in English`()
+    {
+        expectTranslatedAdrException(
+            "noPermissionToAccessResource",
+            "You do not have permission to load this resource from ADR. Contact dataset admin for permission.",
+            Language.EN,
+        )
+    }
+
+    @Test
+    fun `adr no permission to load resource error are correctly formatted in French`()
+    {
+        expectTranslatedAdrException(
+            "noPermissionToAccessResource",
+            "Vous nêtes pas autorisé à charger cette ressource à partir dADR. Contactez ladministrateur " +
+                    "de lensemble de données pour obtenir lautorisation",
+            Language.FR,
+        )
+    }
+
+    @Test
+    fun `adr no permission to load resource error are correctly formatted in Portuguese`()
+    {
+        expectTranslatedAdrException(
+            "noPermissionToAccessResource",
+            "Você não tem permissão para carregar este recurso do ADR. Entre em contato com o " +
+                    "administrador do conjunto de dados para obter permissão.",
+            Language.PT,
+        )
     }
 
     @Test
@@ -178,4 +240,24 @@ class ExceptionHandlerTests : SecureIntegrationTests()
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
+    private fun expectTranslatedAdrException(key: String, expectedMessage: String, lang: Language)
+    {
+        val mockProperties = mock<AppProperties>()
+
+        val mockRequest = mock<HttpServletRequest> {
+            on { getHeader("Accept-Language") } doReturn lang.toString()
+        }
+
+        val sut = HintExceptionHandler(mock(), mockProperties, mockLogger)
+
+        val result = sut.handleAdrException(
+            AdrException(
+                key,
+                HttpStatus.SERVICE_UNAVAILABLE,
+                fakeResourceUrl
+            ), mockRequest
+        )
+
+        JSONValidator().validateError(result.body!!.toString(), "OTHER_ERROR", expectedMessage)
+    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -31,7 +31,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
 
     private val mockLogger = mock<GenericLogger>()
 
-    private val fakeResourceUrl = "https://resource-server.com"
+    private val adrUrl = "https://adr-resource-server.com"
 
     @Test
     fun `route not found errors are correctly formatted`()
@@ -63,8 +63,18 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Unable to load resource, check resource in ADR $fakeResourceUrl.",
+            "Unable to load resource, check resource in ADR $adrUrl.",
             Language.EN,
+        )
+    }
+    @Test
+    fun `adr resource error are correctly formatted without adrURl`()
+    {
+        expectTranslatedAdrException(
+            "adrResourceError",
+            "Unable to load resource, check resource in ADR .",
+            Language.EN,
+            ""
         )
     }
 
@@ -73,7 +83,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Impossible de charger la ressource, vérifiez la ressource dans ADR $fakeResourceUrl.",
+            "Impossible de charger la ressource, vérifiez la ressource dans ADR $adrUrl.",
             Language.FR
         )
     }
@@ -83,7 +93,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "adrResourceError",
-            "Não é possível carregar o recurso, verifique o recurso no ADR $fakeResourceUrl.",
+            "Não é possível carregar o recurso, verifique o recurso no ADR $adrUrl.",
             Language.PT
         )
     }
@@ -240,7 +250,12 @@ class ExceptionHandlerTests : SecureIntegrationTests()
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
-    private fun expectTranslatedAdrException(key: String, expectedMessage: String, lang: Language)
+    private fun expectTranslatedAdrException(
+        key: String,
+        expectedMessage: String,
+        lang: Language,
+        adrUrl: String = this.adrUrl,
+    )
     {
         val mockProperties = mock<AppProperties>()
 
@@ -254,7 +269,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
             AdrException(
                 key,
                 HttpStatus.SERVICE_UNAVAILABLE,
-                fakeResourceUrl
+                adrUrl
             ), mockRequest
         )
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -113,8 +113,8 @@ class ExceptionHandlerTests : SecureIntegrationTests()
     {
         expectTranslatedAdrException(
             "noPermissionToAccessResource",
-            "Vous nêtes pas autorisé à charger cette ressource à partir dADR. " +
-                    "Contacter ladministrateur de lensemble de données pour obtenir lautorisation",
+            "Vous n'êtes pas autorisé à charger cette ressource à partir d'ADR. Contacter " +
+                    "l'administrateur de l'ensemble de données pour obtenir l'autorisation",
             Language.FR,
         )
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -74,7 +74,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
             "adrResourceError",
             "Unable to load resource, check resource in ADR .",
             Language.EN,
-            arrayOf("")
+            ""
         )
     }
 
@@ -254,7 +254,7 @@ class ExceptionHandlerTests : SecureIntegrationTests()
         key: String,
         expectedMessage: String,
         lang: Language,
-        args: Array<String> = this.errorArgs,
+        args: String = "https://adr-resource-server.com",
     )
     {
         val mockProperties = mock<AppProperties>()

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -181,6 +181,6 @@ class HintrApiClientTests
     fun `httpRequestHeaders returns empty string`()
     {
         val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        Assertions.assertThat(sut.httpRequestHeaders()).isEqualTo(arrayOf(""))
+        Assertions.assertThat(sut.httpRequestHeaders()).isEmpty()
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HintrAPIClientTests.kt
@@ -1,6 +1,7 @@
 package org.imperial.mrc.hint.integration.clients
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.imperial.mrc.hint.ConfiguredAppProperties
 import org.imperial.mrc.hint.FileType
@@ -174,5 +175,12 @@ class HintrApiClientTests
         val result = sut.getInputTimeSeriesChartData("anc", emptyMap())
         assertThat(result.statusCodeValue).isEqualTo(400)
         JSONValidator().validateError(result.body!!, "INVALID_INPUT")
+    }
+
+    @Test
+    fun `httpRequestHeaders returns empty string`()
+    {
+        val sut = HintrFuelAPIClient(ConfiguredAppProperties(), ObjectMapper())
+        Assertions.assertThat(sut.httpRequestHeaders()).isEqualTo(arrayOf(""))
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HttpClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/clients/HttpClientTests.kt
@@ -1,0 +1,34 @@
+package org.imperial.mrc.hint.integration.clients
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions
+import org.imperial.mrc.hint.ConfiguredAppProperties
+import org.imperial.mrc.hint.clients.ADRFuelClient
+import org.imperial.mrc.hint.logging.GenericLogger
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class HttpClientTests
+{
+    private val mockLogger = mock<GenericLogger>()
+
+    @Test
+    fun `can parse inputStream success response`()
+    {
+        val sut = ADRFuelClient(ConfiguredAppProperties(), "fakekey", mockLogger)
+        val response = sut.getInputStream("https://mock.codes/200")
+        Assertions.assertThat(response.statusCode()).isEqualTo(200)
+        Assertions.assertThat(response.body().bufferedReader().use { it.readText() }).isNotBlank
+        verify(mockLogger).info(Mockito.contains("ADR request time elapsed: "))
+    }
+
+    @Test
+    fun `can parse inputStream server error response`()
+    {
+        val sut = ADRFuelClient(ConfiguredAppProperties(), "fakekey", mockLogger)
+        val response = sut.getInputStream("https://mock.codes/503")
+        Assertions.assertThat(response.statusCode()).isEqualTo(503)
+        verify(mockLogger).info(Mockito.contains("ADR request time elapsed: "))
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
@@ -46,6 +46,7 @@ class ADRClientBuilderTests
         val result = sut.build() as ADRFuelClient
         val headers = result.standardHeaders()
         Assertions.assertThat(headers["Authorization"]).isEqualTo(TEST_KEY)
+        Assertions.assertThat(result.httpRequestHeaders()).isEqualTo(arrayOf("Authorization", TEST_KEY))
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/LocalFileManagerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/LocalFileManagerTests.kt
@@ -22,6 +22,8 @@ import org.springframework.http.ResponseEntity
 import org.springframework.mock.web.MockMultipartFile
 import java.io.BufferedInputStream
 import java.io.File
+import java.io.InputStream
+import java.net.http.HttpResponse
 
 class LocalFileManagerTests
 {
@@ -46,6 +48,10 @@ class LocalFileManagerTests
     }
 
     private val objectMapper = ObjectMapper()
+
+    private val mockInputStream = mock<HttpResponse<InputStream>> {
+        on { body() } doReturn BufferedInputStream("test content".byteInputStream())
+    }
 
     @AfterEach
     fun tearDown()
@@ -102,7 +108,7 @@ class LocalFileManagerTests
             on { saveNewHash(any()) } doReturn true
         }
         val mockClient = mock<ADRClient> {
-            on { getInputStream(any()) } doReturn BufferedInputStream("test content".byteInputStream())
+            on { getInputStream(any()) } doReturn mockInputStream
             on { get(anyString()) } doReturn mockAdrActivityResponse
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -156,7 +162,7 @@ class LocalFileManagerTests
     {
 
         val mockClient = mock<ADRClient> {
-            on { getInputStream(any()) } doReturn BufferedInputStream("test content".byteInputStream())
+            on { getInputStream(any()) } doReturn mockInputStream
             on { get(anyString()) } doReturn mockAdrActivityResponse
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -177,7 +183,7 @@ class LocalFileManagerTests
             on { saveNewHash(any()) } doReturn false
         }
         val mockClient = mock<ADRClient> {
-            on { getInputStream(any()) } doReturn BufferedInputStream("test content".byteInputStream())
+            on { getInputStream(any()) } doReturn mockInputStream
             on { get(anyString()) } doReturn mockAdrActivityResponse
         }
         val mockBuilder = mock<ADRClientBuilder> {
@@ -289,7 +295,7 @@ class LocalFileManagerTests
         }
 
         val mockClient = mock<ADRClient> {
-            on { getInputStream(any()) } doReturn BufferedInputStream("test content".byteInputStream())
+            on { getInputStream(any()) } doReturn mockInputStream
             on { get(anyString()) } doReturn activityResponse
         }
         val mockBuilder = mock<ADRClientBuilder> {

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
@@ -64,7 +64,7 @@ class FuelFlowClientTests
 
         val sut = LocalFuelFlowClient(ObjectMapper(), mockAppProperties)
 
-        assertThat(sut.httpRequestHeaders()).isEqualTo(arrayOf(""))
+        assertThat(sut.httpRequestHeaders()).isEmpty()
 
         sut.notifyTeams(data)
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/FuelFlowClientTests.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.clients.FuelFlowClient
 import org.imperial.mrc.hint.models.ErrorReport
@@ -64,35 +64,37 @@ class FuelFlowClientTests
 
         val sut = LocalFuelFlowClient(ObjectMapper(), mockAppProperties)
 
+        assertThat(sut.httpRequestHeaders()).isEqualTo(arrayOf(""))
+
         sut.notifyTeams(data)
 
-        Assertions.assertThat(sut.urlPathCapture).isNull()
+        assertThat(sut.urlPathCapture).isNull()
 
         val requestJson = ObjectMapper().readValue<JsonNode>(sut.jsonCapture!!)
 
-        Assertions.assertThat(requestJson["email"].asText()).isEqualTo("test.user@example.com")
-        Assertions.assertThat(requestJson["country"].asText()).isEqualTo("Kenya")
-        Assertions.assertThat(requestJson["projectName"].asText()).isEqualTo("Kenya2022")
-        Assertions.assertThat(requestJson["section"].asText()).isEqualTo("Model")
-        Assertions.assertThat(requestJson["modelRunId"].asText()).isEqualTo("123")
-        Assertions.assertThat(requestJson["calibrateId"].asText()).isEqualTo("1234")
-        Assertions.assertThat(requestJson["downloadIds"]["spectrum"].asText()).isEqualTo("spectrum123")
-        Assertions.assertThat(requestJson["downloadIds"]["summary"].asText()).isEqualTo("summary123")
-        Assertions.assertThat(requestJson["downloadIds"]["coarse_output"].asText()).isEqualTo("coarse123")
-        Assertions.assertThat(requestJson["errors"][0]["key"].asText()).isEqualTo("fomot-hasah-livad")
-        Assertions.assertThat(requestJson["errors"][0]["error"].asText()).isEqualTo("test error msg")
-        Assertions.assertThat(requestJson["errors"][0]["detail"].asText()).isEqualTo("#65ae0d095ea")
-        Assertions.assertThat(requestJson["errors"][1]["key"].asText()).isEqualTo("fomot-hasah-livid")
-        Assertions.assertThat(requestJson["errors"][1]["error"].asText()).isEqualTo("test error msg2")
-        Assertions.assertThat(requestJson["errors"][1]["detail"].asText()).isEqualTo("#25ae0d095e1")
-        Assertions.assertThat(requestJson["description"].asText()).isEqualTo("")
-        Assertions.assertThat(requestJson["stepsToReproduce"].asText()).isEqualTo("test steps")
-        Assertions.assertThat(requestJson["browserAgent"].asText()).isEqualTo("test agent")
-        Assertions.assertThat(requestJson["versions"]["naomi"].asText()).isEqualTo("v1")
-        Assertions.assertThat(requestJson["versions"]["hintr"].asText()).isEqualTo("v2")
-        Assertions.assertThat(requestJson["versions"]["rrq"].asText()).isEqualTo("v3")
-        Assertions.assertThat(requestJson["versions"]["traduire"].asText()).isEqualTo("v4")
-        Assertions.assertThat(requestJson["versions"]["hint"].asText()).isEqualTo("v5")
-        Assertions.assertThat(requestJson["timeStamp"].asText()).isEqualTo("2021-10-12T14:07:22.759Z")
+        assertThat(requestJson["email"].asText()).isEqualTo("test.user@example.com")
+        assertThat(requestJson["country"].asText()).isEqualTo("Kenya")
+        assertThat(requestJson["projectName"].asText()).isEqualTo("Kenya2022")
+        assertThat(requestJson["section"].asText()).isEqualTo("Model")
+        assertThat(requestJson["modelRunId"].asText()).isEqualTo("123")
+        assertThat(requestJson["calibrateId"].asText()).isEqualTo("1234")
+        assertThat(requestJson["downloadIds"]["spectrum"].asText()).isEqualTo("spectrum123")
+        assertThat(requestJson["downloadIds"]["summary"].asText()).isEqualTo("summary123")
+        assertThat(requestJson["downloadIds"]["coarse_output"].asText()).isEqualTo("coarse123")
+        assertThat(requestJson["errors"][0]["key"].asText()).isEqualTo("fomot-hasah-livad")
+        assertThat(requestJson["errors"][0]["error"].asText()).isEqualTo("test error msg")
+        assertThat(requestJson["errors"][0]["detail"].asText()).isEqualTo("#65ae0d095ea")
+        assertThat(requestJson["errors"][1]["key"].asText()).isEqualTo("fomot-hasah-livid")
+        assertThat(requestJson["errors"][1]["error"].asText()).isEqualTo("test error msg2")
+        assertThat(requestJson["errors"][1]["detail"].asText()).isEqualTo("#25ae0d095e1")
+        assertThat(requestJson["description"].asText()).isEqualTo("")
+        assertThat(requestJson["stepsToReproduce"].asText()).isEqualTo("test steps")
+        assertThat(requestJson["browserAgent"].asText()).isEqualTo("test agent")
+        assertThat(requestJson["versions"]["naomi"].asText()).isEqualTo("v1")
+        assertThat(requestJson["versions"]["hintr"].asText()).isEqualTo("v2")
+        assertThat(requestJson["versions"]["rrq"].asText()).isEqualTo("v3")
+        assertThat(requestJson["versions"]["traduire"].asText()).isEqualTo("v4")
+        assertThat(requestJson["versions"]["hint"].asText()).isEqualTo("v5")
+        assertThat(requestJson["timeStamp"].asText()).isEqualTo("2021-10-12T14:07:22.759Z")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/LogElapsedTimeCallbackTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/LogElapsedTimeCallbackTests.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import org.imperial.mrc.hint.clients.ADRClient
-import org.imperial.mrc.hint.clients.ADRFuelClient
 import org.imperial.mrc.hint.clients.FuelClient
 import org.imperial.mrc.hint.logging.GenericLogger
 import org.imperial.mrc.hint.logging.logADRRequestDuration

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -206,7 +206,7 @@ describe("ADR dataset-related actions", () => {
         expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PopulationUpdated);
         expect(commit.mock.calls[1][0]["payload"]["filename"])
             .toBe("population.csv");
-    }, 7000);
+    }, 10000);
 
     it("can import survey", async () => {
 
@@ -222,7 +222,7 @@ describe("ADR dataset-related actions", () => {
         expect(commit.mock.calls[2][0]["payload"]["filename"])
             .toBe("survey.csv")
         expect(commit.mock.calls[3][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
-    }, 7000);
+    }, 10000);
 
     it("can import programme", async () => {
 
@@ -241,7 +241,7 @@ describe("ADR dataset-related actions", () => {
         expect(commit.mock.calls[3][0]["payload"]["filename"])
             .toBe("programme.csv")
         expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
-    }, 7000);
+    }, 10000);
 
     it("can import anc", async () => {
 
@@ -260,7 +260,7 @@ describe("ADR dataset-related actions", () => {
         expect(commit.mock.calls[3][0]["payload"]["filename"])
             .toBe("anc.csv");
         expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
-    }, 7000);
+    }, 10000);
 
     it("hits upload files to adr endpoint and gets appropriate error", async () => {
 
@@ -305,7 +305,7 @@ describe("ADR dataset-related actions", () => {
         expect(commit.mock.calls[2][0]["payload"]["error"]).toBe("OTHER_ERROR");
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("getUploadFiles");
-    }, 7000);
+    }, 10000);
 
     it("attempts to create release and gets appropriate error", async () => {
         const commit = jest.fn();


### PR DESCRIPTION
## Description

This PR implements Java 11 `HttpClient`, a faster and powerful http client. We can now handle requests for inputStreams nicely, it also supports blocking and non-blocking modes. I think we might consider speeding ADR requests by re-writing the way we currently make requests to ADR with `fuelClient` as this only supports blocking mode.

Error messages encountered while making requests to ADR can now be displayed in frontend instead of a generic hint error.

To test

1. upload from ADR
2. Go to ADR and edit selected dataset metadata
3. refresh dataset in Naomi
4. observe the error message.

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
