### PR TITLE
mrc-4620: Fix download indicator button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ and [hintr](https://github.com/mrc-ide/hintr) and add a test user with username 
 1. Run `npm run build` from `src/app/static` to compile front-end dependencies.
 1. Run app from your IDE or by `./src/gradlew -p src :app:bootRun` to serve the app on port 8080
 
+To run with hot reloading of the front end, after installing npm packages and running development dependencies.
+1. Open a terminal at `src/app/static` and run `npm run serve`
+1. In another terminal, from the root run `src/gradlew -PhotReload=true -p src app:bootRun`
+
 For more information about developing the front-end see [src/app/static/README](https://github.com/mrc-ide/hint/blob/master/src/app/static/README.md)
 
 For more information on Generic Chart, see [/docs/GenericChart.md](https://github.com/mrc-ide/hint/blob/mrc-2537/docs/GenericChart.md)

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -3532,9 +3532,9 @@
       },
       "dependencies": {
         "@vue/vue-loader-v15": {
-          "version": "npm:vue-loader@15.10.1",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
-          "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+          "version": "npm:vue-loader@15.10.2",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.2.tgz",
+          "integrity": "sha512-ndeSe/8KQc/nlA7TJ+OBhv2qalmj1s+uBs7yHDRFaAXscFTApBzY9F1jES3bautmgWjDlDct0fw8rPuySDLwxw==",
           "dev": true,
           "requires": {
             "@vue/component-compiler-utils": "^3.1.0",
@@ -3548,6 +3548,12 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
               "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+              "dev": true
+            },
+            "vue-hot-reload-api": {
+              "version": "2.3.4",
+              "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+              "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
               "dev": true
             }
           }
@@ -12957,6 +12963,11 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jsonata": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
+      "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA=="
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -18830,12 +18841,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vue-feather/-/vue-feather-2.0.0.tgz",
       "integrity": "sha512-GBvxJWu2ycGTpB8duYWnc5S/TwWPPb2G5Ft2NbkwK1vZkUDUOTYqIb4Nh1HOL6A37Isfrd0Guun0lesS97PfxA==",
-      "dev": true
-    },
-    "vue-hot-reload-api": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
-      "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
     "vue-loader": {

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -115,6 +115,7 @@
     "chartjs-plugin-annotation": "^3.0.1",
     "core-js": "^3.29.0",
     "feather-icons": "^4.29.0",
+    "jsonata": "^1.8.6",
     "node-sass": "^8.0.0",
     "plotly.js-basic-dist": "^2.4.0",
     "vue": "^3.2.47",

--- a/src/app/static/src/app/components/downloadIndicator/DownloadIndicator.vue
+++ b/src/app/static/src/app/components/downloadIndicator/DownloadIndicator.vue
@@ -3,7 +3,7 @@
         <download-button
             :name="'downloadIndicator'"
             :disabled="downloadingIndicator"
-            @trigger-download="download"></download-button>
+            @click="download"></download-button>
     </div>
 </template>
 

--- a/src/app/static/src/tests/components/downloadIndicator/downloadIndicator.test.ts
+++ b/src/app/static/src/tests/components/downloadIndicator/downloadIndicator.test.ts
@@ -71,11 +71,10 @@ describe("download indicator", () => {
 
     it('can trigger download with iso3 country prefix in filename', async() => {
         const wrapper = getWrapper();
-        const downloadButton = wrapper.findComponent(DownloadButton);
-        const button = downloadButton.find("button");
+        const button = wrapper.find("#indicator-download").find("button");
         expect(button.element.disabled).toBe(false);
-        downloadButton.vm.$emit("trigger-download");
-        expect(mockDownloadFileActions).toHaveBeenCalledTimes(1)
+        await button.trigger("click")
+        await expect(mockDownloadFileActions).toHaveBeenCalledTimes(1)
 
         const filename = mockDownloadFileActions.mock.calls[0][1].filename
         expect(filename.split(".")[0]).toContain("MWI_naomi_data-review_")
@@ -86,10 +85,9 @@ describe("download indicator", () => {
 
     it('can use country prefix when iso3 data is empty', async() => {
         const wrapper = getWrapper(createSut({iso3: "", country: "Malawi"}));
-        const downloadButton = wrapper.findComponent(DownloadButton);
-        const button = downloadButton.find("button");
+        const button = wrapper.find("#indicator-download").find("button");
         expect(button.element.disabled).toBe(false);
-        downloadButton.vm.$emit("trigger-download");
+        await button.trigger("click")
         expect(mockDownloadFileActions).toHaveBeenCalledTimes(1)
 
         const filename = mockDownloadFileActions.mock.calls[0][1].filename


### PR DESCRIPTION
## Description

This PR will fix download indicator button so it actually triggers the download

Looks like this might have regressed because of some merge issue as version with a "click" which got merged in PR https://github.com/mrc-ide/hint/pull/832/files#diff-8a738f358069431b5f882d9eaf4de4af15e4f2b4acb3ce74520b88f0c2385005L6 has changed to "trigger-download" so wonder if some merge timing screwed this up. Either way this should be fixed now.

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
