### PR TITLE
mrc-4225 Fixing bubble plot circle markers not updating and allowing users to select specific area

### DIFF
--- a/src/app/static/src/app/components/plots/FilterSelect.vue
+++ b/src/app/static/src/app/components/plots/FilterSelect.vue
@@ -48,7 +48,7 @@
     interface Props {
         multiple?: boolean,
         label: string,
-        disabled: boolean,
+        disabled?: boolean,
         options: FilterOption[],
         value: string[] | string
     }
@@ -70,7 +70,7 @@
             },
             disabled: {
                 type: Boolean,
-                required: true
+                required: false
             },
             options: {
                 type: Array,
@@ -131,4 +131,3 @@
         }
     });
 </script>
-

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -39,46 +39,39 @@
             </div>
         </div>
         <div id="chart" class="col-md-9">
-            <l-map ref="map" style="height: 800px; width: 100%" @vnode-updated="updateBounds" @ready="updateBounds">
+            <l-map ref="map" style="height: 800px; width: 100%" @vnode-updated="updateBounds">
                 <template v-for="feature in currentFeatures" :key="feature.id">
                     <l-geo-json :geojson="feature"
                                 :options="options"
                                 :optionsStyle="style">
                     </l-geo-json>
-                    <!-- <l-circle-marker v-if="showBubble(feature)"
-                                     :key="feature.id"
-                                     :lat-lng="[feature.properties?.center_y, feature.properties?.center_x]"
-                                     :radius="getRadius(feature)"
-                                     :fill-opacity="0.75"
-                                     :opacity="0.75"
-                                     :color="getColor(feature)"
-                                     :fill-color="getColor(feature)">
-                        <l-tooltip :content="getTooltip(feature)"/>
-                    </l-circle-marker> -->
-                    <!-- <l-circle-marker
-                    :lat-lng="[33.64, -9.61]"
-                    ></l-circle-marker> -->
                 </template>
-                <map-empty-feature v-if="emptyFeature"></map-empty-feature>
-                <reset-map v-else @reset-view="updateBounds"></reset-map>
-                <map-control :initialDetail=selections.detail
-                             :show-indicators="false"
-                             :level-labels="featureLevels"
-                             @detailChanged="onDetailChange($event)"></map-control>
-                <map-legend v-show="!emptyFeature"
-                            :metadata="colorIndicator"
-                            :colour-range="colourRange"
-                            :colour-scale="colourIndicatorScale"
-                            @update="updateColourScale"
-                ></map-legend>
-                <size-legend v-show="!emptyFeature"
-                             :indicatorRange="sizeRange"
-                             :max-radius="maxRadius"
-                             :min-radius="minRadius"
-                             :metadata="sizeIndicator"
-                             :size-scale="sizeIndicatorScale"
-                             @update="updateSizeScale"
-                ></size-legend>
+                <div v-if="emptyFeature">
+                    <map-empty-feature></map-empty-feature>
+                </div>
+                <div v-if="!emptyFeature">
+                    <reset-map v-if="!emptyFeature" @reset-view="updateBounds"></reset-map>
+                    <map-legend v-show="!emptyFeature"
+                                :metadata="colorIndicator"
+                                :colour-range="colourRange"
+                                :colour-scale="colourIndicatorScale"
+                                @update="updateColourScale"
+                    ></map-legend>
+                    <size-legend v-show="!emptyFeature"
+                                :indicatorRange="sizeRange"
+                                :max-radius="maxRadius"
+                                :min-radius="minRadius"
+                                :metadata="sizeIndicator"
+                                :size-scale="sizeIndicatorScale"
+                                @update="updateSizeScale"
+                    ></size-legend>
+                </div>
+                <div>
+                    <map-control :initialDetail=selections.detail
+                                 :show-indicators="false"
+                                 :level-labels="featureLevels"
+                                 @detailChanged="onDetailChange($event)"></map-control>
+                </div>
             </l-map>
         </div>
     </div>
@@ -88,11 +81,11 @@
     import {defineComponentVue2WithProps} from "../../../defineComponentVue2/defineComponentVue2"
     import Treeselect from "vue3-treeselect";
     import {Feature} from "geojson";
-    import {LCircleMarker, LGeoJson, LMap, LTooltip} from "@vue-leaflet/vue-leaflet";
+    import {LGeoJson, LMap} from "@vue-leaflet/vue-leaflet";
     import MapControl from "../MapControl.vue";
     import MapLegend from "../MapLegend.vue";
     import FilterSelect from "../FilterSelect.vue";
-    import {CircleMarker, GeoJSON, GeoJSONOptions, Layer, circleMarker} from "leaflet";
+    import {CircleMarker, GeoJSON, circleMarker} from "leaflet";
     import {ChoroplethIndicatorMetadata, FilterOption, NestedFilterOption} from "../../../generated";
     import {
         BubblePlotSelections,
@@ -180,8 +173,6 @@
         components: {
             LMap,
             LGeoJson,
-            LCircleMarker,
-            LTooltip,
             MapControl,
             MapLegend,
             SizeLegend,
@@ -250,7 +241,7 @@
             },
             emptyFeature() {
                 const nonEmptyFeature = (this.currentFeatures.filter(filtered => !!this.featureIndicators[filtered.properties!.area_id]))
-                return nonEmptyFeature.length == 0 && this.selections.detail !== 0
+                return nonEmptyFeature.length == 0
             },
             sizeRange() {
                 const sizeScale = this.sizeScales[this.selections.sizeIndicatorId];
@@ -373,31 +364,33 @@
             updateBounds: function () {
                 if (this.initialised) {
                     let map = this.$refs.map as any;
-                    if (this.previousCircles.length != 0) {
+                    if (this.previousCircles.length > 0) {
                         this.previousCircles.forEach(circle => circle.remove())
                         this.previousCircles = []
                     }
-                    console.log(this.currentFeatures)
                     let circlesArray: CircleMarker[] = [];
-                    this.currentFeatures.forEach((feature) => {
-                        if (!this.showBubble(feature)) {
-                            return
-                        }
-                        let circle = circleMarker([feature.properties?.center_y, feature.properties?.center_x], {
-                            radius: this.getRadius(feature),
-                            fillOpacity: 0.75,
-                            opacity: 0.75,
-                            color: this.getColor(feature),
-                            fillColor: this.getColor(feature),
+                    if (!this.emptyFeature) {
+                        this.currentFeatures.forEach((feature) => {
+                            if (!this.showBubble(feature)) {
+                                return
+                            }
+                            let circle = circleMarker([feature.properties?.center_y, feature.properties?.center_x], {
+                                radius: this.getRadius(feature),
+                                fillOpacity: 0.75,
+                                opacity: 0.75,
+                                color: this.getColor(feature),
+                                fillColor: this.getColor(feature),
+                            }).bindTooltip(this.getTooltip(feature))
+                            circlesArray.push(circle)
                         })
-                        circlesArray.push(circle)
-                    })
-                    this.previousCircles = circlesArray
-
+                        this.previousCircles = circlesArray
+                    }
 
                     if (map && map.leafletObject) {
                         map.leafletObject.fitBounds(this.selectedAreaFeatures.map((f: Feature) => new GeoJSON(f).getBounds()) as any);
-                        circlesArray.forEach(circle => circle.addTo(map.leafletObject))
+                        if (circlesArray.length > 0) {
+                            circlesArray.forEach(circle => circle.addTo(map.leafletObject))
+                        }
                     }
                 }
             },

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -39,7 +39,7 @@
             </div>
         </div>
         <div id="chart" class="col-md-9">
-            <l-map ref="map" style="height: 800px; width: 100%">
+            <l-map ref="map" style="height: 800px; width: 100%" @vnode-updated="updateBounds" @ready="updateBounds">
                 <template v-for="feature in currentFeatures" :key="feature.id">
                     <l-geo-json :geojson="feature"
                                 :options="options"
@@ -250,7 +250,7 @@
             },
             emptyFeature() {
                 const nonEmptyFeature = (this.currentFeatures.filter(filtered => !!this.featureIndicators[filtered.properties!.area_id]))
-                return nonEmptyFeature.length == 0
+                return nonEmptyFeature.length == 0 && this.selections.detail !== 0
             },
             sizeRange() {
                 const sizeScale = this.sizeScales[this.selections.sizeIndicatorId];
@@ -377,8 +377,12 @@
                         this.previousCircles.forEach(circle => circle.remove())
                         this.previousCircles = []
                     }
+                    console.log(this.currentFeatures)
                     let circlesArray: CircleMarker[] = [];
                     this.currentFeatures.forEach((feature) => {
+                        if (!this.showBubble(feature)) {
+                            return
+                        }
                         let circle = circleMarker([feature.properties?.center_y, feature.properties?.center_x], {
                             radius: this.getRadius(feature),
                             fillOpacity: 0.75,
@@ -524,6 +528,12 @@
                     this.updateBounds();
                 },
                 selectedAreaFeatures: function (newVal) {
+                    this.updateBounds();
+                },
+                colourIndicatorScale: function (newVal) {
+                    this.updateBounds();
+                },
+                sizeIndicatorScale: function (newVal) {
                     this.updateBounds();
                 }
             },

--- a/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
+++ b/src/app/static/src/app/components/plots/bubble/BubblePlot.vue
@@ -515,21 +515,6 @@
                 this.$emit("update-size-scales", newSizeScales);
             },
         },
-        watch:
-            {
-                initialised: function (newVal: boolean) {
-                    this.updateBounds();
-                },
-                selectedAreaFeatures: function (newVal) {
-                    this.updateBounds();
-                },
-                colourIndicatorScale: function (newVal) {
-                    this.updateBounds();
-                },
-                sizeIndicatorScale: function (newVal) {
-                    this.updateBounds();
-                }
-            },
         mounted() {
             this.updateBounds();
         },


### PR DESCRIPTION
## Problems/motivation:
- `FilterSelect` was showing an error as the `disabled` prop was required
- Bubble plot circle markers were not updating when you adjust either of the scales
- On selection detail change (map control in top right of the map) the map was re-rendering in front of the circles
- Tooltips weren't showing for circles

## New features/solutions:
- Changed `disabled` prop to knot required
- Everytime the v-node of the map is updated it will now call `updateBound` so the circles update. Perhaps should call the function `updateMap` now? Since it re-renders the whole thing?
- Added a `.bindTooltip` where I define a circle marker in `updateBounds`
- I had to change the way circle markers were added (this was done before this PR in the `hintpproofofconcept` branch as I needed to do this to even get the map to show up). So the Vue 2 way was just using the `<l-circle-marker>` tag with `vue-leaflet` however, with this different package, we have to use the map instance to add the circle markers. Unfortunately, I cannot use the map instance in a different function because it will throw and error about a new instance being created and I also cannot define a map instance in the data field because it will throw the same error. As such, I have had to put both the circle marker updates and the fit bounds in the same function. This is performs just fine from my testing however maybe a future way to optimise it would be to store previous filter selections and so on and only update the map when the area/detail level selected changes? 

## How PR should behave when tested:
- Circle markers should render on top of the map
- Circle markers should update when changing any of the filters
- Circle markers should update when changing any of the map controls and adjusting scales
- Empty map feature text should show when selecting a combination that is not possible (try selecting area as `Northern` and change detail level (top right of map) to `Country`)
- Tooltips should show when you hover over the circle markers

## How to run app:
1. Run the app according to the README
2. Log in as the test user (in README)
3. Must enter ADR key, use a proper one, do not use `1` for example. This is a bug that will be fixed later but use your proper account ADR key
4. Run up a demo project like Antarctica
5. In model options only need to change Area Level to `Region` and can move on with the fit
6. Use default options for calibrate
7. Test out bubble plot

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
