### PR TITLE
add indicator fetching for table data

### DIFF
--- a/src/app/static/src/app/components/outputTable/TableFilters.vue
+++ b/src/app/static/src/app/components/outputTable/TableFilters.vue
@@ -21,7 +21,6 @@ import { useStore } from "vuex";
 import { computed, defineComponent, onMounted } from "vue";
 import { RootState } from "../../root";
 import { Dict, DisplayFilter } from "../../types";
-import { PlottingSelectionsMutations } from "../../store/plottingSelections/mutations";
 import { TableSelections } from "../../store/plottingSelections/plottingSelections";
 import { CalibrateMetadataResponse, FilterOption } from "../../generated";
 import NewFilters from "./NewFilters.vue";
@@ -53,9 +52,9 @@ export default defineComponent({
             }) || [];
         });
         
-        const updateTableSelections = (payload: Partial<TableSelections>) => {
-            store.commit(
-                `plottingSelections/${PlottingSelectionsMutations.updateTableSelections}`,
+        const updateTableSelections = async (payload: Partial<TableSelections>) => {
+            await store.dispatch(
+                `plottingSelections/updateTableSelections`,
                 { payload }
             );
         };

--- a/src/app/static/src/app/store/modelOutput/actions.ts
+++ b/src/app/static/src/app/store/modelOutput/actions.ts
@@ -30,7 +30,7 @@ export const actions: ActionTree<ModelOutputState, DataExplorationState> & Model
                 currentIndicators.push(rootState.plottingSelections.outputChoropleth.indicatorId);
                 break;
             case ModelOutputTabs.Table:
-                // TODO: Add table selections here
+                currentIndicators.push(rootState.plottingSelections.table.indicator);
                 break;
             default:
                 break;

--- a/src/app/static/src/app/store/plottingSelections/actions.ts
+++ b/src/app/static/src/app/store/plottingSelections/actions.ts
@@ -2,7 +2,8 @@ import {ActionContext, ActionTree} from "vuex";
 import {PlottingSelectionsMutations} from "./mutations";
 import {
     BarchartSelections, BubblePlotSelections, ChoroplethSelections,
-    PlottingSelectionsState
+    PlottingSelectionsState,
+    TableSelections
 } from "./plottingSelections";
 import {PayloadWithType} from "../../types";
 import {DataExplorationState} from "../dataExploration/dataExploration";
@@ -11,6 +12,7 @@ export interface PlottingSelectionsActions {
     updateBarchartSelections: (store: ActionContext<PlottingSelectionsState, DataExplorationState>, payload: PayloadWithType<BarchartSelections>) => void
     updateChoroplethSelections: (store: ActionContext<PlottingSelectionsState, DataExplorationState>, payload: PayloadWithType<Partial<ChoroplethSelections>>) => void
     updateBubblePlotSelections: (store: ActionContext<PlottingSelectionsState, DataExplorationState>, payload: PayloadWithType<Partial<BubblePlotSelections>>) => void
+    updateTableSelections: (store: ActionContext<PlottingSelectionsState, DataExplorationState>, payload: PayloadWithType<Partial<TableSelections>>) => void
 }
 
 export const actions: ActionTree<PlottingSelectionsState, DataExplorationState> & PlottingSelectionsActions = {
@@ -36,5 +38,12 @@ export const actions: ActionTree<PlottingSelectionsState, DataExplorationState> 
         if (colourIndicatorId) await dispatch("modelCalibrate/getResultData", colourIndicatorId, {root:true});
         if (sizeIndicatorId) await dispatch("modelCalibrate/getResultData", sizeIndicatorId, {root:true});
         commit({type: PlottingSelectionsMutations.updateBubblePlotSelections, payload: payload.payload});
+    },
+
+    async updateTableSelections(context, payload) {
+        const {commit, dispatch} = context;
+        const indicatorId = payload.payload.indicator;
+        if (indicatorId) await dispatch("modelCalibrate/getResultData", indicatorId, {root:true});
+        commit({type: PlottingSelectionsMutations.updateTableSelections, payload: payload.payload});
     }
 };

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -110,6 +110,9 @@ function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGette
                     bubbleSizeScales: {
                         output: {test: "TEST OUTPUT BUBBLE SIZE SCALES"} as any
                     },
+                    table: {
+                        indicator: "TestIndicator"
+                    },
                     ...partialSelections
                 },
                 mutations: plottingSelectionMutations,

--- a/src/app/static/src/tests/components/outputTable/tableFilters.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableFilters.test.ts
@@ -1,8 +1,7 @@
-import { flushPromises, shallowMount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import TableFilters from "../../../app/components/outputTable/TableFilters.vue";
 import Vuex from "vuex";
 import { mockModelCalibrateState, mockPlottingSelections } from "../../mocks";
-import { PlottingSelectionsMutations } from "../../../app/store/plottingSelections/mutations";
 import { SingleSelect } from "@reside-ic/vue-nested-multiselect";
 import NewFilters from "../../../app/components/outputTable/NewFilters.vue";
 
@@ -23,8 +22,8 @@ describe("Output Table filters tests", () => {
             plottingSelections: {
                 namespaced: true,
                 state: mockPlottingSelections(),
-                mutations: {
-                    [PlottingSelectionsMutations.updateTableSelections]: mockUpdateTableSelections
+                actions: {
+                    updateTableSelections: mockUpdateTableSelections
                 }
             },
             modelCalibrate: {

--- a/src/app/static/src/tests/modelOutput/actions.test.ts
+++ b/src/app/static/src/tests/modelOutput/actions.test.ts
@@ -41,6 +41,13 @@ describe("ModelOutput actions", () => {
                     selectedFilterOptions: {
                         testFilter: []
                     }
+                },
+                table: {
+                    indicator: "table-indicator",
+                    preset: "test-preset",
+                    selectedFilterOptions: {
+                        testFilter: []
+                    }
                 }
             }),
         });
@@ -93,5 +100,18 @@ describe("ModelOutput actions", () => {
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
         expect(commit.mock.calls[0][0].payload).toBe(ModelOutputTabs.Map);
+
+        dispatch.mockReset();
+        commit.mockReset();
+
+        await actions.updateSelectedTab({commit, rootState, dispatch} as any, ModelOutputTabs.Table);
+
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
+        expect(dispatch.mock.calls[0][1]).toBe("table-indicator");
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
+        expect(commit.mock.calls[0][0].payload).toBe(ModelOutputTabs.Table);
     });
 });

--- a/src/app/static/src/tests/plottingSelections/actions.test.ts
+++ b/src/app/static/src/tests/plottingSelections/actions.test.ts
@@ -1,7 +1,7 @@
 import {actions} from "../../app/store/plottingSelections/actions";
 import {PlottingSelectionsMutations} from "../../app/store/plottingSelections/mutations";
 import {
-    BarchartSelections, BubblePlotSelections, ChoroplethSelections,
+    BarchartSelections, BubblePlotSelections, ChoroplethSelections, TableSelections,
 } from "../../app/store/plottingSelections/plottingSelections";
 
 describe("PlottingSelection actions", () => {
@@ -63,6 +63,42 @@ describe("PlottingSelection actions", () => {
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateOutputChoroplethSelections);
         expect(commit.mock.calls[0][0].payload).toBe(choroplethSelections);
+    });
+
+    it("updateTableSelection dispatches data action and commits mutation", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const tableSelections = {
+            indicator: "test-indicator",
+        } as Partial<TableSelections>;
+
+        await actions.updateTableSelections({commit, dispatch} as any, {payload: tableSelections} as any);
+
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
+        expect(dispatch.mock.calls[0][1]).toBe("test-indicator");
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateTableSelections);
+        expect(commit.mock.calls[0][0].payload).toBe(tableSelections);
+    });
+
+    it("updateTableSelection doesn't dispatch action if indicator not in update", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const tableSelections = {
+            selectedFilterOptions: {
+                testFilter: []
+            }
+        } as Partial<TableSelections>;
+
+        await actions.updateTableSelections({commit, dispatch} as any, {payload: tableSelections} as any);
+
+        expect(dispatch.mock.calls.length).toBe(0);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateTableSelections);
+        expect(commit.mock.calls[0][0].payload).toBe(tableSelections);
     });
 
     it("updateBubblePlotSelections dispatches data action and commits mutation", async () => {


### PR DESCRIPTION
## Description

This is a quick little PR to make sure we have the integration between table tab and indicator slicing. Currently if you go on the table display PR #894 and run it on your machine, it shows no data. I would like to merge this into master and then merge this into that PR so that you can see the data in the table again!

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
