### PR TITLE
mrc 4748 add function to fetch first n indicators

### DIFF
--- a/src/app/static/src/app/store/modelOutput/actions.ts
+++ b/src/app/static/src/app/store/modelOutput/actions.ts
@@ -37,8 +37,7 @@ export const actions: ActionTree<ModelOutputState, DataExplorationState> & Model
         }
 
         currentIndicators.forEach(indicator => {
-            const payload = { indicatorId: indicator, tab };
-            dispatch("modelCalibrate/getResultData", payload, {root:true});
+            dispatch("modelCalibrate/getResultData", indicator, {root:true});
         });
         commit({type: ModelOutputMutation.TabSelected, payload: tab});
     },

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -11,9 +11,7 @@ const namespaced = true;
 
 export interface ModelOutputState {
     selectedTab: string,
-    loading: {
-        [k in ModelOutputTabs]: boolean
-    }
+    indicatorsBeingFetched: string[]
 }
 
 export const modelOutputGetters = {
@@ -114,13 +112,7 @@ const outputPlotFilters = (rootState: RootState, resultName: "metadata" | "compa
 export const initialModelOutputState = (): ModelOutputState => {
     return {
         selectedTab: "",
-        loading: {
-            [ModelOutputTabs.Map]: false,
-            [ModelOutputTabs.Bar]: false,
-            [ModelOutputTabs.Comparison]: false,
-            [ModelOutputTabs.Table]: false,
-            [ModelOutputTabs.Bubble]: false
-        }
+        indicatorsBeingFetched: []
     }
 };
 

--- a/src/app/static/src/app/store/modelOutput/mutations.ts
+++ b/src/app/static/src/app/store/modelOutput/mutations.ts
@@ -4,12 +4,8 @@ import {ModelOutputTabs, PayloadWithType} from "../../types";
 
 export enum ModelOutputMutation {
     TabSelected = "TabSelected",
-    SetTabLoading = "SetTabLoading"
-}
-
-type TabLoading = {
-    tab: ModelOutputTabs,
-    loading: boolean
+    AddIndicatorBeingFetched = "AddIndicatorBeingFetched",
+    RemoveIndicatorBeingFetched = "RemoveIndicatorBeingFetched",
 }
 
 export const mutations: MutationTree<ModelOutputState> = {
@@ -18,7 +14,15 @@ export const mutations: MutationTree<ModelOutputState> = {
         state.selectedTab = payload.payload;
     },
 
-    [ModelOutputMutation.SetTabLoading](state: ModelOutputState, payload: PayloadWithType<TabLoading>) {
-        state.loading[payload.payload.tab] = payload.payload.loading;
+    [ModelOutputMutation.AddIndicatorBeingFetched](state: ModelOutputState, payload: PayloadWithType<string>) {
+        if (!state.indicatorsBeingFetched.includes(payload.payload)) {
+            state.indicatorsBeingFetched.push(payload.payload);
+        }
+    },
+
+    [ModelOutputMutation.RemoveIndicatorBeingFetched](state: ModelOutputState, payload: PayloadWithType<string>) {
+        if (state.indicatorsBeingFetched.includes(payload.payload)) {
+            state.indicatorsBeingFetched = state.indicatorsBeingFetched.filter(indicator => indicator !== payload.payload);
+        }
     },
 };

--- a/src/app/static/src/app/store/plottingSelections/actions.ts
+++ b/src/app/static/src/app/store/plottingSelections/actions.ts
@@ -20,39 +20,30 @@ export const actions: ActionTree<PlottingSelectionsState, DataExplorationState> 
     async updateBarchartSelections(context, payload) {
         const {commit, dispatch} = context;
         const indicatorId = payload.payload.indicatorId;
-        const tab = ModelOutputTabs.Bar;
-        const resultDataPayload = { indicatorId, tab };
-        await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
         commit({type: PlottingSelectionsMutations.updateBarchartSelections, payload: payload.payload});
+        await dispatch("modelCalibrate/getResultData", indicatorId, {root:true});
     },
 
     async updateChoroplethSelections(context, payload) {
         const {commit, dispatch} = context;
         const indicatorId = payload.payload.indicatorId;
-        const tab = ModelOutputTabs.Map;
-        const resultDataPayload = { indicatorId, tab };
-        if (indicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
         commit({type: PlottingSelectionsMutations.updateOutputChoroplethSelections, payload: payload.payload});
+        if (indicatorId) await dispatch("modelCalibrate/getResultData", indicatorId, {root:true});
     },
 
     async updateBubblePlotSelections(context, payload) {
         const {commit, dispatch} = context;
         const colourIndicatorId = payload.payload.colorIndicatorId;
         const sizeIndicatorId = payload.payload.sizeIndicatorId;
-        const tab = ModelOutputTabs.Bubble;
-        const resultDataPayloadColor = { indicatorId: colourIndicatorId, tab };
-        const resultDataPayloadSize = { indicatorId: sizeIndicatorId, tab };
-        if (colourIndicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayloadColor, {root:true});
-        if (sizeIndicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayloadSize, {root:true});
         commit({type: PlottingSelectionsMutations.updateBubblePlotSelections, payload: payload.payload});
+        if (colourIndicatorId) await dispatch("modelCalibrate/getResultData", colourIndicatorId, {root:true});
+        if (sizeIndicatorId) await dispatch("modelCalibrate/getResultData", sizeIndicatorId, {root:true});
     },
 
     async updateTableSelections(context, payload) {
         const {commit, dispatch} = context;
         const indicatorId = payload.payload.indicator;
-        const tab = ModelOutputTabs.Table;
-        const resultDataPayload = { indicatorId, tab };
-        if (indicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
         commit({type: PlottingSelectionsMutations.updateTableSelections, payload: payload.payload});
+        if (indicatorId) await dispatch("modelCalibrate/getResultData", indicatorId, {root:true});
     }
 };

--- a/src/app/static/src/tests/modelOutput/actions.test.ts
+++ b/src/app/static/src/tests/modelOutput/actions.test.ts
@@ -56,7 +56,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bar, indicatorId: "barchart-indicator"});
+        expect(dispatch.mock.calls[0][1]).toBe("barchart-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -69,9 +69,9 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(2);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, indicatorId: "colour-indicator"});
+        expect(dispatch.mock.calls[0][1]).toBe("colour-indicator");
         expect(dispatch.mock.calls[1][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[1][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, indicatorId: "size-indicator"});
+        expect(dispatch.mock.calls[1][1]).toBe("size-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -95,7 +95,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Map, indicatorId: "choropleth-indicator"});
+        expect(dispatch.mock.calls[0][1]).toBe("choropleth-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -108,7 +108,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Table, indicatorId: "table-indicator"});
+        expect(dispatch.mock.calls[0][1]).toBe("table-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);

--- a/src/app/static/src/tests/modelOutput/mutations.test.ts
+++ b/src/app/static/src/tests/modelOutput/mutations.test.ts
@@ -9,23 +9,15 @@ describe("Model output mutations", () => {
         expect(testState.selectedTab).toBe(ModelOutputTabs.Map);
     });
 
-    it("sets tab loading", () => {
-        const testState = mockModelOutputState({
-            loading: {
-                map: false,
-                bar: false,
-                comparison: false,
-                bubble: false,
-                table: false
-            }
-        });
-        mutations[ModelOutputMutation.SetTabLoading](testState, {payload: {tab: ModelOutputTabs.Map, loading: true}});
-        expect(testState.loading).toStrictEqual({
-            map: true,
-            bar: false,
-            comparison: false,
-            bubble: false,
-            table: false
-        });
+    it("adds indicator being fetched", () => {
+        const testState = mockModelOutputState({indicatorsBeingFetched: ["indicator1"]});
+        mutations[ModelOutputMutation.AddIndicatorBeingFetched](testState, {payload: "indicator2"});
+        expect(testState.indicatorsBeingFetched).toStrictEqual(["indicator1", "indicator2"]);
+    });
+
+    it("removes indicator being fetched", () => {
+        const testState = mockModelOutputState({indicatorsBeingFetched: ["indicator1", "indicator2"]});
+        mutations[ModelOutputMutation.RemoveIndicatorBeingFetched](testState, {payload: "indicator2"});
+        expect(testState.indicatorsBeingFetched).toStrictEqual(["indicator1"]);
     });
 });

--- a/src/app/static/src/tests/plottingSelections/actions.test.ts
+++ b/src/app/static/src/tests/plottingSelections/actions.test.ts
@@ -3,7 +3,6 @@ import {PlottingSelectionsMutations} from "../../app/store/plottingSelections/mu
 import {
     BarchartSelections, BubblePlotSelections, ChoroplethSelections, TableSelections,
 } from "../../app/store/plottingSelections/plottingSelections";
-import { ModelOutputTabs } from "../../app/types";
 
 describe("PlottingSelection actions", () => {
 
@@ -23,7 +22,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Bar})
+        expect(dispatch.mock.calls[0][1]).toBe("test-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateBarchartSelections);
@@ -41,7 +40,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Map})
+        expect(dispatch.mock.calls[0][1]).toBe("test-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateOutputChoroplethSelections);
@@ -77,7 +76,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Table})
+        expect(dispatch.mock.calls[0][1]).toBe("test-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateTableSelections);
@@ -114,9 +113,9 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(2);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "colour-indicator", tab: ModelOutputTabs.Bubble})
+        expect(dispatch.mock.calls[0][1]).toBe("colour-indicator");
         expect(dispatch.mock.calls[1][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[1][1]).toStrictEqual({indicatorId: "size-indicator", tab: ModelOutputTabs.Bubble})
+        expect(dispatch.mock.calls[1][1]).toBe("size-indicator");
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateBubblePlotSelections);
@@ -151,7 +150,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "size-indicator", tab: ModelOutputTabs.Bubble})
+        expect(dispatch.mock.calls[0][1]).toBe("size-indicator");
 
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[1][0].type).toBe(PlottingSelectionsMutations.updateBubblePlotSelections);


### PR DESCRIPTION
## Description

Unfortunately, I think I took the wrong approach for showing the loading components per tab. I was focusing too much on per tab and realistically it should be based on the indicator we are fetching. So now there is just an array in state that tracks which indicators we are fetching and uses this to derive whether or not the loading component should show on the various tabs.

This way we can also prevent duplicate requests being sent for the same indicator. A down side of this is that we have to commit the indicator to state instantly and so behind the loading overlay, we will have a no data screen but hopefully that doesnt matter too much.

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
