### PR TITLE
mrc-4766: Format the barchart axes

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.5.2";
+export const currentHintVersion = "3.5.3";

--- a/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
+++ b/src/app/static/src/app/vue-chart/src/bar/BarChartWithErrors.vue
@@ -189,7 +189,12 @@ export default defineComponent({
                     },
                     scales: {
                         y: {
-                            max: this.chartData.maxValuePlusError * 1.1
+                            max: this.chartData.maxValuePlusError * 1.1,
+                            ticks: {
+                                callback: ((value: number | string) => {
+                                    return value == this.chartData.maxValuePlusError * 1.1 ? "" : formatCallback(value)
+                                })
+                            }
                         }
                     },
                     animation: {

--- a/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
@@ -175,7 +175,6 @@ describe("chartjsBar component", () => {
             onComplete: showAllErrorBars
         })
         expect(renderedConfig.scales.y.max).toBeCloseTo(0.22);
-        console.log(renderedConfig.scales.y.ticks.callback(0.2))
         expect(renderedConfig.scales.y.ticks.callback(renderedConfig.scales.y.max)).toStrictEqual("")
         expect(renderedConfig.scales.y.ticks.callback(0.2)).toStrictEqual("Value 0.2")
     });

--- a/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
+++ b/src/app/static/src/app/vue-chart/tests/bar/barChartWithErrors.test.ts
@@ -175,6 +175,9 @@ describe("chartjsBar component", () => {
             onComplete: showAllErrorBars
         })
         expect(renderedConfig.scales.y.max).toBeCloseTo(0.22);
+        console.log(renderedConfig.scales.y.ticks.callback(0.2))
+        expect(renderedConfig.scales.y.ticks.callback(renderedConfig.scales.y.max)).toStrictEqual("")
+        expect(renderedConfig.scales.y.ticks.callback(0.2)).toStrictEqual("Value 0.2")
     });
 
     it("correct chart options if not showErrorBars", async () => {


### PR DESCRIPTION
## Description

This PR will add formatting to the barchart axes. The one bit of fiddlyness here is removing the top level tick as because we are setting this manually it can be at a bit of an ugly value e.g. 109.2% or 240.32 so I have hidden that

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
