### PR TITLE
CodeCov is saved

### DIFF
--- a/src/app/static/jest.config.js
+++ b/src/app/static/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     ],
     moduleDirectories: ["node_modules", "src"],
     coverageDirectory: './coverage/',
+    coverageProvider: "v8",
     collectCoverage: true,
     coveragePathIgnorePatterns: [
         '/node_modules/',


### PR DESCRIPTION
## Description

This has been a long time coming. Did a bit of research and found out that v8 is a better code coverage provider than whatever `vue3-jest` uses. It is apparently about babel dependencies. See https://stackoverflow.com/questions/74701960/why-is-my-jest-code-coverage-report-invalid.

To test:

Snoop around the file explorer on codecov.io (can click link in codecov comment in this PR), it is looking much better. I have compared a few files and they all seem reasonable. For comparison you can use https://app.codecov.io/gh/mrc-ide/hint/pull/904/tree/src/app/static/src/app/components which is the project page bug PR that was merged most recently. Finally can stop ignoring it :laughing: 

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
