### PR TITLE
fix projects page bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# hint 3.5.1
+
+* Fix bug where indicator loading would not end because call stack exceeded error in chrome
+* Fix bug where projects page would be very slow by removing tooltips
+
 # hint 3.5.0
 
 * Add new table tab to Model Outputs page

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -39,7 +39,7 @@
                         {{ p.name }}
                     </a>
                     <span class="float-right">
-                    <button v-if="projects.length <= 25" href="#" class="btn btn-sm btn-red-icons"
+                    <button v-if="showTooltip" href="#" class="btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('editProjectNote')"
                             @click.prevent="handleEditProjectNote(p.id)"
                             v-translate:aria-label="'editProjectNote'">
@@ -65,7 +65,7 @@
                     {{ format(p.versions[0].updated) }}
                 </div>
                 <div class="col-md-1 project-cell load-cell">
-                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                    <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('load')"
                             v-translate:aria-label="'load'"
                             @click="loadVersion($event, p.id, p.versions[0].id)">
@@ -78,7 +78,7 @@
                     </button>
                 </div>
                 <div class="col-md-1 project-cell rename-cell">
-                    <button v-if="projects.length <= 25" class="btn btn-sm btn-red-icons"
+                    <button v-if="showTooltip" class="btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('renameProject')"
                             v-translate:aria-label="'renameProject'"
                             @click="renameProject($event, p.id)">
@@ -91,7 +91,7 @@
                     </button>
                 </div>
                 <div class="col-md-1 project-cell delete-cell">
-                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                    <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('delete')"
                             v-translate:aria-label="'delete'"
                             @click="deleteProject($event, p.id)">
@@ -104,7 +104,7 @@
                     </button>
                 </div>
                 <div class="col-md-1 project-cell copy-cell">
-                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                    <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('copyLatestToNewProject')"
                             v-translate:aria-label="'copyLatestToNewProject'"
                             @click="promoteVersion(
@@ -138,7 +138,7 @@
                     <div class="col-md-1 version-cell"></div>
                     <div class="col-md-3 version-cell edit-cell">
                         <span class="float-right">
-                            <button v-if="projects.length <= 25" href="#" class="btn btn-sm btn-red-icons"
+                            <button v-if="showTooltip" href="#" class="btn btn-sm btn-red-icons"
                                     v-tooltip="getTranslatedValue('editVersionNote')"
                                     v-translate:aria-label="'editVersionNote'"
                                     @click.prevent="handleEditVersionNote(p.id, v.id, v.versionNumber)">
@@ -158,7 +158,7 @@
                         {{ format(v.updated) }}
                     </div>
                     <div class="col-md-1 version-cell load-cell">
-                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                        <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('load')"
                                 v-translate:aria-label="'load'"
                                 @click="loadVersion($event, p.id, v.id)">
@@ -173,7 +173,7 @@
                     <div class="col-md-1 version-cell">
                     </div>
                     <div class="col-md-1 version-cell delete-cell">
-                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                        <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('delete')"
                                 v-translate:aria-label="'delete'"
                                 @click="deleteVersion($event, p.id, v.id)">
@@ -186,7 +186,7 @@
                         </button>
                     </div>
                     <div class="col-md-1 version-cell copy-cell">
-                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
+                        <button v-if="showTooltip" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('copyToNewProject')"
                                 v-translate:aria-label="'copyToNewProject'"
                                 @click="promoteVersion(
@@ -415,7 +415,10 @@
             currentLanguage: mapStateProp<RootState, Language>(
                 null,
                 (state: RootState) => state.language
-            )
+            ),
+            showTooltip() {
+                return this.projects.length <= 25;
+            }
         },
         methods: {
             format(date: string) {

--- a/src/app/static/src/app/components/projects/ProjectHistory.vue
+++ b/src/app/static/src/app/components/projects/ProjectHistory.vue
@@ -39,8 +39,13 @@
                         {{ p.name }}
                     </a>
                     <span class="float-right">
-                    <button href="#" class="btn btn-sm btn-red-icons"
+                    <button v-if="projects.length <= 25" href="#" class="btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('editProjectNote')"
+                            @click.prevent="handleEditProjectNote(p.id)"
+                            v-translate:aria-label="'editProjectNote'">
+                        <vue-feather type="file-text" size="20"></vue-feather>
+                    </button>
+                    <button v-else href="#" class="btn btn-sm btn-red-icons"
                             @click.prevent="handleEditProjectNote(p.id)"
                             v-translate:aria-label="'editProjectNote'">
                         <vue-feather type="file-text" size="20"></vue-feather>
@@ -60,32 +65,56 @@
                     {{ format(p.versions[0].updated) }}
                 </div>
                 <div class="col-md-1 project-cell load-cell">
-                    <button class=" btn btn-sm btn-red-icons"
+                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('load')"
+                            v-translate:aria-label="'load'"
+                            @click="loadVersion($event, p.id, p.versions[0].id)">
+                        <vue-feather type="refresh-cw" size="20"></vue-feather>
+                    </button>
+                    <button v-else class=" btn btn-sm btn-red-icons"
                             v-translate:aria-label="'load'"
                             @click="loadVersion($event, p.id, p.versions[0].id)">
                         <vue-feather type="refresh-cw" size="20"></vue-feather>
                     </button>
                 </div>
                 <div class="col-md-1 project-cell rename-cell">
-                    <button class="btn btn-sm btn-red-icons"
+                    <button v-if="projects.length <= 25" class="btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('renameProject')"
+                            v-translate:aria-label="'renameProject'"
+                            @click="renameProject($event, p.id)">
+                        <vue-feather type="edit" size="20"></vue-feather>
+                    </button>
+                    <button v-else class="btn btn-sm btn-red-icons"
                             v-translate:aria-label="'renameProject'"
                             @click="renameProject($event, p.id)">
                         <vue-feather type="edit" size="20"></vue-feather>
                     </button>
                 </div>
                 <div class="col-md-1 project-cell delete-cell">
-                    <button class=" btn btn-sm btn-red-icons"
+                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('delete')"
+                            v-translate:aria-label="'delete'"
+                            @click="deleteProject($event, p.id)">
+                        <vue-feather type="trash-2" size="20"></vue-feather>
+                    </button>
+                    <button v-else class=" btn btn-sm btn-red-icons"
                             v-translate:aria-label="'delete'"
                             @click="deleteProject($event, p.id)">
                         <vue-feather type="trash-2" size="20"></vue-feather>
                     </button>
                 </div>
                 <div class="col-md-1 project-cell copy-cell">
-                    <button class=" btn btn-sm btn-red-icons"
+                    <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                             v-tooltip="getTranslatedValue('copyLatestToNewProject')"
+                            v-translate:aria-label="'copyLatestToNewProject'"
+                            @click="promoteVersion(
+                                $event,
+                                p.id,
+                                p.versions[0].id,
+                                p.versions[0].versionNumber)">
+                        <vue-feather type="copy" size="20"></vue-feather>
+                    </button>
+                    <button v-else class=" btn btn-sm btn-red-icons"
                             v-translate:aria-label="'copyLatestToNewProject'"
                             @click="promoteVersion(
                                 $event,
@@ -109,8 +138,13 @@
                     <div class="col-md-1 version-cell"></div>
                     <div class="col-md-3 version-cell edit-cell">
                         <span class="float-right">
-                            <button href="#" class="btn btn-sm btn-red-icons"
+                            <button v-if="projects.length <= 25" href="#" class="btn btn-sm btn-red-icons"
                                     v-tooltip="getTranslatedValue('editVersionNote')"
+                                    v-translate:aria-label="'editVersionNote'"
+                                    @click.prevent="handleEditVersionNote(p.id, v.id, v.versionNumber)">
+                            <vue-feather type="file-text" size="20"></vue-feather>
+                            </button>
+                            <button v-else href="#" class="btn btn-sm btn-red-icons"
                                     v-translate:aria-label="'editVersionNote'"
                                     @click.prevent="handleEditVersionNote(p.id, v.id, v.versionNumber)">
                             <vue-feather type="file-text" size="20"></vue-feather>
@@ -124,8 +158,13 @@
                         {{ format(v.updated) }}
                     </div>
                     <div class="col-md-1 version-cell load-cell">
-                        <button class=" btn btn-sm btn-red-icons"
+                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('load')"
+                                v-translate:aria-label="'load'"
+                                @click="loadVersion($event, p.id, v.id)">
+                            <vue-feather type="refresh-cw" size="20"></vue-feather>
+                        </button>
+                        <button v-else class=" btn btn-sm btn-red-icons"
                                 v-translate:aria-label="'load'"
                                 @click="loadVersion($event, p.id, v.id)">
                             <vue-feather type="refresh-cw" size="20"></vue-feather>
@@ -134,16 +173,30 @@
                     <div class="col-md-1 version-cell">
                     </div>
                     <div class="col-md-1 version-cell delete-cell">
-                        <button class=" btn btn-sm btn-red-icons"
+                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('delete')"
+                                v-translate:aria-label="'delete'"
+                                @click="deleteVersion($event, p.id, v.id)">
+                        <vue-feather type="trash-2" size="20"></vue-feather>
+                        </button>
+                        <button v-else class=" btn btn-sm btn-red-icons"
                                 v-translate:aria-label="'delete'"
                                 @click="deleteVersion($event, p.id, v.id)">
                         <vue-feather type="trash-2" size="20"></vue-feather>
                         </button>
                     </div>
                     <div class="col-md-1 version-cell copy-cell">
-                        <button class=" btn btn-sm btn-red-icons"
+                        <button v-if="projects.length <= 25" class=" btn btn-sm btn-red-icons"
                                 v-tooltip="getTranslatedValue('copyToNewProject')"
+                                v-translate:aria-label="'copyToNewProject'"
+                                @click="promoteVersion(
+                                    $event,
+                                    p.id,
+                                    v.id,
+                                    v.versionNumber)">
+                            <vue-feather type="copy" size="20"></vue-feather>
+                        </button>
+                        <button v-else class=" btn btn-sm btn-red-icons"
                                 v-translate:aria-label="'copyToNewProject'"
                                 @click="promoteVersion(
                                     $event,

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.5.0";
+export const currentHintVersion = "3.5.1";

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -67,6 +67,17 @@ describe("Project history component", () => {
         }
     ];
 
+    const testProjectsLong = (n: number) => {
+        const projects: Project[] = [];
+        for (let i = 0; i < n; i++) {
+            projects.push({
+                id: i + 1,
+                name: `proj${i}`,
+                versions: [{ id: `s${i}`, created: isoDates[2], updated: isoDates[3], versionNumber: 1 }]
+            })
+        }
+        return projects;
+    };
 
     const getWrapper = (projects = testProjects) => {
         const store = createStore(projects)
@@ -149,6 +160,34 @@ describe("Project history component", () => {
         expect(mockTooltip.mock.calls[4][1].value).toBe("Copy last updated to a new project");
         expect(mockTooltip.mock.calls[5][1].value).toBe("Add or edit version notes");
         expect(mockTooltip.mock.calls[8][1].value).toBe("Copy to a new project");
+    });
+
+    it("does not render tooltips if project length > 25", () => {
+        const mockTooltip = jest.fn();
+        const store = createStore(testProjectsLong(25))
+        mountWithTranslate(ProjectHistory, store, {
+            global: {
+                directives: {"tooltip": mockTooltip},
+                plugins: [store],
+                stubs: ["share-project"]
+            }
+        });
+
+        // 9 * 25, we have 9 instances of tooltips
+        expect(mockTooltip).toBeCalledTimes(225);
+
+        mockTooltip.mockReset();
+
+        const store1 = createStore(testProjectsLong(26))
+        mountWithTranslate(ProjectHistory, store1, {
+            global: {
+                directives: {"tooltip": mockTooltip},
+                plugins: [store1],
+                stubs: ["share-project"]
+            }
+        });
+
+        expect(mockTooltip).toBeCalledTimes(0);
     });
 
     it("can render tooltips in french without an error", async () => {


### PR DESCRIPTION
## Description

Floating vue tooltips take a long time to unmount when you have 400 of them all rendered. So we are only displaying tooltips for 25 projects or less.

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
