### PR TITLE
mrc-4761: Fix rehydrate bug where fetchedIndicators are incorrect type

### DIFF
--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -41,7 +41,8 @@ docker run --rm -d \
   -e REDIS_URL=redis://redis:6379 \
   -e USE_MOCK_MODEL=true \
   $HINTR_IMAGE \
-  --results-dir=/results
+  --results-dir=/results \
+  --inputs-dir=/uploads
 
 # Need to give the database a little time to initialise before we can run the migration
 docker exec -it $DB wait-for-db

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.5.1";
+export const currentHintVersion = "3.5.2";

--- a/src/app/static/src/app/store/modelCalibrate/mutations.ts
+++ b/src/app/static/src/app/store/modelCalibrate/mutations.ts
@@ -151,7 +151,11 @@ export const mutations: MutationTree<ModelCalibrateState> = {
         } else {
             state.result.data = [...state.result.data, ...action.payload.data];
         }
-        if (!state.fetchedIndicators) {
+        // mrc-4761: Seen an issue where when rehydrating from an output zip for some reason we are
+        // getting the fetchedIndicators as an object. So below where we try to call .add is not working
+        // Not sure why this is the case, can see the rehydration building the state correctly
+        // but then after reloading the fetched indicators are coming through as an empty object
+        if (!state.fetchedIndicators || !(state.fetchedIndicators instanceof Set)) {
             state.fetchedIndicators = new Set<string>([action.payload.indicatorId]);
         } else {
             state.fetchedIndicators.add(action.payload.indicatorId);


### PR DESCRIPTION
## Description

Found another issue when trying to add a script for testing, the rehydrate is not working since we added `fetchedIndicators`. If you rehydrate a project with current step set to output plots then for some reason this is an object in state and so `.add` function doesn't exist which is throwing an error. After refreshing the page it loads fine and recognises it as a set so something a little tricky here.

I had a look at where we do the rehydration and the indicatorsFetched gets set to an empty set correctly there so I think something going on after the reload

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
