### PR TITLE
Example define component

### DIFF
--- a/src/app/static/src/components/adr/ADRIntegration.vue
+++ b/src/app/static/src/components/adr/ADRIntegration.vue
@@ -44,7 +44,7 @@
 
     const namespace = "adr";
 
-    export default defineComponent<unknown, Methods, Computed, unknown>({
+    export default defineComponent<Methods, Computed>({
         components: {adrKey, SelectDataset},
         computed: {
             isGuest: mapGetterByName(null, "isGuest"),

--- a/src/app/static/src/components/adr/ADRKey.vue
+++ b/src/app/static/src/components/adr/ADRKey.vue
@@ -97,7 +97,7 @@
 
     const namespace = "adr";
 
-    export default defineComponent<Data, Methods, Computed, unknown>({
+    export default defineComponent<Methods, Computed, Data>({
         data() {
             return {
                 editableKey: "",

--- a/src/app/static/src/components/adr/SelectDataset.vue
+++ b/src/app/static/src/components/adr/SelectDataset.vue
@@ -92,6 +92,7 @@
     </div>
 </template>
 <script lang="ts">
+    import { defineComponent } from "vue";
     import i18next from "i18next";
     import {Language} from "../../store/translations/locales";
     import TreeSelect from "vue3-treeselect";
@@ -190,7 +191,8 @@
 
     const namespace = "adr";
 
-    export default ResetConfirmationMixin.extend<Data, Methods, Computed, unknown>({
+    export default defineComponent<Computed, Methods, Data>({
+        extends: ResetConfirmationMixin,
         data() {
             return {
                 open: false,
@@ -458,10 +460,10 @@
                     window.clearInterval(this.pollingId);
                 }
             },
-            updateDatasetRelease(release) {
+            updateDatasetRelease(release: Release) {
                 this.newDatasetRelease = release;
             },
-            updateValid(valid) {
+            updateValid(valid: boolean) {
                 this.valid = valid;
             }
         },

--- a/src/app/static/src/components/adr/SelectRelease.vue
+++ b/src/app/static/src/components/adr/SelectRelease.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="selectRelease" v-if="datasetId && releases.length">
+    <div id="selectRelease" v-if="datasetId && (releases as Release[]).length">
         <div class="pt-2">
             <input
                 type="radio"
@@ -57,7 +57,6 @@
 
 <script lang="ts">
     import {defineComponent} from "vue";
-    import type { PropType } from "vue";
     import { mapActionByName, mapStateProp, mapMutationByName } from "../../utils";
     import TreeSelect from "vue3-treeselect";
     import { ADRState } from "../../store/adr/adr";
@@ -75,39 +74,37 @@
         choiceADR: "useLatest" | "useRelease";
     }
 
-    // interface Methods {
-    //     getReleases: (id: string) => void;
-    //     clearReleases: () => void;
-    //     translate(text: string): string;
-    //     preSelectRelease: () => void;
-    // }
+    interface Methods {
+        [key: string]: any
+        getReleases: (id: string) => void;
+        clearReleases: () => void;
+        translate(text: string): string;
+        preSelectRelease: () => void;
+    }
 
-    // interface Computed {
-    //     releases: Release[];
-    //     initialRelease: string | undefined;
-    //     valid: boolean;
-    //     releaseOptions: any[];
-    //     useRelease: boolean;
-    //     currentLanguage: Language;
-    // }
+    interface Computed {
+        [key: string]: any
+        releases: Release[]
+        initialRelease: string | undefined
+        valid(): boolean;
+        releaseOptions(): any[];
+        useRelease(): boolean
+        currentLanguage: Language
+    }
 
-    // interface Props {
-    //     datasetId: string | null;
-    //     open: boolean;
-    // }
+    interface Props {
+        datasetId: string | null;
+        open: boolean;
+    }
 
     const namespace = "adr";
 
-    export default defineComponent({
+    export default defineComponent<Props, unknown, Data, Computed, Methods>({
         components: {
             TreeSelect,
             HelpCircleIcon,
         },
-        props: {
-            datasetId: String as PropType<string | null>,
-            open: Boolean
-        },
-        data(): Data {
+        data() {
             return {
                 releaseId: undefined,
                 choiceADR: "useLatest",
@@ -126,7 +123,7 @@
                 return (this.choiceADR === "useLatest") || !!this.releaseId;
             },
             releaseOptions() {
-                return this.releases.map((d) => ({
+                return (this.releases as Release[]).map((d) => ({
                     id: d.id,
                     label: d.name,
                 customLabel: `${d.name}
@@ -149,12 +146,12 @@
                 return i18next.t(text, { lng: this.currentLanguage });
             },
             clearReleases: mapMutationByName(namespace, ADRMutation.ClearReleases),
-            preSelectRelease(){
+            preSelectRelease() {
                 const selectedReleaseId = this.initialRelease
-                if (selectedReleaseId && this.releases.some(release => release.id === selectedReleaseId)){
+                if (selectedReleaseId && (this.releases as Release[]).some(release => release.id === selectedReleaseId)){
                     this.choiceADR = "useRelease"
                     this.releaseId = selectedReleaseId;
-                } else if (selectedReleaseId && !this.releases.some(release => release.id === selectedReleaseId)) {
+                } else if (selectedReleaseId && !(this.releases as Release[]).some(release => release.id === selectedReleaseId)) {
                     this.choiceADR = "useLatest"
                 }
             }
@@ -173,21 +170,21 @@
                 }
             },
             releaseId() {
-                this.$emit("selected-dataset-release", this.releases.find(release => release.id === this.releaseId))
+                this.$emit("selected-dataset-release", (this.releases as Release[]).find(release => release.id === this.releaseId))
             },
             valid() {
                 this.$emit("valid", this.valid);
             },
-            releases(){
+            releases() {
                 this.preSelectRelease();
             },
-            open(){
+            open() {
                 if (this.open && this.datasetId){
                     this.getReleases(this.datasetId);
                 }
             }
         },
-        mounted(){
+        mounted() {
             this.preSelectRelease();
             this.$emit("selected-dataset-release", this.releaseId);
             this.$emit("valid", this.valid);

--- a/src/app/static/src/components/adr/SelectRelease.vue
+++ b/src/app/static/src/components/adr/SelectRelease.vue
@@ -57,6 +57,7 @@
 
 <script lang="ts">
     import {defineComponent} from "vue";
+    import type { PropType } from "vue";
     import { mapActionByName, mapStateProp, mapMutationByName } from "../../utils";
     import TreeSelect from "vue3-treeselect";
     import { ADRState } from "../../store/adr/adr";
@@ -74,39 +75,39 @@
         choiceADR: "useLatest" | "useRelease";
     }
 
-    interface Methods {
-        getReleases: (id: string) => void;
-        clearReleases: () => void;
-        translate(text: string): string;
-        preSelectRelease: () => void;
-    }
+    // interface Methods {
+    //     getReleases: (id: string) => void;
+    //     clearReleases: () => void;
+    //     translate(text: string): string;
+    //     preSelectRelease: () => void;
+    // }
 
-    interface Computed {
-        releases: Release[];
-        initialRelease: string | undefined;
-        valid: boolean;
-        releaseOptions: any[];
-        useRelease: boolean;
-        currentLanguage: Language;
-    }
+    // interface Computed {
+    //     releases: Release[];
+    //     initialRelease: string | undefined;
+    //     valid: boolean;
+    //     releaseOptions: any[];
+    //     useRelease: boolean;
+    //     currentLanguage: Language;
+    // }
 
-    interface Props {
-        datasetId: string | null;
-        open: boolean;
-    }
+    // interface Props {
+    //     datasetId: string | null;
+    //     open: boolean;
+    // }
 
     const namespace = "adr";
 
-    export default defineComponent<Data, Methods, Computed, Props>({
+    export default defineComponent({
         components: {
             TreeSelect,
             HelpCircleIcon,
         },
         props: {
-            datasetId: String,
+            datasetId: String as PropType<string | null>,
             open: Boolean
         },
-        data() {
+        data(): Data {
             return {
                 releaseId: undefined,
                 choiceADR: "useLatest",
@@ -144,7 +145,7 @@
         },
         methods: {
             getReleases: mapActionByName(namespace, "getReleases"),
-            translate(text) {
+            translate(text: string) {
                 return i18next.t(text, { lng: this.currentLanguage });
             },
             clearReleases: mapMutationByName(namespace, ADRMutation.ClearReleases),

--- a/src/app/static/src/components/dataExploration/DataExploration.vue
+++ b/src/app/static/src/components/dataExploration/DataExploration.vue
@@ -53,7 +53,7 @@
         getPlottingMetadata: (country: string) => void
     }
 
-    export default defineComponent<unknown, Methods, Computed, unknown>({
+    export default defineComponent<Methods, Computed>({
         computed: {
             step: mapStateProp<StepperState, number>("stepper", state => state.activeStep),
             canProgress() {

--- a/src/app/static/src/components/downloadIndicator/DownloadButton.vue
+++ b/src/app/static/src/components/downloadIndicator/DownloadButton.vue
@@ -13,16 +13,16 @@
     import {defineComponent} from "vue";
     import {DownloadIcon} from "vue-feather";
 
-    interface Props {
-        disabled: boolean
-        name: string
-    }
+    // interface Props {
+    //     disabled: boolean
+    //     name: string
+    // }
 
-    interface Method {
-        download: () => void
-    }
+    // interface Method {
+    //     download: () => void
+    // }
 
-    export default defineComponent<unknown, Method, unknown, Props>({
+    export default defineComponent({
         name: "downloadButton",
         components: {
             DownloadIcon

--- a/src/app/static/src/components/downloadIndicator/DownloadIndicator.vue
+++ b/src/app/static/src/components/downloadIndicator/DownloadIndicator.vue
@@ -9,6 +9,7 @@
 
 <script lang="ts">
     import {defineComponent} from "vue";
+    import type { PropType } from "vue";
     import DownloadButton from "./DownloadButton.vue";
     import {DownloadIndicatorPayload} from "../../types";
     import {appendCurrentDateTime, mapActionByName, mapStateProps} from "../../utils";
@@ -33,14 +34,14 @@
         downloadingIndicator: boolean
     }
 
-    export default defineComponent<unknown, Methods, Computed, Props>({
+    export default defineComponent({
         name: "downloadIndicator",
         components: {
             DownloadButton
         },
         props: {
-            unfilteredData: Array,
-            filteredData: Array
+            unfilteredData: Array as PropType<unknown[] | null>,
+            filteredData: Array as PropType<unknown[]>
         },
         computed: {
             ...mapStateProps<BaselineState, keyof Computed>("baseline", {

--- a/src/app/static/src/components/downloadResults/Download.vue
+++ b/src/app/static/src/components/downloadResults/Download.vue
@@ -18,6 +18,7 @@
 
 <script lang="ts">
     import {defineComponent} from "vue";
+    import type { PropType } from "vue";
     import DownloadStatus from "./DownloadStatus.vue";
     import ErrorAlert from "../ErrorAlert.vue";
     import {DownloadIcon} from "vue-feather";
@@ -38,7 +39,7 @@
         download: () => void
     }
 
-    export default defineComponent<unknown, Methods, unknown, Props>({
+    export default defineComponent({
         name: "Download",
         components: {
             DownloadIcon,
@@ -48,11 +49,11 @@
         props: {
             file: {
                 required: true,
-                type: Object
+                type: Object as PropType<DownloadResultsDependency>
             },
             translateKey: {
                 required: true,
-                type: Object
+                type: Object as PropType<downloadTranslate>
             },
             disabled: {
                 required: true,

--- a/src/app/static/src/components/downloadResults/DownloadResults.vue
+++ b/src/app/static/src/components/downloadResults/DownloadResults.vue
@@ -131,7 +131,7 @@
         comparisonSwitch: boolean
     }
 
-    export default defineComponent<Data, Methods, Computed>({
+    export default defineComponent<Computed, Methods, Data>({
         name: "downloadResults",
         data() {
             return {
@@ -180,13 +180,13 @@
             }
         },
         methods: {
-            downloadUrl(downloadId) {
+            downloadUrl(downloadId: string) {
                 return `/download/result/${downloadId}`;
             },
             handleUploadModal() {
                 this.uploadModalOpen = true;
             },
-            handleDownloadResult(downloadResults) {
+            handleDownloadResult(downloadResults: DownloadResultsDependency) {
                 window.location.assign(this.downloadUrl(downloadResults.downloadId));
             },
             downloadSpectrumOutput() {

--- a/src/app/static/src/components/downloadResults/DownloadStatus.vue
+++ b/src/app/static/src/components/downloadResults/DownloadStatus.vue
@@ -13,11 +13,11 @@
     import {defineComponent} from "vue"
     import LoadingSpinner from "../LoadingSpinner.vue";
 
-    interface Props {
-        preparing: boolean,
-        translateKey: string
-    }
-    export default defineComponent<unknown, unknown, unknown, Props>({
+    // interface Props {
+    //     preparing: boolean,
+    //     translateKey: string
+    // }
+    export default defineComponent({
         name: "DownloadStatus",
         components: {
             LoadingSpinner

--- a/src/app/static/src/components/downloadResults/UploadModal.vue
+++ b/src/app/static/src/components/downloadResults/UploadModal.vue
@@ -127,7 +127,7 @@
     const outputFileTypes = ["outputZip", "outputSummary", "outputComparison"];
     const inputFileTypes = ["anc", "programme", "pjnz", "population", "shape", "survey"];
 
-    export default defineComponent<Data, Methods, Computed, unknown>({
+    export default defineComponent<Methods, Computed, Data>({
         name: "UploadModal",
         data(): Data {
             return {
@@ -154,7 +154,7 @@
             handleCancel() {
                 this.$emit("close")
             },
-            translate(text) {
+            translate(text: string) {
                 return i18next.t(text, {lng: this.currentLanguage});
             },
             setDefaultCheckedItems: function () {
@@ -162,7 +162,7 @@
                     .filter(key => this.uploadableFiles.hasOwnProperty(key))
             },
             //show and upload only successfully downloaded outputFiles in upload modal
-            outputFileIsAvailable: function (key) {
+            outputFileIsAvailable: function (key: string) {
                 if (key === "outputZip" && !(this.spectrum.error || this.spectrum.metadataError)) {
                     return true
                 } else if (key === "outputSummary" && !(this.summary.error || this.summary.metadataError)) {
@@ -173,11 +173,11 @@
 
                 return false
             },
-            getSectionHeading: function (sectionIndex) {
+            getSectionHeading: function (sectionIndex: number) {
                 const hasOutputFile = Object.keys(this.uploadFileSections[0]).length > 0
                 return sectionIndex === 0 ? (hasOutputFile ? 'outputFiles' : '') : 'inputFiles';
             },
-            translatedOutputFileError: function (key) {
+            translatedOutputFileError: function (key: string) {
                 return i18next.t("downloadOutputsError", {
                     outputFileType: this.translate(key),
                     lng: this.currentLanguage,


### PR DESCRIPTION
The purpose of this PR is to show an example of the process of changing Vue.extends to defineComponent. The first commit is just for history purposes, you can safely ignore most of it but just have a skim through (most of the stuff from the first commit is changed later on). The second commit "example of define component" has a comment that outlines the process.
