### PR TITLE
mrc-3191 Add Comparison download ID to generateErrorReport action

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.33.0
+
+* Add Comparison download ID to generateErrorReport action
+
 # hint 2.32.4
 
 * Capitalise ADR API key buttons

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.32.4";
+export const currentHintVersion = "2.33.0";

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -103,6 +103,12 @@ const getDownloadIds = (rootState: RootState) => {
     const spectrumId = rootState.downloadResults.spectrum.downloadId || ErrorReportDefaultValue.download;
     const summaryId = rootState.downloadResults.summary.downloadId || ErrorReportDefaultValue.download;
     const coarseOutputId = rootState.downloadResults.coarseOutput.downloadId || ErrorReportDefaultValue.download
+    const comparisonId = rootState.downloadResults.comparison.downloadId || ErrorReportDefaultValue.download
 
-    return {spectrum: spectrumId, summary: summaryId, coarse_output: coarseOutputId}
+    return {
+        spectrum: spectrumId,
+        summary: summaryId,
+        coarse_output: coarseOutputId,
+        comparison: comparisonId
+    }
 }

--- a/src/app/static/src/tests/integration/root.itest.ts
+++ b/src/app/static/src/tests/integration/root.itest.ts
@@ -29,6 +29,9 @@ describe(`root actions`, () => {
                 },
                 coarseOutput: {
                     downloadId: "coarse123"
+                },
+                comparison: {
+                    downloadId: "comparison123"
                 }
             },
             projects: {currentProject: {name: "p1", id: 1, versions: []}}

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -217,6 +217,9 @@ describe("root actions", () => {
                 },
                 spectrum: {
                     downloadId: "spectrum123"
+                },
+                comparison: {
+                    downloadId: "comparison123"
                 }
             } as any),
             projects: mockProjectsState({
@@ -264,7 +267,12 @@ describe("root actions", () => {
             timeStamp: new Date(),
             modelRunId: "1234",
             calibrateId: "2022",
-            downloadIds: {spectrum: "spectrum123", summary: "summary123", coarse_output: "none"},
+            downloadIds: {
+                spectrum: "spectrum123",
+                summary: "summary123",
+                coarse_output: "none",
+                comparison: "comparison123"
+            },
             description: "desc",
             section: "reviewInputs",
             stepsToReproduce: "repro",
@@ -349,7 +357,7 @@ describe("root actions", () => {
             timeStamp: new Date(),
             modelRunId: "no associated modelRunId",
             calibrateId: "no associated calibrateId",
-            downloadIds: {spectrum: "none", summary: "none", coarse_output: "none"},
+            downloadIds: {spectrum: "none", summary: "none", coarse_output: "none", comparison: "none"},
             description: "desc",
             section: "reviewInputs",
             stepsToReproduce: "repro",


### PR DESCRIPTION
## Description

This PR adds comparison download ID to error generation report.

How to test:
1. Load app to the final download step
2. From Online support -> click troubleshooting request and file the form
3. Check teams "Naomi support" channel for the generated error report

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
