### PR TITLE
add formatted value columns to table download

### DIFF
--- a/src/app/static/src/app/components/outputTable/TableData.vue
+++ b/src/app/static/src/app/components/outputTable/TableData.vue
@@ -14,11 +14,14 @@ import TableReshapeData from './TableReshapeData.vue';
 import DownloadButton from '../downloadIndicator/DownloadButton.vue';
 import { exportService } from '../../dataExportService';
 import { appendCurrentDateTime } from '../../utils';
+import { formatOutput } from '../plots/utils';
 
 // defines the order of headers on the excel download
 const header = [ "area_id", "area_name", "area_level",
     "parent_area_id", "indicator", "calendar_quarter",
-    "age_group", "sex", "mode", "mean", "upper", "lower" ];
+    "age_group", "sex", "formatted_mode", "formatted_mean",
+    "formatted_upper", "formatted_lower", "mode",
+    "mean", "upper", "lower" ];
 
 export default defineComponent({
     components: {
@@ -40,6 +43,7 @@ export default defineComponent({
             return idToDataId;
         });
         const features = computed(() => store.state.baseline.shape?.data.features || []);
+        const indicators = computed(() => store.state.modelCalibrate.metadata?.plottingMetadata.choropleth.indicators || []);
 
         const filteredData = computed(() => {
             const result = store.state.modelCalibrate.result;
@@ -72,10 +76,19 @@ export default defineComponent({
         const getDownloadData = (filteredData: any[]) => {
             return filteredData.map(d => {
                 const feature = features.value.find(f => f.properties.area_id === d.area_id);
+                const indicator = indicators.value.find(i => i.indicator === d.indicator);
+                const format = (value: number) => formatOutput(value,
+                                                               indicator?.format || "",
+                                                               indicator?.scale || null,
+                                                               indicator?.accuracy || null);
                 return {
                     ...d,
                     area_name: feature?.properties.area_name || "",
-                    parent_area_id: feature?.properties.parent_area_id || ""
+                    parent_area_id: feature?.properties.parent_area_id || "",
+                    formatted_mode: format(d.mode),
+                    formatted_mean: format(d.mean),
+                    formatted_upper: format(d.upper),
+                    formatted_lower: format(d.lower)
                 }
             });
         };

--- a/src/app/static/src/tests/components/outputTable/tableData.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableData.test.ts
@@ -147,7 +147,8 @@ describe("Output Table display table tests", () => {
         expect(mockExportService.mock.calls[0][0].options).toStrictEqual({
             header: ["area_id", "area_name", "area_level", "parent_area_id",
                     "indicator", "calendar_quarter", "age_group", "sex",
-                    "mode", "mean", "upper", "lower"]
+                    "formatted_mode", "formatted_mean", "formatted_upper",
+                    "formatted_lower", "mode", "mean", "upper", "lower"]
         });
         expect(mockAddFilteredData.mock.calls.length).toBe(1);
         expect(mockDownload.mock.calls.length).toBe(1);

--- a/src/app/static/src/tests/components/outputTable/tableData.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableData.test.ts
@@ -47,7 +47,7 @@ describe("Output Table display table tests", () => {
                         },
                         plottingMetadata: {
                             barchart: {indicators: [], filters: []},
-                            choropleth: {indicators: [{indicator: "pop", name: "Pop"}, {indicator: "pop2", name: "Pop2"}] as any, filters: []}
+                            choropleth: {indicators: [{indicator: "pop", name: "Pop", scale: 10}, {indicator: "pop2", name: "Pop2"}] as any, filters: []}
                         },
                         warnings: []
                     },
@@ -69,7 +69,11 @@ describe("Output Table display table tests", () => {
                                 id: 3,
                                 indicator: "pop",
                                 col_id_filter_1: "op1",
-                                area_level: 2
+                                area_level: 2,
+                                mode: 1,
+                                mean: 2,
+                                upper: 3,
+                                lower: 4
                             },
                         ] as any
                     }
@@ -109,7 +113,10 @@ describe("Output Table display table tests", () => {
     it("filters data and renders as expected", () => {
         const wrapper = getWrapper("pop", "op1", 2);
         expect(wrapper.findComponent(TableReshapeData).props("data")).toStrictEqual([
-            {id: 3, indicator: "pop", col_id_filter_1: "op1", area_level: 2}
+            {
+                id: 3, indicator: "pop", col_id_filter_1: "op1", area_level: 2,
+                mode: 1, mean: 2, upper: 3, lower: 4
+            }
         ]);
 
         const wrapper1 = getWrapper("pop", "op1", 1);
@@ -139,10 +146,17 @@ describe("Output Table display table tests", () => {
     });
 
     it("handle download works as expected", () => {
-        const wrapper = getWrapper("pop", "op1", 1);
+        const wrapper = getWrapper("pop", "op1", 2);
         const downloadButton = wrapper.findComponent(DownloadButton);
         downloadButton.vm.$emit("click");
-        expect(mockExportService.mock.calls[0][0].data).toStrictEqual({filteredData: [], unfilteredData: []});
+        expect(mockExportService.mock.calls[0][0].data.filteredData).toStrictEqual([
+            {
+                area_level: 2, area_name: "", col_id_filter_1: "op1", id: 3,
+                indicator: "pop", parent_area_id: "", mode: 1, mean: 2, upper: 3,
+                lower: 4, formatted_mode: 10, formatted_mean: 20, formatted_upper: 30,
+                formatted_lower: 40
+            }
+        ]);
         expect(mockExportService.mock.calls[0][0].filename).toContain("ABC_naomi_table-data_");
         expect(mockExportService.mock.calls[0][0].options).toStrictEqual({
             header: ["area_id", "area_name", "area_level", "parent_area_id",


### PR DESCRIPTION
## Description

Ian would like nicely formatted values for the data points rather than the raw values so Jeff agreed that we can have some more columns for formatted data.

To test:
Download the filtered data from the table tab and there should be formatted columns in the sheet. Try for different indicators since they have different formatting.

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
