### PR TITLE
mrc-4857 add kotlin endpoint for full filtered data slicing

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:1.6.7'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
     implementation 'org.duckdb:duckdb_jdbc:0.9.1'
+    implementation 'org.ktorm:ktorm-core:3.6.0'
 
     implementation project(":databaseInterface")
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/CalibrateController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/CalibrateController.kt
@@ -7,6 +7,7 @@ import org.imperial.mrc.hint.models.ModelOptions
 import org.imperial.mrc.hint.models.SuccessResponse
 import org.imperial.mrc.hint.models.asResponseEntity
 import org.imperial.mrc.hint.service.CalibrateDataService
+import org.imperial.mrc.hint.models.FilterQuery
 
 @RestController
 @RequestMapping("/calibrate")
@@ -48,6 +49,16 @@ class CalibrateController(val apiClient: HintrAPIClient, val calibrateDataServic
         @PathVariable("indicator") indicator: String): ResponseEntity<String>
     {
         val dataObj = calibrateDataService.getCalibrateData(id, indicator)
+        return SuccessResponse(dataObj).asResponseEntity()
+    }
+
+    @PostMapping("/result/filteredData/{id}")
+    @ResponseBody
+    fun filteredCalibrateResultData(
+        @PathVariable("id") id: String,
+        @RequestBody filterQuery: FilterQuery): ResponseEntity<String>
+    {
+        val dataObj = calibrateDataService.getFilteredCalibrateData(id, filterQuery)
         return SuccessResponse(dataObj).asResponseEntity()
     }
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -2,7 +2,6 @@ package org.imperial.mrc.hint.db
 
 import org.jooq.tools.json.JSONArray
 import org.jooq.tools.jdbc.SingleConnectionDataSource
-import org.jooq.SQLDialect
 import org.springframework.stereotype.Component
 import org.imperial.mrc.hint.models.CalibrateResultRow
 import org.imperial.mrc.hint.models.ResultData
@@ -97,7 +96,6 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
         return arrayList
     }
 
-    @Suppress("MagicNumber")
     private fun getFilteredDataFromConnection(
         conn: Connection,
         filterQuery: FilterQuery): List<CalibrateResultRow>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -105,6 +105,7 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
         return arrayList
     }
 
+    @Suppress("MagicNumber")
     private fun getFilteredDataFromConnection(
         conn: Connection,
         filterQuery: FilterQuery): List<CalibrateResultRow> {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -96,6 +96,7 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
         return arrayList
     }
 
+    @Suppress("UnsafeCallOnNullableType")
     private fun getFilteredDataFromConnection(
         conn: Connection,
         filterQuery: FilterQuery): List<CalibrateResultRow>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -124,7 +124,11 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
         var stmtIndex = 1;
         for ((_, values) in filterQuery) {
             values.forEach { it ->
-                stmt.setString(stmtIndex, it as String)
+                if (it is String) {
+                    stmt.setString(stmtIndex, it)
+                } else if (it is Int) {
+                    stmt.setInt(stmtIndex, it)
+                }
                 stmtIndex++
             }
         }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -41,19 +41,6 @@ ROUND(upper, 4) AS upper,
 area_level,
 FROM data"""
 
-const val FILTER_TEMPLATE = """SELECT
-age_group,area_id,
-calendar_quarter,
-indicator,
-ROUND(lower, 4) AS lower,
-ROUND(mean, 4) AS mean,
-ROUND(mode, 4) AS mode,
-sex,
-ROUND(upper, 4) AS upper,
-area_level,
-FROM data WHERE 
-"""
-
 interface CalibrateDataRepository
 {
     fun getDataFromPath(
@@ -113,8 +100,8 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
     @Suppress("MagicNumber")
     private fun getFilteredDataFromConnection(
         conn: Connection,
-        filterQuery: FilterQuery
-    ): List<CalibrateResultRow> {
+        filterQuery: FilterQuery): List<CalibrateResultRow>
+    {
         val dataSource = SingleConnectionDataSource(conn)
         return Database.connect(dataSource)
             .from(ResultData)
@@ -173,10 +160,10 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
 
     override fun getFilteredCalibrateData(
         path: String,
-        data: FilterQuery): List<CalibrateResultRow>
+        filterQuery: FilterQuery): List<CalibrateResultRow>
     {
         getDBConnFromPathResponse(path).use { conn ->
-            return getFilteredDataFromConnection(conn, data)
+            return getFilteredDataFromConnection(conn, filterQuery)
         }
     }
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -1,8 +1,11 @@
 package org.imperial.mrc.hint.db
 
 import org.jooq.tools.json.JSONArray
+import org.jooq.tools.jdbc.SingleConnectionDataSource
+import org.jooq.SQLDialect
 import org.springframework.stereotype.Component
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import org.imperial.mrc.hint.models.ResultData
 import org.imperial.mrc.hint.models.FilterQuery
 import java.sql.Connection
 import java.sql.DriverManager
@@ -11,6 +14,8 @@ import java.util.Properties
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.PreparedStatement
+import org.ktorm.database.*
+import org.ktorm.dsl.*
 
 const val INDICATOR_QUERY = """SELECT
 age_group,area_id,
@@ -57,7 +62,7 @@ interface CalibrateDataRepository
     
     fun getFilteredCalibrateData(
         path: String,
-        data: FilterQuery): List<CalibrateResultRow>
+        filterQuery: FilterQuery): List<CalibrateResultRow>
 }
 
 @Component
@@ -108,34 +113,46 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
     @Suppress("MagicNumber")
     private fun getFilteredDataFromConnection(
         conn: Connection,
-        filterQuery: FilterQuery): List<CalibrateResultRow> {
-        val resultSet: ResultSet
-        var query = FILTER_TEMPLATE
-
-        for ((field, values) in filterQuery) {
-            if (values.size > 0) {
-                val questionMarks = values.map { "?" }.joinToString(",")
-                query += "$field IN ($questionMarks) AND "
-            }
-        }
-        query = query.dropLast(5)
-
-        val stmt: PreparedStatement = conn.prepareStatement(query)
-        var stmtIndex = 1;
-        for ((_, values) in filterQuery) {
-            values.forEach { it ->
-                if (it is String) {
-                    stmt.setString(stmtIndex, it)
-                } else if (it is Int) {
-                    stmt.setInt(stmtIndex, it)
+        filterQuery: FilterQuery
+    ): List<CalibrateResultRow> {
+        val dataSource = SingleConnectionDataSource(conn)
+        return Database.connect(dataSource)
+            .from(ResultData)
+            .select()
+            .whereWithConditions {
+                if (filterQuery.indicator.size > 0) {
+                    it += ResultData.indicator inList filterQuery.indicator
                 }
-                stmtIndex++
+                if (filterQuery.calendarQuarter.size > 0) {
+                    it += ResultData.calendarQuarter inList filterQuery.calendarQuarter
+                }
+                if (filterQuery.ageGroup.size > 0) {
+                    it += ResultData.ageGroup inList filterQuery.ageGroup
+                }
+                if (filterQuery.sex.size > 0) {
+                    it += ResultData.sex inList filterQuery.sex
+                }
+                if (filterQuery.areaId.size > 0) {
+                    it += ResultData.areaId inList filterQuery.areaId
+                }
+                if (filterQuery.areaLevel.size > 0) {
+                    it += ResultData.areaLevel inList filterQuery.areaLevel
+                }
             }
-        }
-
-        resultSet = stmt.executeQuery()
-        val arrayList = convertDataToArrayList(resultSet)
-        return arrayList
+            .map { it ->
+                CalibrateResultRow(
+                    it.getString("indicator")!!,
+                    it.getString("calendar_quarter")!!,
+                    it.getString("age_group")!!,
+                    it.getString("sex")!!,
+                    it.getString("area_id")!!,
+                    it.getFloat("mode"),
+                    it.getFloat("mean"),
+                    it.getFloat("lower"),
+                    it.getFloat("upper"),
+                    it.getInt("area_level")
+                )
+            }
     }
 
     private fun getDBConnFromPathResponse(path: String): Connection {   

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/CalibrateResultRow.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/CalibrateResultRow.kt
@@ -1,6 +1,20 @@
 package org.imperial.mrc.hint.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.ktorm.schema.*
+
+object ResultData : Table<Nothing>("data") {
+    val indicator = varchar("indicator")
+    val calendarQuarter = varchar("calendar_quarter")
+    val ageGroup = varchar("age_group")
+    val sex = varchar("sex")
+    val areaId = varchar("area_id")
+    val areaLevel = int("area_level")
+    val mode = float("mode")
+    val mean = float("mean")
+    val upper = float("upper")
+    val lower = float("lower")
+}
 
 data class CalibrateResultRow(
     val indicator: String,
@@ -29,16 +43,3 @@ data class FilterQuery(
     val areaId: List<String>,
     @field:JsonProperty("area_level")
     val areaLevel: List<Int>)
-{
-    operator fun iterator(): Iterator<Pair<String, List<Any>>>
-    {
-        return listOf(
-            "indicator" to indicator,
-            "calendar_quarter" to calendarQuarter,
-            "age_group" to ageGroup,
-            "sex" to sex,
-            "area_id" to areaId,
-            "area_level" to areaLevel
-        ).iterator()
-    }
-}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/models/CalibrateResultRow.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/models/CalibrateResultRow.kt
@@ -17,3 +17,28 @@ data class CalibrateResultRow(
     val upper: Number,
     @field:JsonProperty("area_level")
     val areaLevel: Int)
+
+data class FilterQuery(
+    val indicator: List<String>,
+    @field:JsonProperty("calendar_quarter")
+    val calendarQuarter: List<String>,
+    @field:JsonProperty("age_group")
+    val ageGroup: List<String>,
+    val sex: List<String>,
+    @field:JsonProperty("area_id")
+    val areaId: List<String>,
+    @field:JsonProperty("area_level")
+    val areaLevel: List<Int>)
+{
+    operator fun iterator(): Iterator<Pair<String, List<Any>>>
+    {
+        return listOf(
+            "indicator" to indicator,
+            "calendar_quarter" to calendarQuarter,
+            "age_group" to ageGroup,
+            "sex" to sex,
+            "area_id" to areaId,
+            "area_level" to areaLevel
+        ).iterator()
+    }
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
@@ -11,12 +11,17 @@ import org.jooq.tools.json.JSONObject
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import kotlin.system.measureTimeMillis
+import org.imperial.mrc.hint.models.FilterQuery
 
 interface CalibrateService
 {
     fun getCalibrateData(
         id: String,
         indicator: String): List<CalibrateResultRow>
+    
+    fun getFilteredCalibrateData(
+        id: String,
+        filterQuery: FilterQuery): List<CalibrateResultRow>
 }
 
 @Service
@@ -48,5 +53,15 @@ class CalibrateDataService(
         }, logger, "Fetched calibrate data", logData)
 
         return data
+    }
+
+    override fun getFilteredCalibrateData(
+        id: String,
+        filterQuery: FilterQuery): List<CalibrateResultRow>
+    {
+        val res = apiClient.getCalibrateResultData(id)
+        val jsonBody = ObjectMapper().readTree(res.body?.toString())
+        val path = jsonBody.get("data").get("path").textValue()
+        return calibrateDataRepository.getFilteredCalibrateData(path, filterQuery)
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
@@ -54,7 +54,7 @@ class CalibrateDataRepositoryTests
     ))
     val query = FilterQuery(
         listOf("indicator_test_2"),
-        listOf("calendar_quarter_test"),
+        listOf(),
         listOf("age_group_test"),
         listOf("sex_test"),
         listOf("area_id_test"),

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
@@ -2,6 +2,7 @@ package org.imperial.mrc.hint.database
 
 import org.imperial.mrc.hint.db.JooqCalibrateDataRepository
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import org.imperial.mrc.hint.models.FilterQuery
 import org.junit.jupiter.api.Test
 import org.jooq.tools.json.JSONArray
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -51,6 +52,14 @@ class CalibrateDataRepositoryTests
             2
         )
     ))
+    val query = FilterQuery(
+        listOf("indicator_test_2"),
+        listOf("calendar_quarter_test"),
+        listOf("age_group_test"),
+        listOf("sex_test"),
+        listOf("area_id_test"),
+        listOf(2)
+    )
     val path = "/src/test/resources/duckdb/test.duckdb"
     val sut = JooqCalibrateDataRepository()
 
@@ -86,5 +95,14 @@ class CalibrateDataRepositoryTests
             sut.getDataFromPath("/src/test/resources/duckdb/test1.duckdb", "all")
         }.isInstanceOf(SQLException::class.java)
             .hasMessageContaining("database does not exist")
+    }
+
+    @Test
+    fun `can get filtered data`()
+    {
+        val plotData = sut.getFilteredCalibrateData(path, query)
+        val plotDataTree = ObjectMapper().readTree(JSONArray(plotData).toString())
+        val expectedTree = ObjectMapper().readTree(expectedRowIndicator2.toString())
+        assert(plotDataTree.equals(expectedTree))
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/CalibrateControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/CalibrateControllerTests.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.unit.controllers
 import org.junit.jupiter.api.Test
 import org.imperial.mrc.hint.models.ModelOptions
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import org.imperial.mrc.hint.models.FilterQuery
 import org.imperial.mrc.hint.clients.HintrAPIClient
 import org.imperial.mrc.hint.controllers.CalibrateController
 import org.imperial.mrc.hint.db.CalibrateDataRepository
@@ -27,6 +28,7 @@ class CalibrateControllerTests
     )
     private val mockDataFromPath = listOf(mockResultRow)
     private val mockJsonDataFromPath = ObjectMapper().writeValueAsString(JSONArray(mockDataFromPath))
+    private val filterQuery = FilterQuery(listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
 
     @Test
     fun `can submit calibrate`()
@@ -77,6 +79,21 @@ class CalibrateControllerTests
         val sut = CalibrateController(mockAPIClient, mockCalibrateDataService)
 
         val result = sut.calibrateResultData("testId", "all")
+        assertThat(result.body?.toString()).isEqualTo(
+            "{\"data\":$mockJsonDataFromPath,\"errors\":[],\"status\":\"success\"}"
+        )
+    }
+
+    @Test
+    fun `can get filtered calibrate result data`()
+    {
+        val mockAPIClient = mock<HintrAPIClient>()
+        val mockCalibrateDataService = mock<CalibrateDataService> {
+            on { getFilteredCalibrateData("testId", filterQuery) } doReturn mockDataFromPath
+        }
+        val sut = CalibrateController(mockAPIClient, mockCalibrateDataService)
+
+        val result = sut.filteredCalibrateResultData("testId", filterQuery)
         assertThat(result.body?.toString()).isEqualTo(
             "{\"data\":$mockJsonDataFromPath,\"errors\":[],\"status\":\"success\"}"
         )

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
@@ -65,23 +65,4 @@ class CalibrateResultRowTests
         val filterQueryJson = convertToJson(filterQuery)
         assert(expectedJsonFilterQuery.equals(filterQueryJson))
     }
-
-    @Test
-    fun `filter query iterator works as expected`()
-    {
-        val expectedList = listOf(
-            listOf("indicator", listOf("ind1", "ind2")),
-            listOf("calendar_quarter", listOf("cal1")),
-            listOf("age_group", listOf("age1")),
-            listOf("sex", listOf("sex1", "sex2", "sex3")),
-            listOf("area_id", listOf("area1")),
-            listOf("area_level", listOf(1, 2, 3, 4))
-        )
-        var i = 0
-        for ((field, values) in filterQuery) {
-            assert(field == expectedList[i][0])
-            assert(values == expectedList[i][1])
-            i++
-        }
-    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
@@ -2,6 +2,7 @@ package org.imperial.mrc.hint.unit.model
 
 import org.junit.jupiter.api.Test
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import org.imperial.mrc.hint.models.FilterQuery
 import com.fasterxml.jackson.databind.ObjectMapper
 
 class CalibrateResultRowTests
@@ -33,5 +34,32 @@ class CalibrateResultRowTests
         val jsonRow = ObjectMapper().writeValueAsString(row)
         val json = ObjectMapper().readTree(jsonRow)
         assert(json.equals(expectedJson))
+    }
+
+    @Test
+    fun `filter query iterator works as expected`()
+    {
+        val filterQuery = FilterQuery(
+            listOf("ind1", "ind2"),
+            listOf("cal1"),
+            listOf("age1"),
+            listOf("sex1", "sex2", "sex3"),
+            listOf("area1"),
+            listOf(1, 2, 3, 4)
+        )
+        val expectedList = listOf(
+            listOf("indicator", listOf("ind1", "ind2")),
+            listOf("calendar_quarter", listOf("cal1")),
+            listOf("age_group", listOf("age1")),
+            listOf("sex", listOf("sex1", "sex2", "sex3")),
+            listOf("area_id", listOf("area1")),
+            listOf("area_level", listOf(1, 2, 3, 4))
+        )
+        var i = 0
+        for ((field, values) in filterQuery) {
+            assert(field == expectedList[i][0])
+            assert(values == expectedList[i][1])
+            i++
+        }
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/model/CalibrateResultRowTests.kt
@@ -4,10 +4,18 @@ import org.junit.jupiter.api.Test
 import org.imperial.mrc.hint.models.CalibrateResultRow
 import org.imperial.mrc.hint.models.FilterQuery
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
 
 class CalibrateResultRowTests
 {
-    val expectedJsonMap = mapOf(
+    fun convertToJson(input: Any): JsonNode
+    {
+        val objectMapper = ObjectMapper()
+        val raw = objectMapper.writeValueAsString(input)
+        return objectMapper.readTree(raw)
+    }
+
+    val expectedRowJsonMap = mapOf(
         "indicator" to "indicator_test",
         "calendar_quarter" to "calendar_quarter_test",
         "age_group" to "age_group_test",
@@ -17,8 +25,15 @@ class CalibrateResultRowTests
         "mode" to 1, "lower" to 1,
         "area_level" to 1
     )
-    val expectedJsonString = ObjectMapper().writeValueAsString(expectedJsonMap)
-    val expectedJson = ObjectMapper().readTree(expectedJsonString)
+    val expectedRowJson = convertToJson(expectedRowJsonMap)
+    val filterQuery = FilterQuery(
+        listOf("ind1", "ind2"),
+        listOf("cal1"),
+        listOf("age1"),
+        listOf("sex1", "sex2", "sex3"),
+        listOf("area1"),
+        listOf(1, 2, 3, 4)
+    )
 
     @Test
     fun `result row serialises with correct json keys`()
@@ -31,22 +46,29 @@ class CalibrateResultRowTests
             "area_id_test",
             1, 1, 1, 1, 1
         )
-        val jsonRow = ObjectMapper().writeValueAsString(row)
-        val json = ObjectMapper().readTree(jsonRow)
-        assert(json.equals(expectedJson))
+        val json = convertToJson(row)
+        assert(json.equals(expectedRowJson))
+    }
+
+    @Test
+    fun `filter query serialises with correct json keys`()
+    {
+        val expectedFilterJsonMap = mapOf(
+            "indicator" to listOf("ind1", "ind2"),
+            "calendar_quarter" to listOf("cal1"),
+            "age_group" to listOf("age1"),
+            "sex" to listOf("sex1", "sex2", "sex3"),
+            "area_id" to listOf("area1"),
+            "area_level" to listOf(1, 2, 3, 4)
+        )
+        val expectedJsonFilterQuery = convertToJson(expectedFilterJsonMap)
+        val filterQueryJson = convertToJson(filterQuery)
+        assert(expectedJsonFilterQuery.equals(filterQueryJson))
     }
 
     @Test
     fun `filter query iterator works as expected`()
     {
-        val filterQuery = FilterQuery(
-            listOf("ind1", "ind2"),
-            listOf("cal1"),
-            listOf("age1"),
-            listOf("sex1", "sex2", "sex3"),
-            listOf("area1"),
-            listOf(1, 2, 3, 4)
-        )
         val expectedList = listOf(
             listOf("indicator", listOf("ind1", "ind2")),
             listOf("calendar_quarter", listOf("cal1")),

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/service/CalibrateDataServiceTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/service/CalibrateDataServiceTests.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import org.imperial.mrc.hint.clients.HintrAPIClient
 import org.imperial.mrc.hint.db.CalibrateDataRepository
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import org.imperial.mrc.hint.models.FilterQuery
 import org.imperial.mrc.hint.security.Session
 import org.imperial.mrc.hint.service.CalibrateDataService
 import org.imperial.mrc.hint.unit.ADRClientBuilderTests
@@ -23,6 +24,8 @@ class CalibrateDataServiceTests
         "testIndicator", "testCalendarQuarter", "testAgeGroup", "testSex",
         "testAreaId", 1, 2, 3, 4, 5
     )
+
+    private val filterQuery = FilterQuery(listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
 
     @Test
     fun `can get calibrate data`()
@@ -43,6 +46,29 @@ class CalibrateDataServiceTests
         val sut = CalibrateDataService(mockClient, mockCalibrateDataRepo, mockSession)
 
         val dataObj = sut.getCalibrateData("anyPath", "all")
+
+        assert(dataObj[0] == mockResultRow)
+    }
+
+    @Test
+    fun `can get filtered calibrate data`()
+    {
+        val mockClient = mock<HintrAPIClient> {
+            on { getCalibrateResultData(anyString()) } doReturn mockCalibratePathResponse
+        }
+
+        val mockCalibrateDataRepo = mock<CalibrateDataRepository> {
+            on { getFilteredCalibrateData("testPath", filterQuery) } doReturn listOf(mockResultRow)
+        }
+
+        val mockSession = mock<Session> {
+            on { getUserProfile() } doReturn CommonProfile().apply { id = ADRClientBuilderTests.TEST_EMAIL }
+            on { getAccessToken() } doReturn "FAKE_TOKEN"
+        }
+
+        val sut = CalibrateDataService(mockClient, mockCalibrateDataRepo, mockSession)
+
+        val dataObj = sut.getFilteredCalibrateData("anyPath", filterQuery)
 
         assert(dataObj[0] == mockResultRow)
     }

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -84,7 +84,7 @@ export interface WarningsState {
 
 const persistState = (store: Store<RootState>): void => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
-        // console.log(mutation.type);
+        console.log(mutation.type);
         localStorageManager.saveState(state);
 
         const {dispatch} = store;

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -84,7 +84,7 @@ export interface WarningsState {
 
 const persistState = (store: Store<RootState>): void => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
-        console.log(mutation.type);
+        // console.log(mutation.type);
         localStorageManager.saveState(state);
 
         const {dispatch} = store;


### PR DESCRIPTION
## Description

I am not 100% sure if this is the best way to do this but the general strategy for constructing the SQL statement that I have gone for is to build the prepared SQL statement based on the request.

I have added an iterator operator to the FilterQuery data class so that we can loop over its values easily.

We should be able to test this soon with the next PR (frontend support for this endpoint) but for this PR just adding a new endpoint. You could curl if you want to really test it or postman but it'll probably be easier to rely on the unit tests for this PR and manually test next PR. If you really want to test it the request body should look like:

```JSON
{
  "indicator": [],
  "calendar_quarter": [],
  "age_group": [],
  "sex": [],
  "area_id": [],
  "area_level": []
}
```

and fill in whatever you would like to filter by (remember all of them have string values **except** `area_level` which has an integer value)

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
