### PR TITLE
Cancel polling when state is reset

### DIFF
--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -116,6 +116,9 @@ export const mutations: MutationTree<ModelCalibrateState> = {
         state.error = action.payload;
         state.calibrating = false;
         state.generatingCalibrationPlot = false;
+        console.log("Handling error from model calibrate")
+        console.log(JSON.stringify(action))
+        console.log(JSON.stringify(state))
         if (state.statusPollId > -1) {
             stopPolling(state);
         }
@@ -126,7 +129,11 @@ export const mutations: MutationTree<ModelCalibrateState> = {
     },
 
     [ModelCalibrateMutation.PollingForStatusStarted](state: ModelCalibrateState, action: PayloadWithType<number>) {
+        console.log("Setting status poll ID with payload");
+        console.log(action);
+        console.log(state.statusPollId);
         state.statusPollId = action.payload;
+        console.log(state.statusPollId);
     },
 
     [ModelCalibrateMutation.WarningsFetched](state: ModelCalibrateState, action: PayloadWithType<Warning[]>) {
@@ -147,6 +154,7 @@ export const mutations: MutationTree<ModelCalibrateState> = {
 };
 
 const stopPolling = (state: ModelCalibrateState) => {
+    console.log("Stopping polling "+ state.statusPollId)
     clearInterval(state.statusPollId);
     state.statusPollId = -1;
 };

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -13,7 +13,7 @@ import {PayloadWithType, Project} from "../../types";
 import {mutations as languageMutations} from "../language/mutations";
 import {initialProjectsState} from "../projects/projects";
 import {router} from '../../router';
-import {initialModelCalibrateState} from "../modelCalibrate/modelCalibrate";
+import {initialModelCalibrateState, ModelCalibrateState} from "../modelCalibrate/modelCalibrate";
 import {initialADRUploadState} from "../adrUpload/adrUpload";
 import {initialDownloadResultsState} from "../downloadResults/downloadResults";
 import {initialGenericChartState} from "../genericChart/genericChart";
@@ -136,10 +136,16 @@ export const mutations: MutationTree<RootState> = {
     },
 
     [RootMutation.ResetDownload](state: RootState) {
+        stopPolling(state.downloadResults.spectrum);
+        stopPolling(state.downloadResults.coarseOutput);
+        stopPolling(state.downloadResults.summary);
+        stopPolling(state.downloadResults.comparison);
         Object.assign(state.downloadResults, initialDownloadResultsState());
     },
 
     [RootMutation.ResetOutputs](state: RootState) {
+        stopPolling(state.modelRun);
+        stopPolling(state.modelCalibrate);
         Object.assign(state.modelRun, initialModelRunState());
         state.modelRun.ready = true;
         Object.assign(state.modelCalibrate, initialModelCalibrateState());
@@ -157,4 +163,9 @@ export const mutations: MutationTree<RootState> = {
     },
     ...languageMutations
 
+};
+
+const stopPolling = (state: any) => {
+    clearInterval(state.statusPollId);
+    state.statusPollId = -1;
 };


### PR DESCRIPTION
## Description

We have seen an issue where users browser is sending requests to `/download/status` endpoint without an ID. It isn't 100% clear how users are getting into this state, but we can recreate it one way.

1. Start a new project, progress to calibration step and open network tab of devtools
2. Start calibration and see polling start
3. Go to first step and remove a file to trigger "new version" dialog
4. Confirm to create a new version
5. See the browser continue to poll for `/download/status` without a download ID

This is happening because when we reset the state neither the `ResetOutputs` or `ResetDownload` are cancelling any of the potentially in progress polling.

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
