### PR TITLE
Error Bar Resurrection

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -3555,12 +3555,6 @@
               "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
               "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
               "dev": true
-            },
-            "vue-hot-reload-api": {
-              "version": "2.3.4",
-              "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
-              "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
-              "dev": true
             }
           }
         },
@@ -18887,6 +18881,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vue-feather/-/vue-feather-2.0.0.tgz",
       "integrity": "sha512-GBvxJWu2ycGTpB8duYWnc5S/TwWPPb2G5Ft2NbkwK1vZkUDUOTYqIb4Nh1HOL6A37Isfrd0Guun0lesS97PfxA==",
+      "dev": true
+    },
+    "vue-hot-reload-api": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+      "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
     "vue-loader": {

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -49,6 +49,7 @@
                     :formatFunction="formatBarchartValue"
                     :showRangesInTooltips="true"
                     :no-data-message="noChartData"
+                    :show-error-bars="true"
                     @update:selections="updateBarchartSelectionsAndXAxisOrder"></bar-chart-with-filters>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>
@@ -98,6 +99,7 @@
                     :formatFunction="formatBarchartValue"
                     :showRangesInTooltips="true"
                     :no-data-message="noChartData"
+                    :show-error-bars="true"
                     @update:selections="updateComparisonPlotSelectionsAndXAxisOrder"></bar-chart-with-filters>
                 <div class="row mt-2">
                     <div class="col-md-3"></div>

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -250,7 +250,7 @@ export const flattenXAxisFilterOptionIds = (selections: BarchartSelections, filt
 
 
 export const updateSelectionsAndXAxisOrder = (data: BarchartSelections, selections: BarchartSelections, flattenedXAxisFilterOptionIds: string[], updateSelections: (data: {payload: BarchartSelections}) => void) => {
-    const payload = {...selections, ...data}
+    const payload = {...selections, ...structuredClone(data)}
     if (data.xAxisId && data.selectedFilterOptions) {
         const {xAxisId, selectedFilterOptions} = data
         if (selectedFilterOptions[xAxisId] && flattenedXAxisFilterOptionIds.length) {

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
@@ -192,30 +192,6 @@ export default defineComponent({
                     })
                 });
 
-                /*
-                    We need to pass a customLegendClick event into chartOptions so
-                    that our state can update when a user clicks on the legend and
-                    hides some bars. This is required to coordinate the chart with
-                    the error bars.
-                */
-                const customLegendClick = (e: Event, legendItem: any, legend: any) => {
-                    const index = legendItem.datasetIndex;
-                    const ci = legend.chart;
-                    if (ci.isDatasetVisible(index)) {
-                        this.showLabelErrorBars[index] = false;
-                        setTimeout(() => {
-                            ci.hide(index);
-                        }, 50)
-                        legendItem.hidden = true;
-                    } else {
-                        this.showLabelErrorBars[index] = true;
-                        setTimeout(() => {
-                            ci.show(index);
-                        }, 50)
-                        legendItem.hidden = false;
-                    }
-                }
-
                 return {
                     ...baseChartOptions,
                     plugins: {
@@ -223,7 +199,7 @@ export default defineComponent({
                             annotations: errorLines
                         },
                         legend: {
-                            onClick: customLegendClick
+                            onClick: this.customLegendClick
                         }
                     },
                     scales: {
@@ -246,6 +222,29 @@ export default defineComponent({
             this.errorBarTimeout = setTimeout(() => {
                 this.displayErrorBars = true
             }, 1050)
+        },
+        /*
+            We need to pass a customLegendClick event into chartOptions so
+            that our state can update when a user clicks on the legend and
+            hides some bars. This is required to coordinate the chart with
+            the error bars.
+        */
+        customLegendClick(e: Event, legendItem: any, legend: any) {
+            const index = legendItem.datasetIndex;
+            const ci = legend.chart;
+            if (ci.isDatasetVisible(index)) {
+                this.showLabelErrorBars[index] = false;
+                setTimeout(() => {
+                    ci.hide(index);
+                }, 50)
+                legendItem.hidden = true;
+            } else {
+                this.showLabelErrorBars[index] = true;
+                setTimeout(() => {
+                    ci.show(index);
+                }, 50)
+                legendItem.hidden = false;
+            }
         }
     },
     mounted() {
@@ -260,7 +259,6 @@ export default defineComponent({
         },
         chartDatasetLabels: {
             handler: function(newVal, oldVal) {
-                console.log(this.chartDatasetLabels)
                 this.showLabelErrorBars = this.chartData.datasets!.map(() => true)
             }
         },

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
@@ -3,31 +3,25 @@
 </template>
 
 <script lang="ts">
-import {Bar} from 'vue-chartjs'
-// import ErrorBarsPlugin from 'chartjs-plugin-error-bars';
+import {Bar} from 'vue-chartjs';
 import {BarChartData} from "./utils";
-import { ChartDataSetsWithErrors } from "./types"
-import { PropType, defineComponent } from 'vue';
-import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js'
-
-ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
-// interface Props {
-//     [key:string]: any
-//     chartData: BarChartData
-//     xLabel: string
-//     yLabel: string
-//     yFormat: (value: number | string) => string
-//     showErrors: boolean
-// }
-
-// interface Methods {
-//     [key:string]: any
-//     updateRender(): void
-// }
+import { ChartDataSetsWithErrors } from "./types";
+import { PropType, defineComponent, shallowReadonly } from 'vue';
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js';
+import annotationPlugin from "chartjs-plugin-annotation";
+ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, annotationPlugin);
 
 export default defineComponent({
     components: {
         Bar
+    },
+    data() {
+        const showLabelErrorBars = this.chartData.datasets!.map(() => true);
+        return {
+            displayErrorBars: true,
+            errorBarTimeout: null as any,
+            showLabelErrorBars
+        }
     },
     props: {
         chartData: {
@@ -50,179 +44,231 @@ export default defineComponent({
             type: Boolean,
             required: true
         },
+        showErrorBars: {
+            type: Boolean,
+            required: false,
+            default: false
+        }
     },
     computed: {
+        chartDatasetLabels() {
+            return JSON.stringify(this.chartData.datasets.map(x => x.label))
+        },
         chartOptions() {
             const formatCallback = this.yFormat || ((value: number | string) => value);
-            return {
-                // scales: {
-                //     yAxes: [{
-                //         scaleLabel: {
-                //             display: true,
-                //             labelString: this.yLabel
-                //         },
-                //         ticks: {
-                //             suggestedMax: this.chartData.maxValuePlusError,
-                //             beginAtZero: true,
-                //             // callback: formatCallback
-                //         }
-                //     }],
-                //     xAxes: [{
-                //         scaleLabel: {
-                //             display: true,
-                //             labelString: this.xLabel
-                //         }
-                //     }]
-                // },
-                legend: {
-                    position: "right",
-                },
-                tooltips: {
-                    callbacks: {
-                        label: (tooltipItem: any, data: any) => {
-                            let label = ((typeof tooltipItem.datasetIndex !== "undefined") && data.datasets && data.datasets[tooltipItem.datasetIndex].label)
-                                            || '';
-                            if (label) {
-                                label += ': ';
-                            }
+            const chartData = this.chartData as any;
+            const datasets = chartData.datasets as any[];
 
-                            if (tooltipItem.yLabel) {
-                                label += formatCallback(tooltipItem.yLabel);
-                            }
+            if (this.showErrorBars) {
+                const errorLines = [] as any[];
+                const visibleDatasetIndices = this.showLabelErrorBars.reduce(
+                    (out: number[], bool: boolean, index: number) => bool ? out.concat(index) : out, 
+                    []
+                );
+                const numOfDatasets = this.showLabelErrorBars.filter(x => x).length;
+                const numOfLabels = chartData.labels.length;
+                const numOfBars = numOfDatasets * numOfLabels;
+                const barPercentage = 0.8;
+                const barWidth = barPercentage/(numOfDatasets * 2);
+                const errorBarWeight = 1;
+                visibleDatasetIndices.forEach((datasetId, indexDataset) => {
+                    const dataset = datasets[datasetId];
+                    if (!dataset) {
+                        return
+                    }
+                    const errorBarData = dataset.errorBars;
+                    const label = dataset.label;
+                    Object.keys(errorBarData).forEach((xLabel) => {
+                        const labelIndex = chartData.labels.indexOf(xLabel)
+                        const barMidPoint = labelIndex - barPercentage/2 + barWidth * (indexDataset * 2 + 1);
+                        const errorBarWidth = (numOfBars/(numOfBars + 10)) * barWidth * 0.3;
+                        if (errorBarData[xLabel].minus && errorBarData[xLabel].plus) {
+                            const config = [
+                                {
+                                    drawTime: "afterDraw",
+                                    type: "line",
+                                    label: {
+                                        content: label
+                                    },
+                                    display: this.displayErrorBars,
+                                    xMin: barMidPoint,
+                                    xMax: barMidPoint,
+                                    yMin: errorBarData[xLabel].minus,
+                                    yMax: errorBarData[xLabel].plus,
+                                    borderWidth: errorBarWeight
+                                },
+                                {
+                                    drawTime: "afterDraw",
+                                    type: "line",
+                                    label: {
+                                        content: label
+                                    },
+                                    display: this.displayErrorBars,
+                                    xMin: barMidPoint - errorBarWidth,
+                                    xMax: barMidPoint + errorBarWidth,
+                                    yMin: errorBarData[xLabel].plus,
+                                    yMax: errorBarData[xLabel].plus,
+                                    borderWidth: errorBarWeight
+                                },
+                                {
+                                    drawTime: "afterDraw",
+                                    type: "line",
+                                    label: {
+                                        content: label
+                                    },
+                                    display: this.displayErrorBars,
+                                    xMin: barMidPoint - errorBarWidth,
+                                    xMax: barMidPoint + errorBarWidth,
+                                    yMin: errorBarData[xLabel].minus,
+                                    yMax: errorBarData[xLabel].minus,
+                                    borderWidth: errorBarWeight
+                                },
+                            ];
+                            errorLines.push(...config);
+                        }
+                    })
+                });
 
-                            let minus = null
-                            let plus = null
+                const customLegendClick = (e: Event, legendItem: any, legend: any) => {
+                    const index = legendItem.datasetIndex;
+                    const ci = legend.chart;
+                    if (ci.isDatasetVisible(index)) {
+                        this.showLabelErrorBars[index] = false;
+                        setTimeout(() => {
+                            ci.hide(index);
+                        }, 50)
+                        legendItem.hidden = true;
+                    } else {
+                        this.showLabelErrorBars[index] = true;
+                        setTimeout(() => {
+                            ci.show(index);
+                        }, 50)
+                        legendItem.hidden = false;
+                    }
+                }
 
-                            if (this.showErrors && tooltipItem.xLabel && typeof tooltipItem.datasetIndex !== "undefined" && data.datasets && data.datasets[tooltipItem.datasetIndex]) {
-                                const errorBars = (data.datasets[tooltipItem.datasetIndex] as ChartDataSetsWithErrors).errorBars
-                                const xLabelErrorBars = errorBars ? errorBars[tooltipItem.xLabel] : null
-                                if (xLabelErrorBars) {
-                                    minus = xLabelErrorBars.minus
-                                    plus = xLabelErrorBars.plus
+                return {
+                    tooltips: {
+                        callbacks: {
+                            label: (tooltipItem: any, data: any) => {
+                                let label = ((typeof tooltipItem.datasetIndex !== "undefined") && data.datasets && data.datasets[tooltipItem.datasetIndex].label)
+                                                || '';
+                                if (label) {
+                                    label += ': ';
                                 }
+    
+                                if (tooltipItem.yLabel) {
+                                    label += formatCallback(tooltipItem.yLabel);
+                                }
+    
+                                let minus = null
+                                let plus = null
+    
+                                if (this.showErrors && tooltipItem.xLabel && typeof tooltipItem.datasetIndex !== "undefined" && data.datasets && data.datasets[tooltipItem.datasetIndex]) {
+                                    const errorBars = (data.datasets[tooltipItem.datasetIndex] as ChartDataSetsWithErrors).errorBars
+                                    const xLabelErrorBars = errorBars ? errorBars[tooltipItem.xLabel] : null
+                                    if (xLabelErrorBars) {
+                                        minus = xLabelErrorBars.minus
+                                        plus = xLabelErrorBars.plus
+                                    }
+                                }
+    
+                                if ((typeof minus === "number") && (typeof plus === "number")) {
+                                    label = `${label} (${formatCallback(minus)} - ${formatCallback(plus)})`
+                                }
+    
+                                return label;
                             }
-
-                            if ((typeof minus === "number") && (typeof plus === "number")) {
-                                label = `${label} (${formatCallback(minus)} - ${formatCallback(plus)})`
-                            }
-
-                            return label;
+                        }
+                    },
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        annotation: {
+                            annotations: errorLines
+                        },
+                        legend: {
+                            onClick: customLegendClick
+                        }
+                    },
+                    scales: {
+                        y: {
+                            max: this.chartData.maxValuePlusError * 1.1
                         }
                     }
-                },
-                responsive: true,
-                maintainAspectRatio: false,
-                // plugins: {
-                //     chartJsPluginErrorBars: {
-                //         color: '#000',
-                //         width: '2px',
-                //         lineWidth: '2px',
-                //         absoluteValues: true
-                //     }
-                // }
+                }
+            } else {
+                return {
+                    tooltips: {
+                        callbacks: {
+                            label: (tooltipItem: any, data: any) => {
+                                let label = ((typeof tooltipItem.datasetIndex !== "undefined") && data.datasets && data.datasets[tooltipItem.datasetIndex].label)
+                                                || '';
+                                if (label) {
+                                    label += ': ';
+                                }
+    
+                                if (tooltipItem.yLabel) {
+                                    label += formatCallback(tooltipItem.yLabel);
+                                }
+    
+                                let minus = null
+                                let plus = null
+    
+                                if (this.showErrors && tooltipItem.xLabel && typeof tooltipItem.datasetIndex !== "undefined" && data.datasets && data.datasets[tooltipItem.datasetIndex]) {
+                                    const errorBars = (data.datasets[tooltipItem.datasetIndex] as ChartDataSetsWithErrors).errorBars
+                                    const xLabelErrorBars = errorBars ? errorBars[tooltipItem.xLabel] : null
+                                    if (xLabelErrorBars) {
+                                        minus = xLabelErrorBars.minus
+                                        plus = xLabelErrorBars.plus
+                                    }
+                                }
+    
+                                if ((typeof minus === "number") && (typeof plus === "number")) {
+                                    label = `${label} (${formatCallback(minus)} - ${formatCallback(plus)})`
+                                }
+    
+                                return label;
+                            }
+                        }
+                    },
+                    responsive: true,
+                    maintainAspectRatio: false
+                }
             }
         }
+    },
+    watch: {
+        chartData: {
+            handler: function(newVal, oldVal) {
+                this.displayErrorBars = false;
+                if (this.errorBarTimeout) {
+                    window.clearTimeout(this.errorBarTimeout)
+                }
+                this.errorBarTimeout = setTimeout(() => {
+                    this.displayErrorBars = true
+                }, 900)
+            },
+            deep: true
+        },
+        chartDatasetLabels: {
+            handler: function(newVal, oldVal) {
+                console.log(this.chartDatasetLabels)
+                this.showLabelErrorBars = this.chartData.datasets!.map(() => true)
+            }
+        },
+        showLabelErrorBars: {
+            handler: function(newVal, oldVal) {
+                this.displayErrorBars = false;
+                if (this.errorBarTimeout) {
+                    window.clearTimeout(this.errorBarTimeout)
+                }
+                this.errorBarTimeout = setTimeout(() => {
+                    this.displayErrorBars = true
+                }, 1050)
+            },
+            deep: true
+        }        
     }
 })
-
-// @Component
-// export default class BarChartWithErrors extends mixins(Bar) {
-
-//     @Prop()
-//     chartData!: BarChartData;
-
-//     @Prop()
-//     xLabel!: string;
-
-//     @Prop()
-//     yLabel!: string;
-
-//     @Prop()
-//     yFormat!: (value: number | string) => string;
-
-//     @Prop()
-//     showErrors!: boolean;
-
-    // updateRender() {
-    //     (this as any).addPlugin(ErrorBarsPlugin);
-
-    //     const formatCallback = this.yFormat || ((value: number | string) => value);
-    //     (this as any).renderChart(this.chartData, {
-    //         scales: {
-    //             yAxes: [{
-    //                 scaleLabel: {
-    //                     display: true,
-    //                     labelString: this.yLabel
-    //                 },
-    //                 ticks: {
-    //                     suggestedMax: this.chartData.maxValuePlusError,
-    //                     beginAtZero: true,
-    //                     callback: formatCallback
-    //                 }
-    //             }],
-    //             xAxes: [{
-    //                 scaleLabel: {
-    //                     display: true,
-    //                     labelString: this.xLabel
-    //                 }
-    //             }]
-    //         },
-    //         legend: {
-    //             position: "right",
-    //         },
-    //         tooltips: {
-    //             callbacks: {
-    //                 label: (tooltipItem, data) => {
-    //                     let label = ((typeof tooltipItem.datasetIndex !== "undefined") && data.datasets && data.datasets[tooltipItem.datasetIndex].label)
-    //                                     || '';
-    //                     if (label) {
-    //                         label += ': ';
-    //                     }
-
-    //                     if (tooltipItem.yLabel) {
-    //                         label += formatCallback(tooltipItem.yLabel);
-    //                     }
-
-    //                     let minus = null
-    //                     let plus = null
-
-    //                     if (this.showErrors && tooltipItem.xLabel && typeof tooltipItem.datasetIndex !== "undefined" && data.datasets && data.datasets[tooltipItem.datasetIndex]) {
-    //                         const errorBars = (data.datasets[tooltipItem.datasetIndex] as ChartDataSetsWithErrors).errorBars
-    //                         const xLabelErrorBars = errorBars ? errorBars[tooltipItem.xLabel] : null
-    //                         if (xLabelErrorBars) {
-    //                             minus = xLabelErrorBars.minus
-    //                             plus = xLabelErrorBars.plus
-    //                         }
-    //                     }
-
-    //                     if ((typeof minus === "number") && (typeof plus === "number")) {
-    //                         label = `${label} (${formatCallback(minus)} - ${formatCallback(plus)})`
-    //                     }
-
-    //                     return label;
-    //                 }
-    //             }
-    //         },
-    //         responsive: true,
-    //         maintainAspectRatio: false,
-    //         plugins: {
-    //             chartJsPluginErrorBars: {
-    //                 color: '#000',
-    //                 width: '2px',
-    //                 lineWidth: '2px',
-    //                 absoluteValues: true
-    //             }
-    //         }
-    //     })
-    // }
-
-//     mounted() {
-//         this.updateRender();
-//     }
-
-//     @Watch("chartData")
-//     chartDataChanged() {
-//         this.updateRender();
-//     }
-// };
 </script>

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
@@ -74,7 +74,6 @@ export default defineComponent({
                                     raw: yLabel,
                                     label: xLabel
                                 } = context;
-                                console.log(context)
                                 let label = ((typeof datasetIndex !== "undefined") && dataset && dataset.label)
                                                 || '';
                                 if (label) {

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
@@ -71,9 +71,10 @@ export default defineComponent({
                                 const {
                                     datasetIndex,
                                     dataset,
-                                    formattedValue: yLabel,
+                                    raw: yLabel,
                                     label: xLabel
                                 } = context;
+                                console.log(context)
                                 let label = ((typeof datasetIndex !== "undefined") && dataset && dataset.label)
                                                 || '';
                                 if (label) {

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithFilters.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithFilters.vue
@@ -39,7 +39,7 @@
                         :is-x-axis="filter.id === selections.xAxisId"
                         :label="filter.label"
                         :options="filter.options"
-                        @input="changeFilter(filter.id, $event)"></filter-select>
+                        @update:filter-select="changeFilter(filter.id, $event)"></filter-select>
                     </div>
                 </div>
             </template>
@@ -52,6 +52,7 @@
                         :yLabel="indicatorLabel"
                         :yFormat="formatValueFunction"
                         :show-errors="showRangesInTooltips"
+                        :show-error-bars="showErrorBars"
                         style="width: 100%; height: 100%;"></bar-chart-with-errors>
                 <div v-if="showNoDataMessage" id="noDataMessage" class="px-3 py-2 noDataMessage">
                     <span class="lead">
@@ -169,6 +170,11 @@
                 type: String as PropType<string | null>,
                 required: false,
                 default: null
+            },
+            showErrorBars: {
+                type: Boolean,
+                required: false,
+                default: false
             }
         },
         computed: {

--- a/src/app/static/src/app/vue-chart/src/bar/FilterSelect.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/FilterSelect.vue
@@ -2,13 +2,14 @@
     <div>
         <label class="font-weight-bold">{{label}}</label>
         <hint-tree-select :instanceId="id"
-                     :multiple=isXAxisOrDisagg
+                     :multiple="isXAxisOrDisagg"
                      :clearable="false"
-                     :flat=isXAxisOrDisagg
+                     :flat="isXAxisOrDisagg"
                      :options="options"
                      :model-value="selectedValues"
                      @select="select"
-                     @deselect="deselect"></hint-tree-select>
+                     @deselect="deselect"
+                     :key="`${isXAxisOrDisagg}`"></hint-tree-select>
         <span v-if="isXAxisOrDisagg" class="text-muted">
                         <small>{{badge}}</small>
                     </span>
@@ -85,11 +86,11 @@
                 } else {
                     this.selected.push(node);
                 }
-                this.$emit("input", this.selected);
+                this.$emit("update:filter-select", this.selected);
             },
             deselect(node: FilterOption) {
                 this.selected = this.selected.filter((n: any) => n.id != node.id);
-                this.$emit("input", this.selected);
+                this.$emit("update:filter-select", this.selected);
             }
         },
         computed: {
@@ -101,7 +102,7 @@
             },
             badge() {
                 if (this.isXAxis) {
-                    return ("x axis");
+                    return "x axis";
                 } else {
                     return "disaggregate by"
                 }
@@ -120,7 +121,7 @@
                     if (this.selected.length == 0) {
                         this.selected.push(this.options[0]);
                     }
-                    this.$emit("input", this.selected);
+                    this.$emit("update:filter-select", this.selected);
                 }
             }
         },

--- a/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
@@ -160,7 +160,7 @@ describe("chartjsBar component", () => {
         const tooltipLabelCallback = renderedConfig.plugins.tooltip.callbacks.label;
         const renderedLabel = tooltipLabelCallback({
             datasetIndex: 0,
-            formattedValue: 2,
+            raw: 2,
             dataset: newChartData.datasets[0]
         });
         expect(renderedLabel).toBe("dataset1: Value 2");
@@ -215,7 +215,7 @@ describe("chartjsBar component", () => {
         const tooltipLabelCallback = renderedConfig.plugins.tooltip.callbacks.label;
         const renderedLabel = tooltipLabelCallback({
             datasetIndex: 0,
-            formattedValue: 2,
+            raw: 2,
             dataset: newChartData.datasets[0]
         });
         expect(renderedLabel).toBe("dataset1: Value 2");
@@ -249,11 +249,11 @@ describe("chartjsBar component", () => {
         const tooltipLabelCallback = renderedConfig.plugins.tooltip.callbacks.label;
 
         //tooltipItem.datasetIndex is undefined
-        let renderedLabel = tooltipLabelCallback({formattedValue: 2, dataset: newChartData.datasets[0]});
+        let renderedLabel = tooltipLabelCallback({raw: 2, dataset: newChartData.datasets[0]});
         expect(renderedLabel).toBe("Value 2");
 
         //data.datasets is undefined
-        renderedLabel = tooltipLabelCallback({datasetIndex: 0, formattedValue: 2});
+        renderedLabel = tooltipLabelCallback({datasetIndex: 0, raw: 2});
         expect(renderedLabel).toBe("Value 2");
 
         //tooltip.yLabel is undefined - returns dataseries label
@@ -281,7 +281,7 @@ describe("chartjsBar component", () => {
 
         let renderedLabel = tooltipLabelCallback({
             datasetIndex: 0,
-            formattedValue: 2,
+            raw: 2,
             label: "group2",
             dataset: propsData.chartData.datasets[0]
         });
@@ -315,7 +315,7 @@ describe("chartjsBar component", () => {
 
         let renderedLabel = tooltipLabelCallback({
             datasetIndex: 0,
-            formattedValue: 2,
+            raw: 2,
             label: "group2",
             dataset: propsData.chartData.datasets[0]
         });

--- a/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
@@ -1,0 +1,432 @@
+import {flushPromises, shallowMount} from "@vue/test-utils";
+import BarChartWithErrors from "../../src/bar/BarChartWithErrors.vue";
+import { ErrorBars } from "../../src/bar/types"
+import { nextTick } from "vue";
+
+describe("chartjsBar component", () => {
+
+    const errorBars: ErrorBars = {
+        "group1": { plus: 1.1, minus: 0.9 },
+        "group2": { plus: 2.1, minus: 1.9 }
+    }
+
+    const formatFunc = (value: string | number ) => "Value " + value.toString();
+    const propsData = {
+        xLabel: "X Axis",
+        yLabel: "Y Axis",
+        yFormat: formatFunc,
+        chartData: {
+            labels: ["group1", "group2"],
+            datasets:[
+                {
+                    label: "dataset1",
+                    backgroundColor: "#111111",
+                    data: [1,2],
+                    errorBars
+                }
+            ]
+        },
+        showErrorBars: true
+    } as any;
+
+    const expectedPluginConfig = (customLegendClick: Function) => { return {
+        annotation: {
+            annotations: [
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: 0,
+                    xMin: 0,
+                    yMax: 1.1,
+                    yMin: 0.9,
+                },
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: 0.01090909090909091,
+                    xMin: -0.01090909090909091,
+                    yMax: 1.1,
+                    yMin: 1.1,
+                },
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: 0.01090909090909091,
+                    xMin: -0.01090909090909091,
+                    yMax: 0.9,
+                    yMin: 0.9,
+                },
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: -1,
+                    xMin: -1,
+                    yMax: 2.1,
+                    yMin: 1.9,
+                },
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: -0.9890909090909091,
+                    xMin: -1.010909090909091,
+                    yMax: 2.1,
+                    yMin: 2.1,
+                },
+                {
+                    borderColor: "#585858",
+                    borderWidth: 1,
+                    display: false,
+                    drawTime: "afterDatasetsDraw",
+                    label: {
+                    content: "dataset1",
+                    },
+                    type: "line",
+                    xMax: -0.9890909090909091,
+                    xMin: -1.010909090909091,
+                    yMax: 1.9,
+                    yMin: 1.9,
+                },
+            ],
+        },
+        legend: {
+            onClick: customLegendClick,
+        }
+    }}
+
+    const getWrapper = () => {
+        return shallowMount(BarChartWithErrors, {props: propsData});
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.findAll("bar-stub").length).toEqual(1);
+    });
+
+    it("computes correct chart options", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const newChartData = {
+            ...propsData.chartData,
+            labels: ["group1"],
+            maxValuePlusError: 0.2
+        };
+        await wrapper.setProps({
+            ...propsData,
+            chartData: newChartData
+        });
+
+        await nextTick();
+
+        const renderedConfig = vm.chartOptions;
+
+        //Test that the callback to construct the label based on the format func behaves as expected
+        const tooltipLabelCallback = renderedConfig.tooltips.callbacks.label;
+        const renderedLabel = tooltipLabelCallback({datasetIndex: 0, yLabel: 2}, newChartData);
+        expect(renderedLabel).toBe("dataset1: Value 2");
+
+        expect(renderedConfig.responsive).toBe(true);
+        expect(renderedConfig.maintainAspectRatio).toBe(false);
+        expect(renderedConfig.plugins).toStrictEqual(expectedPluginConfig(renderedConfig.plugins.legend.onClick));
+        expect(renderedConfig.scales.y.max).toBeCloseTo(0.22);
+    });
+
+    it("correct chart options if not showErrorBars", async () => {
+        const propsDataNoErrors = {
+            xLabel: "X Axis",
+            yLabel: "Y Axis",
+            yFormat: formatFunc,
+            chartData: {
+                labels: ["group1", "group2"],
+                datasets:[
+                    {
+                        label: "dataset1",
+                        backgroundColor: "#111111",
+                        data: [1,2],
+                        errorBars
+                    }
+                ]
+            }
+        } as any;
+        const wrapper = shallowMount(BarChartWithErrors, {props: propsDataNoErrors});
+        const vm = (wrapper as any).vm;
+
+        const newChartData = {
+            ...propsDataNoErrors.chartData,
+            labels: ["group1"],
+            maxValuePlusError: 0.2
+        };
+        await wrapper.setProps({
+            ...propsDataNoErrors,
+            chartData: newChartData
+        });
+
+        await nextTick();
+
+        const renderedConfig = vm.chartOptions;
+
+        //Test that the callback to construct the label based on the format func behaves as expected
+        const tooltipLabelCallback = renderedConfig.tooltips.callbacks.label;
+        const renderedLabel = tooltipLabelCallback({datasetIndex: 0, yLabel: 2}, newChartData);
+        expect(renderedLabel).toBe("dataset1: Value 2");
+
+        expect(renderedConfig.responsive).toBe(true);
+        expect(renderedConfig.maintainAspectRatio).toBe(false);
+        expect(renderedConfig.hasOwnProperty("plugins")).toBe(false);
+    });
+
+    it("tooltip label callback deals with incomplete parameters", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const newChartData = {
+            ...propsData.chartData,
+        };
+        await wrapper.setProps({
+            ...propsData,
+            chartData: newChartData
+        });
+
+        await nextTick();
+
+        const renderedConfig = vm.chartOptions;
+        const tooltipLabelCallback = renderedConfig.tooltips.callbacks.label;
+
+        //tooltipItem.datasetIndex is undefined
+        let renderedLabel = tooltipLabelCallback({yLabel: 2}, newChartData);
+        expect(renderedLabel).toBe("Value 2");
+
+        //data.datasets is undefined
+        renderedLabel = tooltipLabelCallback({datasetIndex: 0, yLabel: 2}, {});
+        expect(renderedLabel).toBe("Value 2");
+
+        //tooltip.yLabel is undefined - returns dataseries label
+        renderedLabel = tooltipLabelCallback({datasetIndex: 0}, newChartData);
+        expect(renderedLabel).toBe("dataset1: ");
+    });
+
+    it("tooltip label callback renders uncertainty ranges if given showErrors prop", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const newChartData = {
+            ...propsData.chartData,
+        };
+        await wrapper.setProps({
+            ...propsData,
+            chartData: newChartData,
+            showErrors: true
+        });
+
+        await nextTick();
+
+        const renderedConfig = vm.chartOptions;
+        const tooltipLabelCallback = renderedConfig.tooltips.callbacks.label;
+
+        let renderedLabel = tooltipLabelCallback({ datasetIndex: 0, yLabel: 2, xLabel: "group2" }, propsData.chartData);
+        expect(renderedLabel).toBe("dataset1: Value 2 (Value 1.9 - Value 2.1)");
+    });
+
+    it("tooltip label callback does not render uncertainty ranges if given showErrors contains null values", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const newErrorBars = {
+            "group1": { plus: null, minus: null },
+            "group2": { plus: null, minus: null }
+        }
+
+        const newChartData = {
+            ...propsData.chartData,
+        };
+        newChartData.datasets[0].errorBars = newErrorBars
+
+        await wrapper.setProps({
+            ...propsData,
+            chartData: newChartData,
+            showErrors: true
+        });
+
+        await nextTick();
+
+        const renderedConfig = vm.chartOptions;
+        const tooltipLabelCallback = renderedConfig.tooltips.callbacks.label;
+
+        let renderedLabel = tooltipLabelCallback({ datasetIndex: 0, yLabel: 2, xLabel: "group2" }, propsData.chartData);
+        expect(renderedLabel).toBe("dataset1: Value 2");
+    });
+
+    it("hide error bars during animations works as expected", async () => {
+        const wrapper = getWrapper();
+        const vm = wrapper.vm as any
+        vm.hideErrorBarsDuringAnimation();
+        expect(vm.displayErrorBars).toBe(false);
+        await new Promise(r => setTimeout(r, 1050));
+        expect(vm.displayErrorBars).toBe(true);
+    });
+
+    it("clears timeout when hide error bars is called twice", async () => {
+        const wrapper = getWrapper();
+        const vm = wrapper.vm as any
+
+        const spy = jest.spyOn(window, "clearTimeout");
+
+        vm.hideErrorBarsDuringAnimation();
+        // mount already creates a timeout
+        expect(spy).toBeCalledTimes(1);
+        
+        vm.hideErrorBarsDuringAnimation();
+        expect(spy).toBeCalledTimes(2);
+    });
+
+    it("hide error bars gets called on mount, chartData and showLabelErrorBars change", async () => {
+        const mockHideErrorBars = jest.fn();
+        BarChartWithErrors.methods!.hideErrorBarsDuringAnimation = mockHideErrorBars;
+
+        const wrapper = shallowMount(BarChartWithErrors, {props: propsData});
+        const vm = wrapper.vm as any
+
+        expect(mockHideErrorBars).toHaveBeenCalledTimes(1);
+
+        vm.$options.watch.chartData.handler.call(vm);
+        expect(mockHideErrorBars).toHaveBeenCalledTimes(2);
+
+        vm.$options.watch.showLabelErrorBars.handler.call(vm);
+        expect(mockHideErrorBars).toHaveBeenCalledTimes(3);
+    });
+
+    it("chart dataset label watcher resets show label error bars", async () => {
+        const propsDataMultiple = {
+            xLabel: "X Axis",
+            yLabel: "Y Axis",
+            yFormat: formatFunc,
+            chartData: {
+                labels: ["group1", "group2"],
+                datasets:[
+                    {
+                        label: "dataset1",
+                        backgroundColor: "#111111",
+                        data: [1,2],
+                        errorBars
+                    },
+                    {
+                        label: "dataset2",
+                        backgroundColor: "#111111",
+                        data: [3,4],
+                        errorBars
+                    }
+                ]
+            },
+            showErrorBars: true
+        } as any;
+
+        const wrapper = shallowMount(BarChartWithErrors, {props: propsDataMultiple});
+        const vm = wrapper.vm as any
+
+        expect(vm.showLabelErrorBars).toStrictEqual([true, true]);
+        vm.showLabelErrorBars = [false, true];
+        expect(vm.showLabelErrorBars).toStrictEqual([false, true]);
+
+        vm.$options.watch.chartDatasetLabels.handler.call(vm);
+        expect(vm.showLabelErrorBars).toStrictEqual([true, true]);
+    });
+
+    it("custom legend click function works as expected", async () => {
+        const propsDataMultiple = {
+            xLabel: "X Axis",
+            yLabel: "Y Axis",
+            yFormat: formatFunc,
+            chartData: {
+                labels: ["group1", "group2"],
+                datasets:[
+                    {
+                        label: "dataset1",
+                        backgroundColor: "#111111",
+                        data: [1,2],
+                        errorBars
+                    },
+                    {
+                        label: "dataset2",
+                        backgroundColor: "#111111",
+                        data: [3,4],
+                        errorBars
+                    }
+                ]
+            },
+            showErrorBars: true
+        } as any;
+        const mockHide = jest.fn();
+        const mockShow = jest.fn();
+
+        const wrapper = shallowMount(BarChartWithErrors, {props: propsDataMultiple});
+        const vm = wrapper.vm as any
+
+        const getLegendAndItem = (index: number, isVisible: boolean) => {
+            return {
+                legendItem: {
+                    datasetIndex: index,
+                    hidden: !isVisible
+                },
+                legend: {
+                    chart: {
+                        isDatasetVisible: (_: any) => isVisible,
+                        hide: mockHide,
+                        show: mockShow
+                    }
+                }
+            }
+        };
+
+        const { legendItem, legend } = getLegendAndItem(1, true);
+        vm.customLegendClick(null, legendItem, legend);
+        expect(legendItem.hidden).toBe(true);
+        expect(vm.showLabelErrorBars).toStrictEqual([true, false]);
+        expect(mockHide).toBeCalledTimes(0);
+        expect(mockShow).toBeCalledTimes(0);
+        await new Promise(r => setTimeout(r, 50));
+        expect(mockHide).toBeCalledTimes(1);
+        expect(mockShow).toBeCalledTimes(0);
+
+        jest.resetAllMocks();
+
+        const { legendItem: legendItem1, legend: legend1 } = getLegendAndItem(1, false);
+        vm.customLegendClick(null, legendItem1, legend1);
+        expect(legendItem1.hidden).toBe(false);
+        expect(vm.showLabelErrorBars).toStrictEqual([true, true]);
+        expect(mockHide).toBeCalledTimes(0);
+        expect(mockShow).toBeCalledTimes(0);
+        await new Promise(r => setTimeout(r, 50));
+        expect(mockHide).toBeCalledTimes(0);
+        expect(mockShow).toBeCalledTimes(1);
+    });
+});

--- a/src/app/static/src/app/vue-chart/tests/bar/barChartWithFilters.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/barChartWithFilters.test.ts
@@ -1,0 +1,478 @@
+import {shallowMount} from "@vue/test-utils";
+import {data, filters} from "./utils.test";
+import BarChartWithFilters from "../../src/bar/BarChartWithFilters.vue";
+import BarChartWithErrors from "../../src/bar/BarChartWithErrors.vue";
+import {BarchartIndicator} from "../../src/bar/types";
+import { nextTick } from "vue";
+
+const formatFunction = (value: string | number, indicator: BarchartIndicator) => {
+    return `Value: ${value}, Indicator: ${indicator.indicator}`;
+};
+
+const propsData = {
+    chartData: data,
+    filterConfig: {filters},
+    indicators: [
+        {
+            indicator: "art_cov",
+            value_column: "mean",
+            indicator_column: "indicator",
+            indicator_value: "2",
+            name: "ART coverage",
+            error_low_column: "low",
+            error_high_column: "high"
+        },
+        {
+            indicator: "prevalence",
+            value_column: "mean",
+            indicator_column: "indicator",
+            indicator_value: "3",
+            name: "Prevalence",
+            error_low_column: "low",
+            error_high_column: "high"
+        }
+    ],
+    selections: {
+        indicatorId: "art_cov",
+        xAxisId: "region",
+        disaggregateById: "age",
+        selectedFilterOptions: {
+            region: [{id: "1", label: "Northern"}],
+            age: [{id: "0:4", label: "0-4"}],
+            sex: [{id: "female", label: "female"}]
+        }
+    },
+    formatFunction,
+    xAxisConfig: {fixed: false, hideFilter: false},
+    disaggregateByConfig: { fixed: false, hideFilter: false }
+} as any;
+
+const uninitializedSelections = {
+    indicatorId: "",
+    xAxisId: "",
+    disaggregateById: "",
+    selectedFilterOptions: {}
+};
+
+const getWrapper = () => {
+    return shallowMount(BarChartWithFilters, {props: propsData});
+};
+
+const confirmFormGroup = (wrapper: any, elementId: string, label: string) => {
+    const fg = wrapper.find(elementId);
+    expect(fg.find("label").text()).toBe(label);
+    expect(fg.findAll("hint-tree-select-stub").length).toBe(1);
+};
+
+describe("Barchart component", () => {
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find("h3").text()).toBe("Filters");
+
+        confirmFormGroup(wrapper, "#indicator-fg", "Indicator");
+        confirmFormGroup(wrapper, "#x-axis-fg", "X Axis");
+        confirmFormGroup(wrapper, "#disagg-fg", "Disaggregate by");
+
+        const region = wrapper.find("#filter-region filter-select-stub");
+        expect(region.attributes("label")).toBe("Region");
+        expect(region.attributes("isxaxis")).toBe("true");
+        expect(region.attributes("isdisaggregateby")).toBe("false");
+
+        const age = wrapper.find("#filter-age filter-select-stub");
+        expect(age.attributes("label")).toBe("Age group");
+        expect(age.attributes("isxaxis")).toBe("false");
+        expect(age.attributes("isdisaggregateby")).toBe("true");
+
+        const chart = wrapper.find("#chart bar-chart-with-errors-stub");
+        expect(chart.attributes("xlabel")).toBe("Region");
+        expect(chart.attributes("ylabel")).toBe("ART coverage");
+        expect(chart.attributes("style")).toBe("width: 100%; height: 100%;");
+
+        const xAxis = wrapper.find("#x-axis-fg");
+        expect(xAxis.find("label").text()).toBe("X Axis");
+        expect(xAxis.find("hint-tree-select-stub").attributes("modelvalue")).toBe("region");
+
+        const disagg = wrapper.find("#disagg-fg");
+        expect(disagg.find("label").text()).toBe("Disaggregate by");
+        expect(disagg.find("hint-tree-select-stub").attributes("modelvalue")).toBe("age");
+    });
+
+    it("computes x axis label", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.xAxisLabel;
+        expect(result).toBe("Region");
+
+    });
+
+    it("computes x axis labels", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.xAxisLabels;
+        expect(result).toStrictEqual(["Northern"]);
+    });
+
+    it("computes x axis values", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.xAxisValues;
+        expect(result).toStrictEqual(["1"]);
+    });
+
+    it("computes bar label lookup", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.barLabelLookup;
+        expect(result).toStrictEqual({"0:4": "0-4"});
+    });
+
+    it("computes x axis label lookup", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.xAxisLabelLookup;
+        expect(result).toStrictEqual({"1": "Northern"});
+    });
+
+    it("computes disaggregate as options", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.filterDisaggregateOptions
+        expect(result).toStrictEqual([
+            {id: "region", label: "Region"},
+            {id: "age", label: "Age group"},
+            {id: "sex", label: "Sex"}
+        ]);
+    });
+
+    it("computes xaxis as options", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.filterXaxisOptions
+        expect(result).toStrictEqual([
+            {id: "region", label: "Region"},
+            {id: "age", label: "Age group"},
+            {id: "sex", label: "Sex"}
+        ]);
+    });
+
+    it("computes filter disaggregate options when xaxis is fixed", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                xAxisConfig: {fixed: true, hideFilter: false}
+            },
+        });
+        const vm = (wrapper as any).vm;
+
+        const result = vm.filterDisaggregateOptions
+        expect(result).toStrictEqual([
+            {id: "age", label: "Age group"},
+            {id: "sex", label: "Sex"}
+        ]);
+    });
+
+    it("computes filter Xaxis options when disaggregate is fixed", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                disaggregateByConfig: {fixed: true, hideFilter: false}
+            },
+        });
+        const vm = (wrapper as any).vm;
+
+        const result = vm.filterXaxisOptions
+        expect(result).toStrictEqual([
+            {id: "region", label: "Region"},
+            {id: "sex", label: "Sex"}
+        ]);
+    });
+
+
+    it("computes indicator", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.indicator;
+        expect(result).toStrictEqual(propsData.indicators[0]);
+    });
+
+    it("computed processedData", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const result = vm.processedOutputData;
+        expect(result).toStrictEqual({
+            labels: ["Northern"],
+            datasets: [
+                {
+                    label: "0-4",
+                    backgroundColor: "#e41a1c",
+                    data: [0.40],
+                    errorBars: {"Northern": {plus: 0.43, minus: 0.38}}
+                }
+            ],
+            maxValuePlusError: 0.43
+        });
+    });
+
+    it("computes formatValueFunction and renders on BarChartWithErrors", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        const formatValueFunction = vm.formatValueFunction;
+        expect(formatValueFunction(99)).toBe("Value: 99, Indicator: art_cov");
+
+        expect(wrapper.findComponent(BarChartWithErrors).props().yFormat).toBe(formatValueFunction);
+    });
+
+    it("computes initialised", () => {
+        let wrapper = getWrapper();
+        let vm = (wrapper as any).vm;
+        expect(vm.initialised).toBe(true);
+
+        const props = {
+            ...propsData,
+            selections: uninitializedSelections
+        };
+        wrapper = shallowMount(BarChartWithFilters, {props: props});
+        vm = (wrapper as any).vm;
+        expect(vm.initialised).toBe(false);
+    });
+
+    it("does not render controls when not initialised", () => {
+        const props = {
+            ...propsData,
+            selections: uninitializedSelections
+        };
+        const wrapper = shallowMount(BarChartWithFilters, {props: props});
+
+        expect(wrapper.findAll(".form-group").length).toBe(0);
+        expect(wrapper.findAll("#chart").length).toBe(0);
+    });
+
+    it("initialises selections on create", async () => {
+        const props = {
+            ...propsData,
+            selections: uninitializedSelections
+        };
+        const wrapper = shallowMount(BarChartWithFilters, {props: props});
+
+        await nextTick();
+        expect(wrapper.emitted("update:selections")!.length).toBe(4);
+
+        const emptySelection = {
+            disaggregateById: "",
+            indicatorId: "",
+            xAxisId: "",
+            selectedFilterOptions: {}
+        };
+
+        expect(wrapper.emitted("update:selections")![0][0]).toStrictEqual({...emptySelection, indicatorId: "art_cov"});
+        expect(wrapper.emitted("update:selections")![1][0]).toStrictEqual({...emptySelection, xAxisId: "region"});
+        expect(wrapper.emitted("update:selections")![2][0]).toStrictEqual({...emptySelection, disaggregateById: "age"});
+        expect(wrapper.emitted("update:selections")![3][0]).toStrictEqual({
+            ...emptySelection,
+            selectedFilterOptions: {
+                region: [{id: "1", label: "Northern"}],
+                age: [{id: "0:4", label: "0-4"}],
+                sex: [{id: "female", label: "female"}]
+            }
+        });
+    });
+
+    it("normalizeIndicators returns expected result", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        const result = vm.normalizeIndicators(propsData.indicators[0]);
+        expect(result).toStrictEqual({id: "art_cov", label: "ART coverage"});
+    });
+
+    it("setting indicatorId emits changed-selections event with new data", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.indicatorId = "newIndicatorId";
+
+        expect(wrapper.emitted("update:selections")!.length).toBe(1);
+        const expected = {indicatorId: "newIndicatorId"};
+        expect(wrapper.emitted("update:selections")![0][0]).toStrictEqual({...propsData.selections, ...expected});
+    });
+
+    it("csetting xAxisId emits update event with new data", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.xAxisId = "newXAxisId";
+
+        expect(wrapper.emitted("update:selections")!.length).toBe(1);
+        const expected = {xAxisId: "newXAxisId"};
+        expect(wrapper.emitted("update:selections")![0][0]).toStrictEqual({...propsData.selections, ...expected});
+    });
+
+    it("setting disaggregateById emits update event with new data", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.disaggregateById = "newDisaggById";
+
+        expect(wrapper.emitted("update:selections")!.length).toBe(1);
+        const expected = {disaggregateById: "newDisaggById"};
+        expect(wrapper.emitted("update:selections")![0][0]).toStrictEqual({...propsData.selections, ...expected});
+    });
+
+    it("changeFilter emits update event with new data", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.changeFilter("age", [{id: "newAgeId", label: "newAgeLabel"}]);
+
+        expect(wrapper.emitted("update:selections")!.length).toBe(1);
+
+        const expectedSelectedFilterOptions = {
+            ...propsData.selections.selectedFilterOptions,
+            age: [{id: "newAgeId", label: "newAgeLabel"}]
+        };
+
+        const expected = {...propsData.selections, selectedFilterOptions: expectedSelectedFilterOptions};
+        expect(wrapper.emitted("update:selections")![0][0]).toStrictEqual(expected);
+    });
+
+    it("hides x axis controls when x axis should be fixed", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                xAxisConfig: {fixed: true, hideFilter: false}
+            },
+        });
+
+        expect(wrapper.find("#x-axis-fg").exists()).toBe(false);
+        expect(wrapper.find("#disagg-fg").exists()).toBe(true);
+    });
+
+    it("hides disaggregated by controls when disaggregated by should be fixed", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                disaggregateByConfig: {fixed: true, hideFilter: false}
+            },
+        });
+
+        expect(wrapper.find("#x-axis-fg").exists()).toBe(true);
+        expect(wrapper.find("#disagg-fg").exists()).toBe(false);
+    });
+
+    it("can hide x axis filter", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                xAxisConfig: {fixed: true, hideFilter: true}
+            },
+        });
+        expect(wrapper.find("#filter-region").exists()).toBe(false);
+        expect(wrapper.find("#filter-age").exists()).toBe(true);
+    });
+
+    it("can hide disaggregated by filter", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                disaggregateByConfig: {fixed: true, hideFilter: true}
+            },
+        });
+        expect(wrapper.find("#filter-region").exists()).toBe(true);
+        expect(wrapper.find("#filter-age").exists()).toBe(false);
+    });
+
+    it("defaults all axis config to false when props are null", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                xAxisConfig: null,
+                disaggregateByConfig: null
+            },
+        });
+        expect(wrapper.find("#x-axis-fg").exists()).toBe(true);
+        expect(wrapper.find("#disagg-fg").exists()).toBe(true);
+        expect(wrapper.find("#filter-region").exists()).toBe(true);
+        expect(wrapper.find("#filter-age").exists()).toBe(true);
+    });
+
+    it("hides Filters header when all filters are hidden", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                filterConfig: {
+                    filters: [
+                        filters[0],
+                        filters[1]
+                    ]
+                },
+                xAxisConfig: {fixed: true, hideFilter: true},
+                disaggregateByConfig: {fixed: true, hideFilter: true}
+            },
+        });
+        expect(wrapper.find("h3").exists()).toBe(false);
+    });
+
+    it("does not hide Filters header when not all filters are hidden", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                xAxisConfig: {fixed: true, hideFilter: true},
+                disaggregateByConfig: {fixed: true, hideFilter: true}
+            },
+        });
+        expect(wrapper.find("h3").text()).toBe("Filters");
+    });
+
+    it("renders warning message when no data exist for current combination of filters", () => {
+        const noDataMessage = "No data are available for the selected combination. Please review the combination of filter values selected."
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                selections: {
+                    ...propsData.selections,
+                    selectedFilterOptions: {
+                        region: [{id: "1", label: "Northern"}],
+                        age: [{id: "0:4", label: "0-4"}],
+                        sex: []
+                    }
+                },
+                noDataMessage
+            },
+        });
+        expect(wrapper.find("#noDataMessage").text()).toBe(noDataMessage);
+    });
+
+    it("does not render warning message when prop given but data exist for current combination of filters", () => {
+        const noDataMessage = "No data are available for the selected combination. Please review the combination of filter values selected."
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                noDataMessage
+            },
+        });
+        expect(wrapper.find("#noDataMessage").exists()).toBe(false);
+    });
+
+    it("does not render warning message when no data exist for current combination of filters but prop not given", () => {
+        const wrapper = shallowMount(BarChartWithFilters, {
+            props: {
+                ...propsData,
+                selections: {
+                    ...propsData.selections,
+                    selectedFilterOptions: {
+                        region: [{id: "1", label: "Northern"}],
+                        age: [{id: "0:4", label: "0-4"}],
+                        sex: []
+                    }
+                }
+            },
+        });
+        expect(wrapper.find("#noDataMessage").exists()).toBe(false);
+    });
+});

--- a/src/app/static/src/app/vue-chart/tests/bar/filterSelect.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/filterSelect.test.ts
@@ -1,0 +1,133 @@
+import { nextTick } from "vue";
+import FilterSelect from "../../src/bar/FilterSelect.vue";
+import {shallowMount} from "@vue/test-utils";
+
+const defaultProps = () => {
+    return {
+        id: "test",
+        options: [{id: "fo1", label: "option 1"}, {id: "fo2", label: "option 2"}],
+        isXAxis: true,
+        isDisaggregateBy: false,
+        value: [{id: "fo2", label: "option 2"}],
+        label: "Test Filter"
+    }
+};
+
+const getWrapper = (props: any = {}) => {
+    return shallowMount(FilterSelect, {props: {...defaultProps(), ...props}});
+};
+
+describe("FilterSelect component", () => {
+    it("renders as expected", () => {
+        const  wrapper = getWrapper();
+
+        const label = wrapper.find("label");
+        expect(label.text()).toBe("Test Filter");
+
+        const treeSelect = wrapper.find("hint-tree-select-stub");
+        expect(treeSelect.attributes("instanceid")).toBe("test");
+        expect(treeSelect.attributes("multiple")).toBe("true");
+        expect(treeSelect.attributes("flat")).toBe("true");
+
+        const badge = wrapper.find("span");
+        expect(badge.text()).toBe("x axis");
+    });
+
+    it("initialises selected", () => {
+        const  wrapper = getWrapper({value: [{id: "fo1", label: "option 1"}, {id: "fo2", label: "option 2"}]});
+        const vm = (wrapper as any).vm;
+
+        expect(vm.selected).toStrictEqual([{id: "fo1", label: "option 1"}, {id: "fo2", label: "option 2"}]);
+    });
+
+    it("initialises selected when not xAxis or disAgg", () => {
+        const  wrapper = getWrapper({
+                isXAxis: false,
+                value: [{id: "fo1", label: "option 1"}, {id: "fo2", label: "option 2"}]
+        });
+        const vm = (wrapper as any).vm;
+
+        expect(vm.selected).toStrictEqual([{id: "fo1", label: "option 1"}]);
+    });
+
+    it("emits input event on select when isXAxisOrDisAgg", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        vm.select({id: "fo1", label: "option 1"});
+        expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([
+            {id: "fo2", label: "option 2"}, {id: "fo1", label: "option 1"}]);
+    });
+
+    it("emits input event on select when not isXAxisOrDisAgg", () => {
+        const wrapper = getWrapper({isXAxis: false, isDisaggregateBy: false});
+        const vm = (wrapper as any).vm;
+
+        vm.select({id: "fo1", label: "option 1"});
+        expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "fo1", label: "option 1"}]);
+    });
+
+    it("emits input event on deselect", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+
+        vm.deselect({id: "fo2", label: "option 2"});
+        expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([]);
+    });
+
+    it("computes isXAxisOrDisagg", () => {
+        let wrapper = getWrapper();
+        let vm = (wrapper as any).vm;
+        expect(vm.isXAxisOrDisagg).toEqual(true);
+
+        wrapper = getWrapper({isXAxis: false, isDisaggregateBy: true});
+        vm = (wrapper as any).vm;
+        expect(vm.isXAxisOrDisagg).toEqual(true);
+
+        wrapper = getWrapper({isXAxis: false, isDisaggregateBy: false});
+        vm = (wrapper as any).vm;
+        expect(vm.isXAxisOrDisagg).toEqual(false);
+    });
+
+    it("computes selectedValues", () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        expect(vm.selectedValues).toStrictEqual(["fo2"]);
+    });
+
+    it("computes badge", () => {
+        let wrapper = getWrapper();
+        let vm = (wrapper as any).vm;
+        expect(vm.badge).toEqual("x axis");
+
+        wrapper = getWrapper({isXAxis: false, isDisaggregateBy: true});
+        vm = (wrapper as any).vm;
+        expect(vm.badge).toEqual("disaggregate by");
+
+        wrapper = getWrapper({isXAxis: true, isDisaggregateBy: true});
+        vm = (wrapper as any).vm;
+        expect(vm.badge).toEqual("x axis");
+    });
+
+    it("updates selected when isXAxisOrDisagg changes and multiple selected", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.selected =  [{id: "fo2", label: "option 2"}, {id: "fo1", label: "option 1"}];
+        await nextTick();
+
+        await wrapper.setProps({isXAxis: false, isDisaggregateBy: false});
+
+        expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "fo2", label: "option 2"}]);
+    });
+
+    it("updates selected when isXAxisOrDisagg changes and none selected", async () => {
+        const wrapper = getWrapper();
+        const vm = (wrapper as any).vm;
+        vm.deselect({id: "fo2", label: "option 2"});
+        await nextTick();
+
+        await wrapper.setProps({isXAxis: false, isDisaggregateBy: false});
+
+        expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "fo1", label: "option 1"}]);
+    });
+});

--- a/src/app/static/src/app/vue-chart/tests/bar/utils.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/utils.test.ts
@@ -1,0 +1,129 @@
+import {getProcessedOutputData, toFilterLabelLookup} from "../../src/bar/utils";
+
+export const data = [
+    {area_id: 1, age_group: '0:4', sex: 'female', indicator: 2, mean: 0.40, high: 0.43, low: 0.38},
+    {area_id: 1, age_group: '5:9', sex: 'female', indicator: 2, mean: 0.20, high: 0.24, low: 0.16},
+    {area_id: 1, age_group: '0:4', sex: 'male', indicator: 2, mean: 0.35, high: 0.40, low: 0.34},
+    {area_id: 1, age_group: '5:9', sex: 'male', indicator: 2, mean: 0.25, high: 0.28, low: 0.21},
+    {area_id: 1, age_group: '0:4', sex: 'female', indicator: 3, mean: 0.20, high: 0.22, low: 0.18},
+    {area_id: 1, age_group: '5:9', sex: 'female', indicator: 3, mean: 0.10, high: 0.14, low: 0.06},
+    {area_id: 1, age_group: '0:4', sex: 'male', indicator: 3, mean: 0.25, high: 0.30, low: 0.21},
+    {area_id: 1, age_group: '5:9', sex: 'male', indicator: 3, mean: 0.15, high: 0.2, low: 0.13},
+    {area_id: 2, age_group: '0:4', sex: 'female', indicator: 2, mean: 0.50, high: 0.53, low: 0.48},
+    {area_id: 2, age_group: '5:9', sex: 'female', indicator: 2, mean: 0.25, high: 0.29, low: 0.21},
+];
+
+export const filters = [
+    {
+        id: "region",
+        column_id: "area_id",
+        label: "Region",
+        options: [
+            {id: "1", label: "Northern"},
+            {id: "2", label: "Central"}
+        ]
+    },
+    {
+        id: "age",
+        column_id: "age_group",
+        label: "Age group",
+        options: [
+            {id: "0:4", label: "0-4"},
+            {id: "5:9", label: "5-9"}
+        ]
+    },
+    {
+        id: "sex",
+        column_id: "sex",
+        label: "Sex",
+        options: [
+            {id: "female", label: "female"},
+            {id: "both", label: "both"},
+            {id: "male", label: "male"}
+        ]
+    }
+];
+
+describe("Barchart utils", () => {
+
+    const xAxis = "age";
+    const disAggBy = "sex";
+    const indicator = {
+        indicator: "art_cov",
+        value_column: "mean",
+        indicator_column: "indicator",
+        indicator_value: "2",
+        name: "ART coverage",
+        error_low_column: "low",
+        error_high_column: "high",
+        format: "0.00",
+        scale: 1,
+        accuracy: null
+    };
+
+    const selectedFilterValues = {
+        region: [{id: "1", label: "Northern"}],
+        age: [{id: "5:9", label: "5-9"}],
+        sex: [{id: "female", label: "female"}, {id: "male", label: "male"}],
+    };
+
+    const barLabelLookup = {female: "female", male: "male"};
+    const xAxisLabelLookup = {"0:4": "0-4", "5:9": "5-9"};
+    const xAxisLabels = ["5-9"];
+    const xAxisValues = ["5:9"];
+
+    it("gets processed output data", () => {
+
+        const result = getProcessedOutputData(data, xAxis, disAggBy, indicator, filters, selectedFilterValues,
+            barLabelLookup, xAxisLabelLookup, xAxisLabels, xAxisValues);
+
+        expect(result).toStrictEqual({
+            labels: ["5-9"],
+            datasets: [
+                {
+                    label: "female",
+                    backgroundColor: "#e41a1c",
+                    data: [0.20],
+                    errorBars: {"5-9": {plus: 0.24, minus: 0.16}}
+                },
+                {
+                    label: "male",
+                    backgroundColor: "#377eb8",
+                    data: [0.25],
+                    errorBars: {"5-9": {plus: 0.28, minus: 0.21}}
+                }
+            ],
+            maxValuePlusError: 0.28
+        });
+
+    });
+
+    it("omits rows with null or undefined values", () => {
+
+        const data = [
+            {area_id: 1, age_group: '5:9', sex: 'female', indicator: 2, high: 0.43, low: 0.38},
+            {area_id: 1, age_group: '5:9', sex: 'female', indicator: 2, mean: null, high: 0.24, low: 0.16}];
+
+        const result = getProcessedOutputData(data, xAxis, disAggBy, indicator, filters, selectedFilterValues,
+            barLabelLookup, xAxisLabelLookup, xAxisLabels, xAxisValues);
+
+        expect(result).toStrictEqual({
+            labels: ["5-9"],
+            datasets: [{
+                "backgroundColor": "#e41a1c",
+                "data": [],
+                "errorBars": {},
+                "label": "female",
+            }],
+            maxValuePlusError: 0
+        });
+    });
+
+    it("toFilterLabelLookup converts array", () => {
+        const result = toFilterLabelLookup([
+            {id: "id1", label: "label1"},
+            {id: "id2", label: "label2"}
+        ]);
+        expect(result).toStrictEqual({id1: "label1", id2: "label2"});
+    });
+});

--- a/src/app/static/src/tests/components/genericChart/genericChart.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChart.test.ts
@@ -207,7 +207,6 @@ describe("GenericChart component", () => {
 
         const wrapper = getWrapper();
         setTimeout(() => {
-            console.log(wrapper.html())
             expect(wrapper.findAllComponents(DataSource).length).toBe(0);
             expect(wrapper.findAllComponents(FiltersComp).length).toBe(0);
             expect(wrapper.findComponent(Plotly).exists()).toBe(false);
@@ -459,7 +458,6 @@ describe("GenericChart component", () => {
 
         setTimeout(() => {
             const dataset1Filters = wrapper.findAllComponents(FiltersComp)[0];
-            console.log(dataset1Filters.html())
             const newFilterSelections = {
                 age: [{id: "2", label: "2"}],
                 year: [{id: "2020", label: "2020"}]


### PR DESCRIPTION
## Description
This PR aims to add error bars back into Hint. Unfortunately, there is no vue 3 version of chart js error bars plugin so I am using the annotation plugin to draw the 3 lines for an error bar (the two horizontal lines and one vertical line). I have also included tests for the vue-charts folder. It makes sense to leave these components in Hint because Hint is the only thing that uses vue-charts.

As a side note, you can click the legend to hide bars in chart js and the production version of hint actually doesn't work with this feature (you can try it out on the production version, the error bars go weird)
