### PR TITLE
mrc-4341 Reload on retry if user is guest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 2.37.1
+
+* Fix Retry load for guest user
+
 # hint 2.37.0
 
 * Auth0 single sign on authorization integration 

--- a/src/app/static/src/app/components/load/LoadInvalidModal.vue
+++ b/src/app/static/src/app/components/load/LoadInvalidModal.vue
@@ -91,12 +91,16 @@
           rollbackInvalidState: mapActionByName(null, "rollbackInvalidState"),
           loadVersion: mapActionByName("projects", "loadVersion"),
           retryLoad() {
-            const versionId = this.currentVersion!.id;
-            const projectId = this.currentProject!.id;
-            this.loadVersion({
-              versionId,
-              projectId
-            })
+            if (this.isGuest) {
+              location.reload();
+            } else {
+              const versionId = this.currentVersion!.id;
+              const projectId = this.currentProject!.id;
+              this.loadVersion({
+                versionId,
+                projectId
+              })
+            }
           },
           stepTextKey(stepNumber: number) {
             return this.steps.find(step => step.number === stepNumber)?.textKey || stepNumber.toString();

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "2.37.0";
+export const currentHintVersion = "2.37.1";

--- a/src/app/static/src/tests/components/load/loadInvalidModal.test.ts
+++ b/src/app/static/src/tests/components/load/loadInvalidModal.test.ts
@@ -50,6 +50,19 @@ const getStore = (invalidSteps: number[], isGuest: boolean) => {
 describe("loadInvalidModal", () => {
 
     const mockTranslate = jest.fn();
+    const mockLocationReload = jest.fn();
+
+    const win = window as any;
+    const realLocation = win.location;
+
+    beforeAll(() => {
+        delete win.location;
+        win.location = {reload: mockLocationReload};
+    });
+
+    afterAll(() => {
+        win.location = realLocation;
+    });
 
     beforeEach(() => {
         jest.resetAllMocks()
@@ -132,10 +145,18 @@ describe("loadInvalidModal", () => {
         expect(wrapper.find("#load-invalid-projects").exists()).toBe(false);
     });
 
-    it("click Retry invokes loadVersion action", async () => {
+    it("click Retry invokes loadVersion action for logged in user", async () => {
         const wrapper = getWrapper([1]);
         await wrapper.find("button#retry-load").trigger("click");
         expect(mockLoadVersion.mock.calls[0][1]).toStrictEqual({versionId:  "testVersionId", projectId: "testProjectId"});
+        expect(mockLocationReload).not.toHaveBeenCalled();
+    });
+
+    it("click Retry reloads location for guest user", async () => {
+        const wrapper = getWrapper([1], true);
+        await wrapper.find("button#retry-load").trigger("click");
+        expect(mockLocationReload).toHaveBeenCalled();
+        expect(mockLoadVersion).not.toHaveBeenCalled();
     });
 
     it("click Rollback invokes rollbackInvalidState action", async () => {


### PR DESCRIPTION
## Description

"Retry" was not working from the Load Failed on invalid state dialog when user was guest. This was because it was attempting to load project by requested id from backend - however this load path is not available to guest users, who can only reload from current session (and current local storage state in front end). We can retry the load process for guest users by simply reloading the browser location, 

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
