### PR TITLE
mrc-4768 fix double re-rendering of components

### DIFF
--- a/src/app/static/src/app/store/modelOutput/actions.ts
+++ b/src/app/static/src/app/store/modelOutput/actions.ts
@@ -3,6 +3,7 @@ import {ModelOutputMutation} from "./mutations";
 import {ModelOutputTabs} from "../../types";
 import {DataExplorationState} from "../dataExploration/dataExploration";
 import {ModelOutputState} from "./modelOutput";
+import { ResultDataPayload } from "../modelCalibrate/actions";
 
 export interface ModelOutputActions {
     updateSelectedTab: (store: ActionContext<ModelOutputState, DataExplorationState>, tab: ModelOutputTabs) => void
@@ -13,31 +14,45 @@ export const actions: ActionTree<ModelOutputState, DataExplorationState> & Model
     async updateSelectedTab(context, tab) {
         const {commit, rootState, dispatch} = context;
 
-        const currentIndicators: string[] = [];
+        const currentIndicatorPayloads: ResultDataPayload[] = [];
         switch (tab) {
             case ModelOutputTabs.Bar:
-                currentIndicators.push(rootState.plottingSelections.barchart.indicatorId);
+                currentIndicatorPayloads.push({
+                    tab,
+                    payload: { indicatorId: rootState.plottingSelections.barchart.indicatorId }
+                });
                 break;
             case ModelOutputTabs.Bubble:
-                currentIndicators.push(rootState.plottingSelections.bubble.colorIndicatorId);
-                currentIndicators.push(rootState.plottingSelections.bubble.sizeIndicatorId);
+                currentIndicatorPayloads.push({
+                    tab,
+                    payload: { colorIndicatorId: rootState.plottingSelections.bubble.colorIndicatorId }
+                });
+                currentIndicatorPayloads.push({
+                    tab,
+                    payload: { sizeIndicatorId: rootState.plottingSelections.bubble.sizeIndicatorId }
+                });
                 break;
             case ModelOutputTabs.Comparison:
                 // Comparison plot data is fetched separately immediately after calibration is complete
                 // We don't need to retrieve slices of it here.
                 break;
             case ModelOutputTabs.Map:
-                currentIndicators.push(rootState.plottingSelections.outputChoropleth.indicatorId);
+                currentIndicatorPayloads.push({
+                    tab,
+                    payload: { indicatorId: rootState.plottingSelections.outputChoropleth.indicatorId }
+                });
                 break;
             case ModelOutputTabs.Table:
-                currentIndicators.push(rootState.plottingSelections.table.indicator);
+                currentIndicatorPayloads.push({
+                    tab,
+                    payload: { indicator: rootState.plottingSelections.table.indicator }
+                });
                 break;
             default:
                 break;
         }
 
-        currentIndicators.forEach(indicator => {
-            const payload = { indicatorId: indicator, tab };
+        currentIndicatorPayloads.forEach(payload => {
             dispatch("modelCalibrate/getResultData", payload, {root:true});
         });
         commit({type: ModelOutputMutation.TabSelected, payload: tab});

--- a/src/app/static/src/app/store/plottingSelections/actions.ts
+++ b/src/app/static/src/app/store/plottingSelections/actions.ts
@@ -18,41 +18,30 @@ export interface PlottingSelectionsActions {
 export const actions: ActionTree<PlottingSelectionsState, DataExplorationState> & PlottingSelectionsActions = {
 
     async updateBarchartSelections(context, payload) {
-        const {commit, dispatch} = context;
-        const indicatorId = payload.payload.indicatorId;
+        const { dispatch } = context;
         const tab = ModelOutputTabs.Bar;
-        const resultDataPayload = { indicatorId, tab };
+        const resultDataPayload = { payload: payload.payload, tab };
         await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
-        commit({type: PlottingSelectionsMutations.updateBarchartSelections, payload: payload.payload});
     },
 
     async updateChoroplethSelections(context, payload) {
-        const {commit, dispatch} = context;
-        const indicatorId = payload.payload.indicatorId;
+        const { dispatch } = context;
         const tab = ModelOutputTabs.Map;
-        const resultDataPayload = { indicatorId, tab };
-        if (indicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
-        commit({type: PlottingSelectionsMutations.updateOutputChoroplethSelections, payload: payload.payload});
+        const resultDataPayload = { payload: payload.payload, tab };
+        dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
     },
 
     async updateBubblePlotSelections(context, payload) {
-        const {commit, dispatch} = context;
-        const colourIndicatorId = payload.payload.colorIndicatorId;
-        const sizeIndicatorId = payload.payload.sizeIndicatorId;
+        const { dispatch } = context;
         const tab = ModelOutputTabs.Bubble;
-        const resultDataPayloadColor = { indicatorId: colourIndicatorId, tab };
-        const resultDataPayloadSize = { indicatorId: sizeIndicatorId, tab };
-        if (colourIndicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayloadColor, {root:true});
-        if (sizeIndicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayloadSize, {root:true});
-        commit({type: PlottingSelectionsMutations.updateBubblePlotSelections, payload: payload.payload});
+        const resultDataPayload = { payload: payload.payload, tab };
+        await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
     },
 
     async updateTableSelections(context, payload) {
-        const {commit, dispatch} = context;
-        const indicatorId = payload.payload.indicator;
+        const { dispatch } = context;
         const tab = ModelOutputTabs.Table;
-        const resultDataPayload = { indicatorId, tab };
-        if (indicatorId) await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
-        commit({type: PlottingSelectionsMutations.updateTableSelections, payload: payload.payload});
+        const resultDataPayload = { payload: payload.payload, tab };
+        await dispatch("modelCalibrate/getResultData", resultDataPayload, {root:true});
     }
 };

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -315,10 +315,10 @@ describe("ModelCalibrate actions", () => {
             result: mockCalibrateResultResponse(),
             fetchedIndicators: new Set(["mock"])
         });
+        const payload = {indicatorId: "prevalence"};
+        await actions.getResultData({commit, state, rootState, dispatch} as any, { payload, tab: ModelOutputTabs.Map});
 
-        await actions.getResultData({commit, state, rootState, dispatch} as any, {indicatorId: "prevalence", tab: ModelOutputTabs.Map});
-
-        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls.length).toBe(4);
         expect(commit.mock.calls[0][0]).toBe("modelOutput/SetTabLoading");
         expect(commit.mock.calls[0][1].payload).toStrictEqual({tab: ModelOutputTabs.Map, loading: true});
         expect(commit.mock.calls[0][2]["root"]).toBe(true);
@@ -331,10 +331,16 @@ describe("ModelCalibrate actions", () => {
         expect(commit.mock.calls[2][1].payload).toStrictEqual({tab: ModelOutputTabs.Map, loading: false});
         expect(commit.mock.calls[2][2]["root"]).toBe(true);
 
-        // Fetching an already-known indicator does not trigger a refresh
-        await actions.getResultData({commit, state, rootState, dispatch} as any, {indicatorId: "mock", tab: ModelOutputTabs.Map});
+        expect(commit.mock.calls[3][0]).toBe("plottingSelections/updateOutputChoroplethSelections");
+        expect(commit.mock.calls[3][1].payload).toStrictEqual({indicatorId: "prevalence"});
+        expect(commit.mock.calls[3][2]["root"]).toBe(true);
 
-        expect(commit.mock.calls.length).toBe(3);
+        // Fetching an already-known indicator does not trigger a refresh
+        const payload1 = { indicatorId: "mock" }
+        await actions.getResultData({commit, state, rootState, dispatch} as any, {payload: payload1 , tab: ModelOutputTabs.Map});
+
+        // still needs to update selections
+        expect(commit.mock.calls.length).toBe(5);
     });
 
     it("getResultData commits error when unsuccessful data fetch", async () => {
@@ -350,10 +356,10 @@ describe("ModelCalibrate actions", () => {
                 done: true
             } as any
         });
+        const payload = {indicatorId: "prevalence"};
+        await actions.getResultData({commit, dispatch, state, rootState} as any, {payload, tab: ModelOutputTabs.Map});
 
-        await actions.getResultData({commit, dispatch, state, rootState} as any, {indicatorId: "prevalence", tab: ModelOutputTabs.Map});
-
-        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls.length).toBe(4);
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: "SetError",
             payload: mockError("Test Error")
@@ -376,11 +382,15 @@ describe("ModelCalibrate actions", () => {
                 done: false
             } as any
         });
-
-        await actions.getResultData({commit, dispatch, state, rootState} as any, {indicatorId: "prevalence", tab: ModelOutputTabs.Map});
+        const payload = {indicatorId: "prevalence"};
+        await actions.getResultData({commit, dispatch, state, rootState} as any, {payload, tab: ModelOutputTabs.Map});
 
         expect(mockAxios.history.get.length).toBe(0);
-        expect(commit.mock.calls.length).toBe(0);
+        expect(commit.mock.calls.length).toBe(1);
+
+        expect(commit.mock.calls[0][0]).toBe("plottingSelections/updateOutputChoroplethSelections");
+        expect(commit.mock.calls[0][1].payload).toStrictEqual(payload);
+        expect(commit.mock.calls[0][2]["root"]).toBe(true);
     });
 
     it("getCalibratePlot fetches the calibrate plot data and sets it when successful", async () => {

--- a/src/app/static/src/tests/modelOutput/actions.test.ts
+++ b/src/app/static/src/tests/modelOutput/actions.test.ts
@@ -56,7 +56,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bar, indicatorId: "barchart-indicator"});
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bar, payload: {indicatorId: "barchart-indicator"}});
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -69,9 +69,9 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(2);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, indicatorId: "colour-indicator"});
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, payload: {colorIndicatorId: "colour-indicator"}});
         expect(dispatch.mock.calls[1][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[1][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, indicatorId: "size-indicator"});
+        expect(dispatch.mock.calls[1][1]).toStrictEqual({tab: ModelOutputTabs.Bubble, payload: {sizeIndicatorId: "size-indicator"}});
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -95,7 +95,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Map, indicatorId: "choropleth-indicator"});
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Map, payload: {indicatorId: "choropleth-indicator"}});
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);
@@ -108,7 +108,7 @@ describe("ModelOutput actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Table, indicatorId: "table-indicator"});
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({tab: ModelOutputTabs.Table, payload: {indicator: "table-indicator"}});
 
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0].type).toBe(ModelOutputMutation.TabSelected);

--- a/src/app/static/src/tests/plottingSelections/actions.test.ts
+++ b/src/app/static/src/tests/plottingSelections/actions.test.ts
@@ -23,11 +23,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Bar})
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateBarchartSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(barchartSelections);
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({payload: barchartSelections, tab: ModelOutputTabs.Bar})
     });
 
     it("updateChoroplethSelections dispatches data action and commits mutation", async () => {
@@ -41,29 +37,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Map})
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateOutputChoroplethSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(choroplethSelections);
-    });
-
-    it("updateChoroplethSelections doesn't dispatch action if indicator not in update", async () => {
-        const commit = jest.fn();
-        const dispatch = jest.fn();
-        const choroplethSelections = {
-            selectedFilterOptions: {
-                testFilter: []
-            }
-        } as Partial<ChoroplethSelections>;
-
-        await actions.updateChoroplethSelections({commit, dispatch} as any, {payload: choroplethSelections} as any);
-
-        expect(dispatch.mock.calls.length).toBe(0);
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateOutputChoroplethSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(choroplethSelections);
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({payload: choroplethSelections, tab: ModelOutputTabs.Map})
     });
 
     it("updateTableSelection dispatches data action and commits mutation", async () => {
@@ -77,29 +51,7 @@ describe("PlottingSelection actions", () => {
 
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "test-indicator", tab: ModelOutputTabs.Table})
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateTableSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(tableSelections);
-    });
-
-    it("updateTableSelection doesn't dispatch action if indicator not in update", async () => {
-        const commit = jest.fn();
-        const dispatch = jest.fn();
-        const tableSelections = {
-            selectedFilterOptions: {
-                testFilter: []
-            }
-        } as Partial<TableSelections>;
-
-        await actions.updateTableSelections({commit, dispatch} as any, {payload: tableSelections} as any);
-
-        expect(dispatch.mock.calls.length).toBe(0);
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateTableSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(tableSelections);
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({payload: tableSelections, tab: ModelOutputTabs.Table})
     });
 
     it("updateBubblePlotSelections dispatches data action and commits mutation", async () => {
@@ -112,49 +64,8 @@ describe("PlottingSelection actions", () => {
 
         await actions.updateBubblePlotSelections({commit, dispatch} as any, {payload: bubbleSelections} as any);
 
-        expect(dispatch.mock.calls.length).toBe(2);
-        expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "colour-indicator", tab: ModelOutputTabs.Bubble})
-        expect(dispatch.mock.calls[1][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[1][1]).toStrictEqual({indicatorId: "size-indicator", tab: ModelOutputTabs.Bubble})
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateBubblePlotSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(bubbleSelections);
-    });
-
-    it("updateBubblePlotSelections doesn't dispatch action if indicator not in update", async () => {
-        const commit = jest.fn();
-        const dispatch = jest.fn();
-        const bubbleSelections = {
-            selectedFilterOptions: {
-                testFilter: []
-            }
-        } as Partial<BubblePlotSelections>;
-
-        await actions.updateBubblePlotSelections({commit, dispatch} as any, {payload: bubbleSelections} as any);
-
-        expect(dispatch.mock.calls.length).toBe(0);
-
-        expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0].type).toBe(PlottingSelectionsMutations.updateBubblePlotSelections);
-        expect(commit.mock.calls[0][0].payload).toBe(bubbleSelections);
-
-        const bubbleSelections2 = {
-            sizeIndicatorId: "size-indicator",
-            selectedFilterOptions: {
-                testFilter: []
-            }
-        } as Partial<BubblePlotSelections>;
-
-        await actions.updateBubblePlotSelections({commit, dispatch} as any, {payload: bubbleSelections2} as any);
-
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("modelCalibrate/getResultData");
-        expect(dispatch.mock.calls[0][1]).toStrictEqual({indicatorId: "size-indicator", tab: ModelOutputTabs.Bubble})
-
-        expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[1][0].type).toBe(PlottingSelectionsMutations.updateBubblePlotSelections);
-        expect(commit.mock.calls[1][0].payload).toBe(bubbleSelections2);
+        expect(dispatch.mock.calls[0][1]).toStrictEqual({payload: bubbleSelections, tab: ModelOutputTabs.Bubble})
     });
 });


### PR DESCRIPTION
## Description

The components for the plots are re-rendering. This is because in the updating plot selection actions, we fetch the data and then we commit the actual selections to state. These two commits at different times causes a double re-compute of the filtered data in the various components, this fixes that. @r-ash and I did some profiling to find this out. Here are some of the results for Malawi. For the bubble plot (our most render intensive plot), before:

![image](https://github.com/mrc-ide/hint/assets/98405247/ec7ff303-5db3-45b0-a2e6-cfe515a0bce8)

After:

![image](https://github.com/mrc-ide/hint/assets/98405247/6094af58-9438-479f-a2e5-95c748570cbe)

Scaled comparison (times shown are nothing to do with what we are interested in, they are just the durations of the snapshots):

![image](https://github.com/mrc-ide/hint/assets/98405247/18e5b2e3-1cd9-41b1-8971-8a1900ea2635)

Rough timing changes:
  - With double mutation (master):
    - Bar: 360 - 430ms
    - Table: 290 - 350ms
    - Map: 420 - 500ms
    - Bubble 490 - 750ms

  - With this PR:
    - Bar: 220 - 290ms
    - Table: 188 - 215ms
    - Map: 228 - 400ms
    - Bubble: 420 - 580ms

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
