### PR TITLE
mrc-4762 fetch first n indicators

### DIFF
--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -1,10 +1,11 @@
 import {ModelCalibrateState} from "./modelCalibrate";
-import {ActionContext, ActionTree, Commit} from "vuex";
+import {ActionContext, ActionTree, Commit, Dispatch} from "vuex";
 import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-next-dynamic-form";
 import {api} from "../../apiService";
 import {RootState} from "../../root";
 import {ModelCalibrateMutation} from "./mutations";
 import {
+    BarchartIndicator,
     CalibrateDataResponse,
     CalibrateMetadataResponse,
     CalibrateResultResponse,
@@ -164,6 +165,14 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
     }
 };
 
+export const fetchFirstNIndicators = async (dispatch: Dispatch, indicators: BarchartIndicator[], n: number) => {
+    const promisesArray = [];
+    for (let i = 0; i < n && i < indicators.length; i++) {
+        promisesArray.push(dispatch("modelCalibrate/getResultData", {indicatorId: indicators[i].indicator, tab: ModelOutputTabs.Bar}, {root: true}));
+    }
+    await Promise.all(promisesArray);
+};
+
 export const getResultMetadata = async function (context: ActionContext<ModelCalibrateState, RootState>) {
     const {commit, dispatch, state} = context;
     const calibrateId = state.calibrateId;
@@ -180,6 +189,10 @@ export const getResultMetadata = async function (context: ActionContext<ModelCal
 
         selectFilterDefaults(data, commit, PlottingSelectionsMutations.updateBarchartSelections)
         commit(ModelCalibrateMutation.Calibrated);
+
+        const indicators = data.plottingMetadata.barchart.indicators;
+        await fetchFirstNIndicators(dispatch, indicators, 5);
+
         if (switches.modelCalibratePlot) {
             dispatch("getCalibratePlot");
         }

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -188,10 +188,12 @@ export const getResultMetadata = async function (context: ActionContext<ModelCal
         commit({type: ModelCalibrateMutation.MetadataFetched, payload: data});
 
         selectFilterDefaults(data, commit, PlottingSelectionsMutations.updateBarchartSelections)
-        commit(ModelCalibrateMutation.Calibrated);
 
         const indicators = data.plottingMetadata.barchart.indicators;
         await fetchFirstNIndicators(dispatch, indicators, 5);
+        
+        commit(ModelCalibrateMutation.Calibrated);
+
 
         if (switches.modelCalibratePlot) {
             dispatch("getCalibratePlot");

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -9,12 +9,13 @@ import {
     mockSuccess,
     mockWarning
 } from "../mocks";
-import {actions} from "../../app/store/modelCalibrate/actions";
+import {actions, fetchFirstNIndicators} from "../../app/store/modelCalibrate/actions";
 import {ModelCalibrateMutation} from "../../app/store/modelCalibrate/mutations";
 import {freezer} from "../../app/utils";
 import {switches} from "../../app/featureSwitches";
 import {DownloadResultsMutation} from "../../app/store/downloadResults/mutations";
 import { ModelOutputTabs } from "../../app/types";
+import { BarchartIndicator } from "../../app/generated";
 
 const rootState = mockRootState();
 describe("ModelCalibrate actions", () => {
@@ -174,7 +175,8 @@ describe("ModelCalibrate actions", () => {
                         x_axis_id: "test_x",
                         disaggregate_by_id: "test_dis",
                         selected_filter_options: {"test_name": ["test_value"]}
-                    }
+                    },
+                    indicators: []
                 }
             },
             uploadMetadata: {
@@ -247,7 +249,8 @@ describe("ModelCalibrate actions", () => {
                         selected_filter_options: {
                             type: [{id: "test", label: "test"}]
                         }
-                    }
+                    },
+                    indicators: []
                 }
             },
             uploadMetadata: {
@@ -272,6 +275,23 @@ describe("ModelCalibrate actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("getComparisonPlot");
+    });
+
+    it("fetchFirstNIndicators works as expected", () => {
+        const dispatch = jest.fn();
+        const mockBarchartIndicators: Partial<BarchartIndicator>[] = [
+            { indicator: "indicator1" },
+            { indicator: "indicator2" },
+            { indicator: "indicator3" },
+        ]
+        fetchFirstNIndicators(dispatch, mockBarchartIndicators as any, 2);
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({ indicatorId: "indicator1", tab: ModelOutputTabs.Bar });
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
+        expect(dispatch.mock.calls[1][0]).toBe("modelCalibrate/getResultData");
+        expect(dispatch.mock.calls[1][1]).toStrictEqual({ indicatorId: "indicator2", tab: ModelOutputTabs.Bar });
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({ root: true });
     });
 
     it("getResult does not fetch when status is not done", async () => {


### PR DESCRIPTION
## Description

For the first iteration let's go for a simpler approach! Let's just block the user from going to the model outputs page until we have fetched the first n indicators on the calibrate plot

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
