### PR TITLE
Restart polling for calibrate status if stage incomplete but calibration in progress

### DIFF
--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -76,6 +76,7 @@
     interface Methods {
         fetchOptions: () => void;
         submitCalibrate: (data: DynamicFormData) => void;
+        resumeCalibrate: () => void;
         update: (data: DynamicFormMeta) => void;
         submitForm: (e: Event) => void;
     }
@@ -167,6 +168,7 @@
         methods: {
             update: mapMutationByName(namespace, ModelCalibrateMutation.Update),
             submitCalibrate: mapActionByName(namespace, "submit"),
+            resumeCalibrate: mapActionByName(namespace, "resumeCalibrate"),
             fetchOptions: mapActionByName(namespace, "fetchModelCalibrateOptions"),
             submitForm() {
                 (this.$refs.form as any).submit();
@@ -181,6 +183,7 @@
         },
         mounted() {
             this.fetchOptions();
+            this.resumeCalibrate();
         }
     });
 </script>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.34.0";
+export const currentHintVersion = "2.34.1";

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -23,6 +23,7 @@ export interface ModelCalibrateActions {
     getResult: (store: ActionContext<ModelCalibrateState, RootState>) => void
     getCalibratePlot: (store: ActionContext<ModelCalibrateState, RootState>) => void
     getComparisonPlot: (store: ActionContext<ModelCalibrateState, RootState>) => void
+    resumeCalibrate: (store: ActionContext<ModelCalibrateState, RootState>) => void
 }
 
 export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrateActions = {
@@ -126,6 +127,13 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
                 selectFilterDefaults(response.data, commit, PlottingSelectionsMutations.updateComparisonPlotSelections)
             }
             commit(ModelCalibrateMutation.SetComparisonPlotData, response.data);
+        }
+    },
+
+    async resumeCalibrate(context) {
+        const {dispatch, state} = context;
+        if (state.calibrating && !state.complete) {
+            await dispatch("poll");
         }
     }
 };

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -132,7 +132,7 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
 
     async resumeCalibrate(context) {
         const {dispatch, state} = context;
-        if (state.calibrating && !state.complete) {
+        if (state.calibrating && !state.complete && state.calibrateId) {
             await dispatch("poll");
         }
     }

--- a/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
+++ b/src/app/static/src/tests/components/modelCalibrate/modelCalibrate.test.ts
@@ -12,11 +12,15 @@ import {expectTranslated} from "../../testHelpers";
 import Tick from "../../../app/components/Tick.vue";
 import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 import {ModelCalibrateMutation} from "../../../app/store/modelCalibrate/mutations";
-import { Language } from "../../../app/store/translations/locales";
+import {Language} from "../../../app/store/translations/locales";
 
 describe("Model calibrate component", () => {
-    const getStore = (state: Partial<ModelCalibrateState> = {}, fetchAction = jest.fn(), submitAction = jest.fn(),
-                      updateMutation = jest.fn(), rootState: Partial<RootState> = {}) => {
+    const getStore = (state: Partial<ModelCalibrateState> = {},
+                      fetchAction = jest.fn(),
+                      submitAction = jest.fn(),
+                      resumeCalibrateAction = jest.fn(),
+                      updateMutation = jest.fn(),
+                      rootState: Partial<RootState> = {}) => {
         const store = new Vuex.Store({
             state: mockRootState(rootState),
             modules: {
@@ -25,7 +29,8 @@ describe("Model calibrate component", () => {
                     state: mockModelCalibrateState(state),
                     actions: {
                         fetchModelCalibrateOptions: fetchAction,
-                        submit: submitAction
+                        submit: submitAction,
+                        resumeCalibrate: resumeCalibrateAction
                     },
                     mutations: {
                         [ModelCalibrateMutation.Update]: updateMutation
@@ -83,13 +88,13 @@ describe("Model calibrate component", () => {
     });
 
     it("translates required text", () => {
-        const store = getStore({}, jest.fn(), jest.fn(), jest.fn(), {language: Language.fr});
+        const store = getStore({}, jest.fn(), jest.fn(), jest.fn(), jest.fn(), {language: Language.fr});
         const wrapper = shallowMount(ModelCalibrate, {store});
         expect(wrapper.find(DynamicForm).props("requiredText")).toBe("obligatoire");
     });
 
     it("translates select text", () => {
-        const store = getStore({}, jest.fn(), jest.fn(), jest.fn(), {language: Language.fr});
+        const store = getStore({}, jest.fn(), jest.fn(), jest.fn(), jest.fn(), {language: Language.fr});
         const wrapper = shallowMount(ModelCalibrate, {store});
         expect(wrapper.find(DynamicForm).props("selectText")).toBe("Sélectionner...");
     });
@@ -134,7 +139,7 @@ describe("Model calibrate component", () => {
 
     it("setting options value commits update mutation", () => {
         const mockUpdate = jest.fn();
-        const store = getStore({optionsFormMeta: mockOptionsFormMeta()}, jest.fn(), jest.fn(), mockUpdate);
+        const store = getStore({optionsFormMeta: mockOptionsFormMeta()}, jest.fn(), jest.fn(), jest.fn(), mockUpdate);
         const wrapper = mount(ModelCalibrate, {store});
 
         wrapper.find(DynamicForm).find("input").setValue("6");
@@ -173,5 +178,12 @@ describe("Model calibrate component", () => {
         const wrapper = getWrapper(store);
         expect(wrapper.find(CalibrationResults).exists()).toBe(false);
         expect(wrapper.find("#reviewResults").exists()).toBe(false)
+    });
+
+    it("calls resume calibrate on mount", () => {
+        const mockResumeCalibrate = jest.fn();
+        const store = getStore({}, jest.fn(), jest.fn(), mockResumeCalibrate, jest.fn());
+        getWrapper(store);
+        expect(mockResumeCalibrate.mock.calls.length).toBe(1);
     });
 });

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -431,18 +431,18 @@ describe("ModelCalibrate actions", () => {
 
     it("resume calibrate starts polling if calibration started but no result fetched", async () => {
         const dispatch = jest.fn();
-        const initial_state = mockModelCalibrateState();
-        await actions.resumeCalibrate({dispatch, state: initial_state} as any);
+        const initialState = mockModelCalibrateState();
+        await actions.resumeCalibrate({dispatch, state: initialState} as any);
 
         expect(dispatch.mock.calls.length).toBe(0);
 
-        const complete_state = mockModelCalibrateState({calibrating: false, complete: true});
-        await actions.resumeCalibrate({dispatch, state: complete_state} as any);
+        const completeState = mockModelCalibrateState({calibrating: false, complete: true});
+        await actions.resumeCalibrate({dispatch, state: completeState} as any);
 
         expect(dispatch.mock.calls.length).toBe(0);
 
-        const incomplete_state = mockModelCalibrateState({calibrating: true, complete: false});
-        await actions.resumeCalibrate({dispatch, state: incomplete_state} as any);
+        const incompleteState = mockModelCalibrateState({calibrating: true, complete: false});
+        await actions.resumeCalibrate({dispatch, state: incompleteState} as any);
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("poll");

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -436,15 +436,25 @@ describe("ModelCalibrate actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(0);
 
-        const completeState = mockModelCalibrateState({calibrating: false, complete: true});
+        const completeState = mockModelCalibrateState(
+            {calibrating: false, complete: true, calibrateId: "123"});
         await actions.resumeCalibrate({dispatch, state: completeState} as any);
 
         expect(dispatch.mock.calls.length).toBe(0);
 
-        const incompleteState = mockModelCalibrateState({calibrating: true, complete: false});
+        const incompleteState = mockModelCalibrateState(
+            {calibrating: true, complete: false, calibrateId: "123"});
         await actions.resumeCalibrate({dispatch, state: incompleteState} as any);
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("poll");
+
+        // Following state should not be possible but checking for completeness
+        const brokenState = mockModelCalibrateState(
+            {calibrating: true, complete: false, calibrateId: ""});
+        await actions.resumeCalibrate({dispatch, state: completeState} as any);
+
+        // No new polls
+        expect(dispatch.mock.calls.length).toBe(1);
     });
 });


### PR DESCRIPTION
## Description

Spotted this whilst doing #840, when we load calibrate page we do not start polling again if the users project has a calibration active i.e. `state.calibrating` is true. This can result in users opening the page and the interface shows the last received status which can be an in progress state. Meaning that they see a spinner but it will never complete and the progress won't update, and they can't even restart the calibrate.

I have seen users in this state sometimes, though not clear how they get into that state. Had Ian report he waited for calibration for 5 hours once but I suspect his project was just not polling. I think the large DRC results can appear like this if someone reloads a project after it failed to get the result but not 100% sure. You can recreate reliably however by
1. Start a new project, run fit and start calibration
2. After calibration starts polling go back to first page and remove one of the files
3. Click OK on "new version" dialog to create a new version
4. In a private browser window open v1 of the project
5. See the spinner shown forever but no polling for calibration result

This PR fixes this by adding a new action called on mount which will restart the polling if `state.calibrating` is true but `state.complete` is false. I took a go on this so let me know if approach is not quite right or anything not idiomatic.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
