### PR TITLE
mrc-4030 fix export model outputs download for failing to prepare file download when logged in as guest user.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.33.1
+
+* Bug: fix export model outputs download, it fails to prepare file download.
+
 # hint 2.33.0
 
 * Add Comparison download ID to generateErrorReport action

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # hint 2.33.1
 
-* Bug: fix export model outputs download, it fails to prepare file download.
+* Bug: fix export model outputs download, it fails to prepare file download when logged in as guest user.
 
 # hint 2.33.0
 

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.33.0";
+export const currentHintVersion = "2.33.1";

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -28,7 +28,7 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
     projectState: (rootState: RootState): DownloadSubmitRequest => {
         const versions = rootState.projects.currentProject?.versions || []
         const name = rootState.projects.currentProject?.name || ""
-        const getProjectUpdateDate = versions.length > 0 ? versions[0].updated : new Date().toUTCString()
+        const getUpdatedDate = versions.length > 0 ? versions[0].updated : new Date().toUTCString()
 
         return {
             state: {
@@ -71,7 +71,7 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
             notes: {
                 project_notes: {
                     name: name,
-                    updated: formatToLocalISODateTime(getProjectUpdateDate),
+                    updated: formatToLocalISODateTime(getUpdatedDate),
                     note: rootState.projects.currentProject?.note || ""
                 },
                 version_notes: getVersionNotes(versions, name)

--- a/src/app/static/src/app/store/root/getters.ts
+++ b/src/app/static/src/app/store/root/getters.ts
@@ -28,6 +28,7 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
     projectState: (rootState: RootState): DownloadSubmitRequest => {
         const versions = rootState.projects.currentProject?.versions || []
         const name = rootState.projects.currentProject?.name || ""
+        const getProjectUpdateDate = versions.length > 0 ? versions[0].updated : new Date().toUTCString()
 
         return {
             state: {
@@ -70,7 +71,7 @@ export const getters: RootGetters & GetterTree<RootState, RootState> = {
             notes: {
                 project_notes: {
                     name: name,
-                    updated: versions && formatToLocalISODateTime(versions[0].updated),
+                    updated: formatToLocalISODateTime(getProjectUpdateDate),
                     note: rootState.projects.currentProject?.note || ""
                 },
                 version_notes: getVersionNotes(versions, name)

--- a/src/app/static/src/tests/integration/downloadResults.itest.ts
+++ b/src/app/static/src/tests/integration/downloadResults.itest.ts
@@ -5,7 +5,7 @@ import {formatToLocalISODateTime} from "../../app/utils";
 
 describe(`download results actions integration`, () => {
 
-    it(`can download comparison output report`, async () => {
+    it.skip(`can download comparison output report`, async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {

--- a/src/app/static/src/tests/integration/downloadResults.itest.ts
+++ b/src/app/static/src/tests/integration/downloadResults.itest.ts
@@ -5,7 +5,7 @@ import {formatToLocalISODateTime} from "../../app/utils";
 
 describe(`download results actions integration`, () => {
 
-    it.skip(`can download comparison output report`, async () => {
+    it(`can download comparison output report`, async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
         const root = {

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -454,6 +454,39 @@ describe("root getters", () => {
             } as any
         }))
     })
+
+    it(`can get serialized project states when logged in as guest`, () => {
+        const projectStates = () => {
+            return mockRootState(projectStateTestData({
+                projects: mockProjectsState()
+            }))
+        }
+
+        const rootState = projectStates()
+
+        const millis = Date.UTC(2023, 1, 23, 17, 35, 19)
+
+        const mockDate = jest.spyOn(Date, 'UTC').mockImplementation(() => millis)
+
+        const result = getters.projectState(rootState, null, projectStates() as any, null)
+
+        const date = new Date(millis)
+
+        const updated = `2023/02/${date.getDate()} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`
+
+        expect(mockDate).toHaveBeenCalled()
+
+        expect(result).toStrictEqual(mockProjectOutputState({
+            notes: {
+                project_notes: {
+                    name: "",
+                    updated: updated,
+                    note: ""
+                },
+                version_notes: []
+            } as any
+        }))
+    })
 })
 
 const projectStateTestData = (props: Partial<any> = {}) => {


### PR DESCRIPTION
this PR does not attempt to retrieve first index of project versions when user is logged in as guest. 

## Description

Please describe your changes here

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
