### PR TITLE
Mrc 4744 Refactor table tab with id, label objects for column and row in preset metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hint 3.5.0
+
+* Add new table tab to Model Outputs page
+
 # hint 3.3.0
 
 * Keep user's language preference outside project state

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -225,14 +225,12 @@
             this.tabSelected(tab);
         },
         data: () => {
-            const tabs: (keyof Translations)[] = [ModelOutputTabs.Bar];
-
-            if (switches.tableTab) {
-                tabs.push(ModelOutputTabs.Table);
-            }
-
-            tabs.push(ModelOutputTabs.Map);
-            tabs.push(ModelOutputTabs.Comparison);
+            const tabs: (keyof Translations)[] = [
+                ModelOutputTabs.Bar,
+                ModelOutputTabs.Table,
+                ModelOutputTabs.Map,
+                ModelOutputTabs.Comparison
+            ];
 
             if (!inactiveFeatures.includes("BubblePlot")) {
                 tabs.push(ModelOutputTabs.Bubble);

--- a/src/app/static/src/app/components/outputTable/TableDisplay.vue
+++ b/src/app/static/src/app/components/outputTable/TableDisplay.vue
@@ -119,7 +119,7 @@ export default defineComponent({
         const columnDefs = computed(() => {
             if (!presets.value) return [];
             const currentPreset = presets.value.find(p => p.defaults.id === selections.value.preset)!;
-            const columnFilter = filters.value.find(f => f.column_id === currentPreset.defaults.column);
+            const columnFilter = filters.value.find(f => f.column_id === currentPreset.defaults.column.id);
             if (!columnFilter) return [];
             const columnSelections = selections.value.selectedFilterOptions[columnFilter.id];
             const columnHeaders = columnSelections.map(selection => {

--- a/src/app/static/src/app/components/outputTable/TableFilters.vue
+++ b/src/app/static/src/app/components/outputTable/TableFilters.vue
@@ -74,7 +74,7 @@ export default defineComponent({
 
         const getCurrentPresetColumnDefaults = (preset: Preset) => {
             const defaultSels = Object.fromEntries(filters.value.map(f => {
-                if (f.id === preset.defaults.column || f.id === preset.defaults.row) {
+                if (f.id === preset.defaults.column.id || f.id === preset.defaults.row.id) {
                     return [f.id, f.options]
                 }
                 return [f.id, [f.options[0]]]

--- a/src/app/static/src/app/components/outputTable/TableReshapeData.vue
+++ b/src/app/static/src/app/components/outputTable/TableReshapeData.vue
@@ -44,7 +44,7 @@ export default defineComponent({
             const data = props.data;
             if (presetMetadata.value && data) {
                 const tableData: any[] = [];
-                const rowKey = presetMetadata.value.row;
+                const rowKey = presetMetadata.value.row.id;
                 let rowOptions: FilterOption[] = [];
                 // If rows are per area, generate pseudo filter options from all features in shape data
                 if (rowKey === "area_id") {
@@ -56,7 +56,7 @@ export default defineComponent({
                 } else {
                     rowOptions = selections.value.selectedFilterOptions[filterDataIdtoId.value[rowKey]];
                 }
-                const columnKey = presetMetadata.value.column;
+                const columnKey = presetMetadata.value.column.id;
                 for (let i = 0; i < data.length; i++) {
                     const currentRow = data[i];
                     const rowVal = currentRow[rowKey];
@@ -80,9 +80,7 @@ export default defineComponent({
             return [];
         });
 
-        const tableLabelHeader = computed(() => {
-            return presetMetadata.value?.row === "age_group" ? "Age" : presetMetadata.value?.row === "area_id" ? "Area" : "";
-        });
+        const tableLabelHeader = computed(() => presetMetadata.value?.row.label || "");
 
         return {
             reshapedData,

--- a/src/app/static/src/app/featureSwitches.ts
+++ b/src/app/static/src/app/featureSwitches.ts
@@ -4,13 +4,11 @@ const modelCalibratePlot = !urlParams.get('modelCalibratePlot');
 const comparisonOutput = !urlParams.get('comparisonOutput');
 const agywDownload = !!urlParams.get('agywDownload');
 const loadJson = !!urlParams.get('loadJson');
-const tableTab = !!urlParams.get('tableTab')
 
 export const switches = {
     modelBugReport,
     modelCalibratePlot,
     comparisonOutput,
     agywDownload,
-    loadJson,
-    tableTab
+    loadJson
 };

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -201,8 +201,14 @@ export interface CalibrateMetadataResponse {
       defaults: {
         id: string;
         label: string;
-        column: string;
-        row: string;
+        column: {
+          id: string;
+          label: string;
+        };
+        row: {
+          id: string;
+          label: string;
+        };
         selected_filter_options?: {
           /**
            * This interface was referenced by `undefined`'s JSON-Schema definition
@@ -396,8 +402,14 @@ export interface CalibrateResultResponse {
       defaults: {
         id: string;
         label: string;
-        column: string;
-        row: string;
+        column: {
+          id: string;
+          label: string;
+        };
+        row: {
+          id: string;
+          label: string;
+        };
         selected_filter_options?: {
           /**
            * This interface was referenced by `undefined`'s JSON-Schema definition
@@ -812,6 +824,7 @@ export type InputTimeSeriesData = {
   time_period: string;
   quarter: string;
   area_hierarchy: string;
+  missing_ids?: string[] | null;
 }[];
 export interface InputTimeSeriesDefaults {
   selected_filter_options: {
@@ -861,6 +874,7 @@ export interface InputTimeSeriesResponse {
     time_period: string;
     quarter: string;
     area_hierarchy: string;
+    missing_ids?: string[] | null;
   }[];
   metadata: {
     columns: {
@@ -911,6 +925,7 @@ export interface InputTimeSeriesRow {
   time_period: string;
   quarter: string;
   area_hierarchy: string;
+  missing_ids?: string[] | null;
 }
 export type InputType = "pjnz" | "shape" | "population" | "survey" | "programme" | "anc";
 export interface LevelLabels {
@@ -1054,7 +1069,7 @@ export interface SelectControl {
   required: boolean;
   value?: string;
   helpText?: string;
-  options?: {
+  options: {
     id: string;
     label: string;
     children?: {
@@ -1069,7 +1084,7 @@ export interface MultiselectControl {
   required: boolean;
   value?: string[] | string;
   helpText?: string;
-  options?: {
+  options: {
     id: string;
     label: string;
     children?: {
@@ -1601,8 +1616,14 @@ export interface TablePreset {
 export interface TableDefaults {
   id: string;
   label: string;
-  column: string;
-  row: string;
+  column: {
+    id: string;
+    label: string;
+  };
+  row: {
+    id: string;
+    label: string;
+  };
   selected_filter_options?: {
     /**
      * This interface was referenced by `undefined`'s JSON-Schema definition

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.4.2";
+export const currentHintVersion = "3.5.0";

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -50,13 +50,13 @@ export const modelOutputGetters = {
         });
     },
     tableFilters: (state: ModelOutputState, getters: any, rootState: RootState, rootGetters: any): DisplayFilter[] => {
-        const outputFilters = outputPlotFilters(rootState, "table");
+        const outputFilters = outputPlotFilters(rootState, "table") as DisplayFilter[];
         const currentPresetMetadata = getPresetMetadata(rootState);
         if (currentPresetMetadata) {
             return outputFilters.map(f => {
                 return {
                     ...f,
-                    allowMultiple: f.column_id === currentPresetMetadata.defaults.row || f.column_id === currentPresetMetadata.defaults.column
+                    allowMultiple: f.column_id === currentPresetMetadata.defaults.row.id || f.column_id === currentPresetMetadata.defaults.column.id
                 }
             });
         } else {

--- a/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/components/modelOutput/modelOutput.test.ts
@@ -133,11 +133,6 @@ function getStore(modelOutputState: Partial<ModelOutputState> = {}, partialGette
 declare let currentUser: string;
 currentUser = "guest";
 
-// will be easy to just remove this once feature switch enabled
-jest.mock("../../../app/featureSwitches",() => {
-    return {switches: {tableTab: true}}
-});
-
 describe("ModelOutput component", () => {
     beforeAll(async () => {
         inactiveFeatures.splice(0, inactiveFeatures.length);

--- a/src/app/static/src/tests/components/outputTable/tableDisplay.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableDisplay.test.ts
@@ -87,7 +87,9 @@ describe("Output Table display table tests", () => {
                                 {
                                     defaults: {
                                         id: "preset1",
-                                        column: "sex",
+                                        column: {
+                                            id: "sex"
+                                        },
                                     } as any
                                 } as any
                             ]

--- a/src/app/static/src/tests/components/outputTable/tableFilters.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableFilters.test.ts
@@ -34,10 +34,16 @@ describe("Output Table filters tests", () => {
                             presets: [
                                 {
                                     defaults: {
-                                        column: "col",
+                                        column: {
+                                            id: "col",
+                                            label: "colLabel"
+                                        },
                                         id: "preset1",
                                         label: "Label",
-                                        row: "row"
+                                        row: {
+                                            id: "row",
+                                            label: "rowLabel"
+                                        }
                                     },
                                     filters: [{
                                         column_id: "filter_test_col",
@@ -48,10 +54,16 @@ describe("Output Table filters tests", () => {
                                 },
                                 {
                                     defaults: {
-                                        column: "col2",
+                                        column: {
+                                            id: "col2",
+                                            label: "colLabel2"
+                                        },
                                         id: "preset2",
                                         label: "Label2",
-                                        row: "row2",
+                                        row: {
+                                            id: "row2",
+                                            label: "rowLabel2"
+                                        },
                                         selected_filter_options: {
                                             id: ["op2"]
                                         }

--- a/src/app/static/src/tests/components/outputTable/tableReshapeData.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableReshapeData.test.ts
@@ -45,8 +45,14 @@ describe("Output Table display table tests", () => {
                             presets: [{
                                 defaults: {
                                     id: "preset1",
-                                    column: "col_filter",
-                                    row: rowId,
+                                    column: {
+                                        id: "col_filter",
+                                        label: "colLabel"
+                                    },
+                                    row: {
+                                        id: rowId,
+                                        label: rowId + "Label"
+                                    },
                                     label: "Cool Preset"
                                 },
                                 filters: mockFilters
@@ -183,12 +189,6 @@ describe("Output Table display table tests", () => {
 
     it("computes correct label", () => {
         const wrapper = getWrapper("row_filter");
-        expect(wrapper.findComponent(TableDisplay).props("headerName")).toBe("");
-
-        const wrapper1 = getWrapper("area_id");
-        expect(wrapper1.findComponent(TableDisplay).props("headerName")).toBe("Area");
-
-        const wrapper2 = getWrapper("age_group");
-        expect(wrapper2.findComponent(TableDisplay).props("headerName")).toBe("Age");
+        expect(wrapper.findComponent(TableDisplay).props("headerName")).toBe("row_filterLabel");
     });
 });

--- a/src/app/static/src/tests/modelOutput/modelOutput.test.ts
+++ b/src/app/static/src/tests/modelOutput/modelOutput.test.ts
@@ -56,9 +56,15 @@ describe("modelOutput module", () => {
             presets: [
                 {
                     defaults: {
-                        column: "age_group_id",
+                        column: {
+                            id: "age_group_id",
+                            label: "Age group"
+                        },
                         id: "preset_id",
-                        row: "quarter_id",
+                        row: {
+                            id: "quarter_id",
+                            label: "Quarter"
+                        },
                         label: "Preset ID"
                     },
                     filters

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-mrc-4673
+master


### PR DESCRIPTION
## Description

Note: still have to increment version number + news, should we do a bigger increment? like instead of 3.4.2 -> 3.4.3, should we do 3.4.2 -> 3.5.0? Table tab is fairly big.

This is officially the last PR for tables epic I think! Should be fairly quick to review, main things changed include:
* Hintr branch is now back to master
* Every place we were using `.column` or `.row` from the preset defaults we are now using `.column.id` and `.row.id` except for one place which is the `tableLabelHeader` computed value in `TableReshapeData` where we use the value
* Removed the feature switch for the table completely

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
