### PR TITLE
Unpin version of JDK

### DIFF
--- a/buildkite/shared-build-env.dockerfile
+++ b/buildkite/shared-build-env.dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install wget
 RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
 RUN add-apt-repository --yes https://packages.adoptium.net/artifactory/deb/
 RUN apt-get update
-RUN apt-get install temurin-11-jdk=11.0.20.1.0+1 -y
+RUN apt-get install temurin-11-jdk -y
 
 # Setup gradle
 COPY ./src/gradlew /hint/src/


### PR DESCRIPTION
## Description

Creating a PR for this so we don't forget to unpin it, can be merged as soon as we see the install of temurin-11-jdk pass

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
