### PR TITLE
Display calibration options in rehydrated project

### DIFF
--- a/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
+++ b/src/app/static/src/app/components/modelCalibrate/ModelCalibrate.vue
@@ -1,6 +1,5 @@
 <template>
     <div id="model-options">
-        <!-- <div>sidojfaiosdfj</div> -->
         <div v-if="loading" class="text-center">
             <loading-spinner size="lg"></loading-spinner>
             <h2 id="loading-message" v-translate="'loadingOptions'"></h2>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.0.0";
+export const currentHintVersion = "3.0.1";

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -51,7 +51,7 @@ export const mutations: MutationTree<ModelCalibrateState> = {
     },
 
     [ModelCalibrateMutation.ModelCalibrateOptionsFetched](state: ModelCalibrateState, action: PayloadWithType<DynamicFormMeta>) {
-        const newForm = state.optionsFormMeta.controlSections.length
+        const newForm = state.optionsFormMeta.controlSections?.length
             ? {...updateForm(state.optionsFormMeta, action.payload)}
             : constructOptionsFormMetaFromData(state, action.payload)
         state.optionsFormMeta = newForm;

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -51,7 +51,7 @@ export const mutations: MutationTree<ModelCalibrateState> = {
     },
 
     [ModelCalibrateMutation.ModelCalibrateOptionsFetched](state: ModelCalibrateState, action: PayloadWithType<DynamicFormMeta>) {
-        const newForm = state.optionsFormMeta.controlSections?.length
+        const newForm = state.optionsFormMeta.controlSections.length
             ? {...updateForm(state.optionsFormMeta, action.payload)}
             : constructOptionsFormMetaFromData(state, action.payload)
         state.optionsFormMeta = newForm;

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -2,7 +2,7 @@ import {MutationTree} from 'vuex';
 import {ModelCalibrateState} from "./modelCalibrate";
 import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-next-dynamic-form";
 import {PayloadWithType} from "../../types";
-import {updateForm} from "../../utils";
+import {constructOptionsFormMetaFromData, updateForm} from "../../utils";
 import {
     CalibrateMetadataResponse,
     CalibrateResultResponse,
@@ -51,7 +51,9 @@ export const mutations: MutationTree<ModelCalibrateState> = {
     },
 
     [ModelCalibrateMutation.ModelCalibrateOptionsFetched](state: ModelCalibrateState, action: PayloadWithType<DynamicFormMeta>) {
-        const newForm = {...updateForm(state.optionsFormMeta, action.payload)};
+        const newForm = state.optionsFormMeta.controlSections.length
+            ? {...updateForm(state.optionsFormMeta, action.payload)}
+            : constructOptionsFormMetaFromData(state, action.payload)
         state.optionsFormMeta = newForm;
         state.fetching = false;
     },

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -23,7 +23,7 @@ import {RootState} from "./root";
 import {initialStepperState} from "./store/stepper/stepper";
 import {LoadState} from "./store/load/state";
 import {initialModelRunState} from "./store/modelRun/modelRun";
-import {initialModelCalibrateState} from "./store/modelCalibrate/modelCalibrate";
+import {initialModelCalibrateState, ModelCalibrateState} from "./store/modelCalibrate/modelCalibrate";
 import {AxiosResponse} from "axios";
 import { ComputedGetter } from 'vue';
 
@@ -528,7 +528,7 @@ export const constructRehydrateProjectState = async (context: ActionContext<Load
     return {files, savedState}
 }
 
-export const constructOptionsFormMetaFromData = (state: ModelOptionsState, meta: DynamicFormMeta): DynamicFormMeta => {
+export const constructOptionsFormMetaFromData = (state: ModelOptionsState | ModelCalibrateState, meta: DynamicFormMeta): DynamicFormMeta => {
     const stateContainsOptions = Object.keys(state.options).length > 0
     if (stateContainsOptions) {
         meta.controlSections.forEach(newSection => {

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -1,6 +1,11 @@
 import {expectAllMutationsDefined} from "../testHelpers";
 import {ModelCalibrateMutation, mutations} from "../../app/store/modelCalibrate/mutations";
-import {mockCalibrateResultResponse, mockError, mockModelCalibrateState, mockWarning,} from "../mocks";
+import {
+    mockCalibrateResultResponse,
+    mockError,
+    mockModelCalibrateState,
+    mockWarning,
+} from "../mocks";
 import {VersionInfo, ComparisonPlotResponse} from "../../app/generated";
 
 describe("ModelCalibrate mutations", () => {
@@ -135,6 +140,76 @@ describe("ModelCalibrate mutations", () => {
         const options = { "testOption": "testValue" };
         mutations[ModelCalibrateMutation.SetOptionsData](state, {payload: options});
         expect(state.options).toBe(options);
+    });
+
+    it("recovers selected calibrate options from state when reloading from model output", () => {
+        // In this scenario we have recovered calibration options from the state JSON in
+        // the uploaded model output but, we've not fetched the form data yet.
+        const options = {"spectrum_plhiv_calibration_level": "national"}
+        const state = mockModelCalibrateState({options: options});
+        const payload = {controlSections: [{
+            label: "Calibrate section",
+            controlGroups: [{
+                "label": "Adjust to spectrum PLHIV",
+                "controls": [{
+                    "name": "spectrum_plhiv_calibration_level",
+                    "type": "select",
+                    "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                    "value": "none"
+                }]
+            }]
+        }]};
+
+        mutations[ModelCalibrateMutation.ModelCalibrateOptionsFetched](state, {payload: payload});
+
+        const expected = {controlSections: [{
+                label: "Calibrate section",
+                controlGroups: [{
+                    "label": "Adjust to spectrum PLHIV",
+                    "controls": [{
+                        "name": "spectrum_plhiv_calibration_level",
+                        "type": "select",
+                        "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                        "value": "national"
+                    }]
+                }]
+            }]};
+        expect(state.optionsFormMeta).toStrictEqual(expected);
+    });
+
+    it("invalid option in state is still set when loading from output zip", () => {
+        // In this scenario we have recovered calibration options from the state JSON in
+        // the uploaded model output but, we've not fetched the form data yet.
+        const options = {"spectrum_plhiv_calibration_level": "unknown"}
+        const state = mockModelCalibrateState({options: options});
+        const payload = {controlSections: [{
+                label: "Calibrate section",
+                controlGroups: [{
+                    "label": "Adjust to spectrum PLHIV",
+                    "controls": [{
+                        "name": "spectrum_plhiv_calibration_level",
+                        "type": "select",
+                        "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                        "value": "none"
+                    }]
+                }]
+            }]};
+
+        mutations[ModelCalibrateMutation.ModelCalibrateOptionsFetched](state, {payload: payload});
+
+        const expected = {controlSections: [{
+                label: "Calibrate section",
+                controlGroups: [{
+                    "label": "Adjust to spectrum PLHIV",
+                    "controls": [{
+                        "name": "spectrum_plhiv_calibration_level",
+                        "type": "select",
+                        "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                        "value": "unknown"
+                    }]
+                }]
+            }]};
+        expect(state.optionsFormMeta).toStrictEqual(expected);
     });
 
     it("PollingForStatusStarted sets statusPollId", () => {

--- a/src/app/static/src/tests/modelCalibrate/mutations.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/mutations.test.ts
@@ -7,6 +7,7 @@ import {
     mockWarning,
 } from "../mocks";
 import {VersionInfo, ComparisonPlotResponse} from "../../app/generated";
+import {DynamicFormMeta} from "@reside-ic/vue-next-dynamic-form";
 
 describe("ModelCalibrate mutations", () => {
     afterEach(() => {
@@ -210,6 +211,41 @@ describe("ModelCalibrate mutations", () => {
                 }]
             }]};
         expect(state.optionsFormMeta).toStrictEqual(expected);
+    });
+
+    it("ModelCalibrateOptionsFetched preserves selected values when reloading", () => {
+        const optionsFormMeta = {controlSections: [{
+                label: "Calibrate section",
+                controlGroups: [{
+                    "label": "Adjust to spectrum PLHIV",
+                    "controls": [{
+                        "name": "spectrum_plhiv_calibration_level",
+                        "type": "select",
+                        "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                        "value": "national"
+                    }]
+                }]
+            }]};
+        const state = mockModelCalibrateState({fetching: true,
+            optionsFormMeta: optionsFormMeta as DynamicFormMeta});
+
+        const payload = {controlSections: [{
+                label: "Calibrate section",
+                controlGroups: [{
+                    "label": "Adjust to spectrum PLHIV",
+                    "controls": [{
+                        "name": "spectrum_plhiv_calibration_level",
+                        "type": "select",
+                        "options": [{"id": "none", "label": "None"}, {"id": "national", "label": "National"}],
+                        "value": "none"
+                    }]
+                }]
+            }]};
+
+
+        mutations[ModelCalibrateMutation.ModelCalibrateOptionsFetched](state, {payload});
+        expect(state.fetching).toBe(false);
+        expect(state.optionsFormMeta).toStrictEqual(optionsFormMeta);
     });
 
     it("PollingForStatusStarted sets statusPollId", () => {


### PR DESCRIPTION
## Description

This PR will fix issue reported where in a project rehydrated from model output zip the calibration options used where not shown. See ticket for how to recreate this.

Digging into this I think this was because when we have a rehydrated project this puts the `options` from the model calibration into the state before the `optionFormMeta` is retrieved. Then when we open the calibrate page, the app fetches the `optionFormMeta` which was then never being populated with the `options` which existed in the state. I've updated this so that if the `optionFormMeta` has no sections then populate it from the options, this is the same behaviour as the model options page uses.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
