### PR TITLE
mrc-4338 Display Input Time Series plots with single values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.37.1
+
+* Fix Input Time Series plots with single values
+
 # hint 2.37.0
 
 * Auth0 single sign on authorization integration 

--- a/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
+++ b/src/app/src/main/resources/metadata/input-time-series-config-jsonata.txt
@@ -65,8 +65,8 @@ $lastXAxisVal := $timePeriods[$count(timePeriods) - 1];
                {
                     "name": ($lookup($dataByArea, $v).area_name)[0],
                     "showlegend": false,
-                    "x": $areaData.time_period,
-                    "y": $areaData.value,
+                    "x": [$areaData.time_period],
+                    "y": [$areaData.value],
                     "xaxis": 'x' & ($i+1),
                     "yaxis": 'y' & ($i+1),
                     "type": "scatter",

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.37.0";
+export const currentHintVersion = "2.37.1";

--- a/src/app/static/src/tests/integration/genericChart/genericChart_jsonata.itest.ts
+++ b/src/app/static/src/tests/integration/genericChart/genericChart_jsonata.itest.ts
@@ -72,6 +72,17 @@ const testChartData = {
             "plot": "art_total",
             "value": 4795,
             "page": 1
+        },
+        {
+            "area_id": "MWI_4_4_demo",
+            "area_name": "Mzuzu City",
+            "area_hierarchy": "Northern/Mzuzu City",
+            "area_level": 4,
+            "quarter": "Q4",
+            "time_period": "2012 Q4",
+            "plot": "art_total",
+            "value": 1024,
+            "page": 1
         }
     ],
     "subplots": {
@@ -183,6 +194,28 @@ describe("inputTimeSeries jsonata", () => {
                 "type": "scatter",
                 "line": {"color": "rgb(255, 51, 51)"},
                 "hovertemplate": "%{x}, %{y}<br>Northern/Rumphi<extra></extra>"
+            },
+            {
+                "name": "Mzuzu City",
+                "showlegend": false,
+                "x": ["2012 Q4"],
+                "y": [1024],
+                "xaxis": "x4",
+                "yaxis": "y4",
+                "type": "scatter",
+                "line": {"color": "rgb(51, 51, 51)"},
+                "hovertemplate": "%{x}, %{y}<br>Northern/Mzuzu City<extra></extra>"
+            },
+            {
+                "name": "Mzuzu City",
+                "showlegend": false,
+                "x": [],
+                "y": [],
+                "xaxis": "x4",
+                "yaxis": "y4",
+                "type": "scatter",
+                "line": {"color": "rgb(255, 51, 51)"},
+                "hovertemplate": "%{x}, %{y}<br>Northern/Mzuzu City<extra></extra>"
             }
         ]));
     });
@@ -199,7 +232,7 @@ describe("inputTimeSeries jsonata", () => {
         const layout = inputTimeSeriesJsonataResult.layout;
         expect(Object.keys(layout)).toStrictEqual([
             "margin", "dragmode", "grid", "annotations",
-            "yaxis1", "xaxis1", "yaxis2", "xaxis2", "yaxis3", "xaxis3"
+            "yaxis1", "xaxis1", "yaxis2", "xaxis2", "yaxis3", "xaxis3", "yaxis4", "xaxis4"
         ]);
         expect(layout.margin).toStrictEqual({"t": 32});
         expect(layout.dragmode).toBe(false);
@@ -241,6 +274,17 @@ describe("inputTimeSeries jsonata", () => {
                 "y": 1.1,
                 "yanchor": "middle",
                 "yref": "y3 domain"
+            },
+            {
+                "text": "Mzuzu City (MWI_4_4_demo)",
+                "textfont": {},
+                "showarrow": false,
+                "x": 0.5,
+                "xanchor": "middle",
+                "xref": "x4 domain",
+                "y": 1.1,
+                "yanchor": "middle",
+                "yref": "y4 domain"
             }
         ]));
     });
@@ -250,7 +294,8 @@ describe("inputTimeSeries jsonata", () => {
 
         expect(layout.xaxis1).toStrictEqual(expectedXAxis);
         expect(layout.xaxis2).toStrictEqual(expectedXAxis);
-        expect(layout.xaxis3).toStrictEqual(expectedXAxis);
+        expect(layout.xaxis3).toStrictEqual(expectedXAxis)
+        expect(layout.xaxis4).toStrictEqual(expectedXAxis);
 
         expectYAxis(1, 0.7, layout.yaxis1);
         expectYAxis(1, 0.7, layout.yaxis2);


### PR DESCRIPTION
## Description

With the latest Angola data (see zip file attached to ticket), ART data was not being plotted on the Input Time Series, because it has only a single data point. 

This was because of the Generic Plot config [jsonata](https://jsonata.org/), which is transformed into the full json passed to plotly by injecting the plot data. Jsonata has a tendency to convert arrays with single values in them into scalar values which are not in arrays. However, plotly requires json arrays for its data values. 

You can force jsonata to use an array for single values by wrapping the expression in square brackets, and happily this also works for multi-value arrays - it won't nest the array in a further array. Hence the change here which simply forces the x and y values for each subplot to be an array. 

We don't need to do this for the 'highlighted' values in red, as these are already calculated in pairs of values so you'll always have at least two. 

The resulting single-value plots are pretty useless as time series plots since there isn't a time series as such, but this is probably the expected behaviour, and better than not showing the values at all!

Updated the integration tests to include a further area with a single data point. 

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
