### PR TITLE
Mrc 4222 Area Indicator Table bugs

### DIFF
--- a/src/app/static/src/app/components/plots/table/Table.vue
+++ b/src/app/static/src/app/components/plots/table/Table.vue
@@ -11,7 +11,10 @@
                         @update:model-value="changeFilter"
                         :placeholder="translate('typeSearch')"></b-form-input>
                     <b-input-group-append>
-                        <b-button :disabled="!filter" @click="filter = ''" v-translate="'clearText'"></b-button>
+                        <b-button :disabled="!filter"
+                        @click="filter = ''"
+                        v-translate="'clearText'"
+                        size="sm"></b-button>
                     </b-input-group-append>
                 </b-input-group>
             </b-form-group>
@@ -19,9 +22,8 @@
                 striped hover
                 :fields="fields"
                 :items="filteredData"
-                :sort-by="sortBy"
-                :sort-desc="sortDesc"
                 :filter="filter"
+                :filterable="[]"
                 responsive="sm"
                 show-empty>
                 <template v-for="(_, slot) in $slots" v-slot:[slot]="props">
@@ -56,8 +58,6 @@
         },
         data() {
             return {
-                sortBy: "",
-                sortDesc: false,
                 filter: ""
             }
         },

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -140,7 +140,7 @@ describe('Table from testdata', () => {
 
     it("scoped slot content is rendered correctly", () => {
         const store = createStore();
-        const scopedSlots = {
+        const slots = {
             "cell(area_id)": `<template v-slot:cell(area_id)="props">
                     <div class="value">{{ props.item.area_id }}</div>
                     <div class="small">{{ props.item.area_hierarchy }}</div>
@@ -180,19 +180,16 @@ describe('Table from testdata', () => {
         const wrapper = mountWithTranslate(Table, store, {
             global: {
                 plugins: [store]
-            }, props: customPropsData, scopedSlots
+            }, props: customPropsData, slots
         });
 
         const dataRow1 = wrapper.findAll("tr")[1];
         const dataRow2 = wrapper.findAll("tr")[2];
 
-        console.log(dataRow1.html())
-
         expect(wrapper.find('th').text()).toBe('Area');
-        // TODO continueeee
-        expect(dataRow1.find('td').text()).toBe('4.1');
+        expect(dataRow1.find('td .value').text()).toBe('4.1');
         expect(dataRow1.find('td .small').text()).toBe('3.1');
-        expect(dataRow2.find('td').text()).toBe('4.2');
+        expect(dataRow2.find('td .value').text()).toBe('4.2');
         expect(dataRow2.find('td .small').text()).toBe('3.2');
 
         expect(wrapper.findAll('th')[1].text()).toBe('Age');

--- a/src/app/static/src/tests/components/plots/table/table.test.ts
+++ b/src/app/static/src/tests/components/plots/table/table.test.ts
@@ -64,19 +64,19 @@ describe('Table from testdata', () => {
         const dataRow1 = wrapper.findAll("tr")[1];
         const dataRow2 = wrapper.findAll("tr")[2];
 
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
+        expect(wrapper.find('th').text()).toBe('Area');
         expect(dataRow1.find('td').text()).toBe('4.1');
         expect(dataRow2.find('td').text()).toBe('4.2');
 
-        expect(wrapper.findAll('th')[1].text()).toBe('Age (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[1].text()).toBe('Age');
         expect(dataRow1.findAll('td')[1].text()).toBe('0-15');
         expect(dataRow2.findAll('td')[1].text()).toBe('15-30');
 
-        expect(wrapper.findAll('th')[2].text()).toBe('Sex (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[2].text()).toBe('Sex');
         expect(dataRow1.findAll('td')[2].text()).toBe('Female');
         expect(dataRow2.findAll('td')[2].text()).toBe('Male');
 
-        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence');
         expect(dataRow1.findAll('td')[3].text()).toBe('80.00%');
         expect(dataRow2.findAll('td')[3].text()).toBe('30.00%');
 
@@ -111,35 +111,6 @@ describe('Table from testdata', () => {
         expect(wrapper.text()).toContain("Aucune donnée n'est disponible pour ces sélections.")
     });
 
-    it('renders correct markup when sorting by HIV prevalence ascending', async () => {
-        const wrapper = getWrapper();
-        await wrapper.setData({sortBy: 'prevalence'});
-
-        const dataRow1 = wrapper.findAll("tr")[1];
-        const dataRow2 = wrapper.findAll("tr")[2];
-
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(dataRow1.find('td').text()).toBe('4.2');
-        expect(dataRow2.find('td').text()).toBe('4.1');
-
-        expect(wrapper.findAll('th')[1].text()).toBe('Age (Click to sort Ascending)');
-        expect(dataRow1.findAll('td')[1].text()).toBe('15-30');
-        expect(dataRow2.findAll('td')[1].text()).toBe('0-15');
-
-
-        expect(wrapper.findAll('th')[2].text()).toBe('Sex (Click to sort Ascending)');
-        expect(dataRow1.findAll('td')[2].text()).toBe('Male');
-        expect(dataRow2.findAll('td')[2].text()).toBe('Female');
-
-
-        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence (Click to sort Descending)');
-        expect(dataRow1.findAll('td')[3].text()).toBe('30.00%');
-        expect(dataRow2.findAll('td')[3].text()).toBe('80.00%');
-
-        expect(wrapper.findAll('tr').length).toBe(3);
-
-    });
-
     it('renders correct markup when sorting by HIV prevalence descending', async () => {
         const wrapper = getWrapper();
         await wrapper.setData({sortBy: 'prevalence', sortDesc: true});
@@ -149,13 +120,13 @@ describe('Table from testdata', () => {
     it('renders correct markup when filtering by 4.2', async () => {
         const wrapper = getWrapper();
         await wrapper.setData({filter: '4.2'})
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
+        expect(wrapper.find('th').text()).toBe('Area');
         expect(wrapper.find('td').text()).toBe('4.2');
-        expect(wrapper.findAll('th')[1].text()).toBe('Age (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[1].text()).toBe('Age');
         expect(wrapper.findAll('td')[1].text()).toBe('15-30');
-        expect(wrapper.findAll('th')[2].text()).toBe('Sex (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[2].text()).toBe('Sex');
         expect(wrapper.findAll('td')[2].text()).toBe('Male');
-        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence');
         expect(wrapper.findAll('td')[3].text()).toBe('30.00%');
         expect(wrapper.findAll('tr').length).toBe(2);
     });
@@ -215,21 +186,24 @@ describe('Table from testdata', () => {
         const dataRow1 = wrapper.findAll("tr")[1];
         const dataRow2 = wrapper.findAll("tr")[2];
 
-        expect(wrapper.find('th').text()).toBe('Area (Click to sort Ascending)');
-        expect(dataRow1.find('td .value').text()).toBe('4.1');
+        console.log(dataRow1.html())
+
+        expect(wrapper.find('th').text()).toBe('Area');
+        // TODO continueeee
+        expect(dataRow1.find('td').text()).toBe('4.1');
         expect(dataRow1.find('td .small').text()).toBe('3.1');
-        expect(dataRow2.find('td .value').text()).toBe('4.2');
+        expect(dataRow2.find('td').text()).toBe('4.2');
         expect(dataRow2.find('td .small').text()).toBe('3.2');
 
-        expect(wrapper.findAll('th')[1].text()).toBe('Age (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[1].text()).toBe('Age');
         expect(dataRow1.findAll('td')[1].text()).toBe('0-15');
         expect(dataRow2.findAll('td')[1].text()).toBe('15-30');
 
-        expect(wrapper.findAll('th')[2].text()).toBe('Sex (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[2].text()).toBe('Sex');
         expect(dataRow1.findAll('td')[2].text()).toBe('Female');
         expect(dataRow2.findAll('td')[2].text()).toBe('Male');
 
-        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence (Click to sort Ascending)');
+        expect(wrapper.findAll('th')[3].text()).toBe('HIV prevalence');
         expect(dataRow1.findAll('td')[3].find(".value").text()).toBe('80.00%');
         expect(dataRow1.findAll('td')[3].find(".small").text()).toBe('(70.00% - 90.00%)');
         expect(dataRow2.findAll('td')[3].find(".value").text()).toBe('30.00%');


### PR DESCRIPTION
## Problems/motivation:
- Clear button was too big and so not aligned with the search bar properly
- Entering anything in the search bar causes errors

## New features/solutions:
- Made clear button small
- Added a filterable property to the `b-table` which is apparently required in this new version of bootstrap vue
- Note that the filter arrows have been removed and a ticket has been made for adding them in, the new version does not show the arrows in a nice way but we will see if anyone actually complains about this. Also this feature is not too important since the table is getting a re-work anyway in the future!

## How PR should behave when tested:
- Should be able to search in the search bar
- Search bar and clear button should be aligned
- Table should update whenever you change the filters

## How to run app:
1. Run the app according to the README

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
