### PR TITLE
Mrc 5039 new state for plot selection + commit defaults into state

### DIFF
--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -119,105 +119,138 @@ export interface CalibrateDataResponse {
   [k: string]: any;
 }
 export interface CalibrateMetadataResponse {
-  plottingMetadata: {
-    barchart: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        indicator_column: string;
-        indicator_value: string;
-        indicator_sort_order?: number;
-        name: string;
-        error_low_column: string;
-        error_high_column: string;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults?: {
-        indicator_id: string;
-        x_axis_id: string;
-        disaggregate_by_id: string;
-        selected_filter_options: {
-          [k: string]: any;
-        };
-      };
-    };
-    choropleth: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        error_low_column?: string;
-        error_high_column?: string;
-        indicator_column?: string;
-        indicator_value?: string;
-        indicator_sort_order?: number;
-        name: string;
-        min: number;
-        max: number;
-        colour: string;
-        invert_scale: boolean;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-    };
-  };
-  tableMetadata: {
-    presets: {
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults: {
-        id: string;
-        label: string;
-        column: {
-          id: string;
-          label: string;
-        };
-        row: {
-          id: string;
-          label: string;
-        };
-        selected_filter_options?: {
-          /**
-           * This interface was referenced by `undefined`'s JSON-Schema definition
-           * via the `patternProperty` "^.*$".
-           */
-          [k: string]: string[];
-        };
-      };
+  filterTypes: {
+    id: string;
+    column_id: string;
+    options: {
+      label: string;
+      id: string;
+      description?: string;
     }[];
+    use_shape_regions?: boolean;
+  }[];
+  indicators: {
+    indicator: string;
+    value_column: string;
+    error_low_column?: string;
+    error_high_column?: string;
+    indicator_column?: string;
+    indicator_value?: string;
+    indicator_sort_order?: number;
+    name: string;
+    min: number;
+    max: number;
+    colour: string;
+    invert_scale: boolean;
+    scale: number;
+    accuracy: number | null;
+    format: string;
+  }[];
+  plotSettingsControl: {
+    choropleth: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
+    barchart: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
+    table: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
+    bubble: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
   };
   warnings: {
     text: string;
@@ -320,106 +353,6 @@ export interface CalibrateResultResponse {
     upper: number | null;
     [k: string]: any;
   }[];
-  plottingMetadata: {
-    barchart: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        indicator_column: string;
-        indicator_value: string;
-        indicator_sort_order?: number;
-        name: string;
-        error_low_column: string;
-        error_high_column: string;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults?: {
-        indicator_id: string;
-        x_axis_id: string;
-        disaggregate_by_id: string;
-        selected_filter_options: {
-          [k: string]: any;
-        };
-      };
-    };
-    choropleth: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        error_low_column?: string;
-        error_high_column?: string;
-        indicator_column?: string;
-        indicator_value?: string;
-        indicator_sort_order?: number;
-        name: string;
-        min: number;
-        max: number;
-        colour: string;
-        invert_scale: boolean;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-    };
-  };
-  tableMetadata: {
-    presets: {
-      filters: {
-        id: string;
-        column_id: string;
-        label: string;
-        options: {
-          label: string;
-          id: string;
-          description?: string;
-        }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults: {
-        id: string;
-        label: string;
-        column: {
-          id: string;
-          label: string;
-        };
-        row: {
-          id: string;
-          label: string;
-        };
-        selected_filter_options?: {
-          /**
-           * This interface was referenced by `undefined`'s JSON-Schema definition
-           * via the `patternProperty` "^.*$".
-           */
-          [k: string]: string[];
-        };
-      };
-    }[];
-  };
   warnings: {
     text: string;
     locations: (
@@ -788,6 +721,21 @@ export interface FilterOption {
   label: string;
   id: string;
   description?: string;
+}
+export interface FilterRef {
+  filterId: string;
+  label: string;
+  stateFilterId: string;
+}
+export interface FilterTypes {
+  id: string;
+  column_id: string;
+  options: {
+    label: string;
+    id: string;
+    description?: string;
+  }[];
+  use_shape_regions?: boolean;
 }
 export interface HintrVersionResponse {
   [k: string]: string;
@@ -1281,6 +1229,77 @@ export interface Note {
 export interface PjnzResponseData {
   country: string;
   iso3: string;
+}
+export interface PlotSetting {
+  id: string;
+  label: string;
+  options: {
+    id: string;
+    label: string;
+    effect: {
+      setFilters?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      setMultiple?: string[];
+      setFilterValues?: {
+        [k: string]: string[];
+      };
+    };
+  }[];
+}
+export interface PlotSettingEffect {
+  setFilters?: {
+    filterId: string;
+    label: string;
+    stateFilterId: string;
+  }[];
+  setMultiple?: string[];
+  setFilterValues?: {
+    [k: string]: string[];
+  };
+}
+export interface PlotSettingOption {
+  id: string;
+  label: string;
+  effect: {
+    setFilters?: {
+      filterId: string;
+      label: string;
+      stateFilterId: string;
+    }[];
+    setMultiple?: string[];
+    setFilterValues?: {
+      [k: string]: string[];
+    };
+  };
+}
+export interface PlotSettingsControl {
+  defaultFilterTypes?: {
+    filterId: string;
+    label: string;
+    stateFilterId: string;
+  }[];
+  plotSettings: {
+    id: string;
+    label: string;
+    options: {
+      id: string;
+      label: string;
+      effect: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
+    }[];
+  }[];
 }
 export interface PlottingMetadataResponse {
   survey: Metadata;

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -86,7 +86,7 @@ export interface WarningsState {
 
 const persistState = (store: Store<RootState>): void => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
-        // console.log(mutation.type);
+        console.log(mutation.type);
         localStorageManager.saveState(state);
 
         const {dispatch} = store;

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -50,6 +50,7 @@ import {
     DownloadIndicatorState,
     initialDownloadIndicatorState
 } from "./store/downloadIndicator/downloadIndicator";
+import { initialPlotSelectionsState, PlotSelectionsState, plotSelections } from "./store/plotSelections/plotSelections";
 
 export interface RootState extends DataExplorationState {
     version: string,
@@ -65,6 +66,7 @@ export interface RootState extends DataExplorationState {
     modelCalibrate: ModelCalibrateState,
     modelOutput: ModelOutputState,
     plottingSelections: PlottingSelectionsState,
+    plotSelections: PlotSelectionsState,
     load: LoadState,
     errors: ErrorsState,
     projects: ProjectsState
@@ -84,7 +86,7 @@ export interface WarningsState {
 
 const persistState = (store: Store<RootState>): void => {
     store.subscribe((mutation: MutationPayload, state: RootState) => {
-        console.log(mutation.type);
+        // console.log(mutation.type);
         localStorageManager.saveState(state);
 
         const {dispatch} = store;
@@ -168,6 +170,7 @@ export const emptyState = (): RootState => {
         stepper: initialStepperState(),
         load: initialLoadState(),
         plottingSelections: initialPlottingSelectionsState(),
+        plotSelections: initialPlotSelectionsState(),
         errors: initialErrorsState(),
         projects: initialProjectsState(),
         currentUser: currentUser,
@@ -195,6 +198,7 @@ export const storeOptions: StoreOptions<RootState> = {
         modelRun: modelRun(existingState),
         modelOutput: modelOutput(existingState),
         plottingSelections: plottingSelections(existingState),
+        plotSelections,
         stepper: stepper(existingState),
         load,
         errors,

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -187,7 +187,6 @@ export const getResultMetadata = async function (context: ActionContext<ModelCal
 
     if (response) {
         const data = response.data;
-        console.log(data)
         commit({type: ModelCalibrateMutation.MetadataFetched, payload: data});
 
         commitPlotDefaultSelections(data, commit, rootState);

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -19,6 +19,7 @@ import {CalibrateResultWithType, Dict, ModelOutputTabs} from "../../types";
 import {DownloadResultsMutation} from "../downloadResults/mutations";
 import {PlottingSelectionsMutations} from "../plottingSelections/mutations";
 import { ModelOutputMutation } from "../modelOutput/mutations";
+import { commitPlotDefaultSelections } from "../plotSelections/utils";
 
 type ResultDataPayload = {
     indicatorId: string,
@@ -116,7 +117,8 @@ export const actions: ActionTree<ModelCalibrateState, RootState> & ModelCalibrat
 
         if (response) {
             if (response.data) {
-                selectFilterDefaults(response.data, commit, PlottingSelectionsMutations.updateComparisonPlotSelections)
+                // TODO:PC
+                // selectFilterDefaults(response.data, commit, PlottingSelectionsMutations.updateComparisonPlotSelections)
             }
             commit(ModelCalibrateMutation.SetComparisonPlotData, response.data);
         }
@@ -174,7 +176,7 @@ export const fetchFirstNIndicators = async (dispatch: Dispatch, indicators: Barc
 };
 
 export const getResultMetadata = async function (context: ActionContext<ModelCalibrateState, RootState>) {
-    const {commit, dispatch, state} = context;
+    const {commit, dispatch, state, rootState} = context;
     const calibrateId = state.calibrateId;
 
     const response = await api<ModelCalibrateMutation, ModelCalibrateMutation>(context)
@@ -185,15 +187,12 @@ export const getResultMetadata = async function (context: ActionContext<ModelCal
 
     if (response) {
         const data = response.data;
+        console.log(data)
         commit({type: ModelCalibrateMutation.MetadataFetched, payload: data});
 
-        selectFilterDefaults(data, commit, PlottingSelectionsMutations.updateBarchartSelections)
+        commitPlotDefaultSelections(data, commit, rootState);
 
-        const indicators = data.plottingMetadata.barchart.indicators;
-        await fetchFirstNIndicators(dispatch, indicators, 5);
-        
         commit(ModelCalibrateMutation.Calibrated);
-
 
         if (switches.modelCalibratePlot) {
             dispatch("getCalibratePlot");

--- a/src/app/static/src/app/store/plotSelections/mutations.ts
+++ b/src/app/static/src/app/store/plotSelections/mutations.ts
@@ -14,5 +14,6 @@ export type PlotSelectionUpdate = {
 export const mutations: MutationTree<PlotSelectionsState> = {
     [PlotSelectionsMutations.updatePlotSelection](state: PlotSelectionsState, action: PayloadWithType<PlotSelectionUpdate>) {
         state[action.payload.plot] = action.payload.selections;
+        console.log(state)
     }
 };

--- a/src/app/static/src/app/store/plotSelections/mutations.ts
+++ b/src/app/static/src/app/store/plotSelections/mutations.ts
@@ -14,6 +14,5 @@ export type PlotSelectionUpdate = {
 export const mutations: MutationTree<PlotSelectionsState> = {
     [PlotSelectionsMutations.updatePlotSelection](state: PlotSelectionsState, action: PayloadWithType<PlotSelectionUpdate>) {
         state[action.payload.plot] = action.payload.selections;
-        console.log(state)
     }
 };

--- a/src/app/static/src/app/store/plotSelections/mutations.ts
+++ b/src/app/static/src/app/store/plotSelections/mutations.ts
@@ -1,0 +1,18 @@
+import { MutationTree } from "vuex";
+import { PlotName, PlotSelectionsState } from "./plotSelections";
+import { PayloadWithType } from "../../types";
+
+export enum PlotSelectionsMutations {
+    updatePlotSelection = "updatePlotSelection"
+}
+
+export type PlotSelectionUpdate = {
+    plot: PlotName,
+    selections: PlotSelectionsState[PlotName]
+}
+
+export const mutations: MutationTree<PlotSelectionsState> = {
+    [PlotSelectionsMutations.updatePlotSelection](state: PlotSelectionsState, action: PayloadWithType<PlotSelectionUpdate>) {
+        state[action.payload.plot] = action.payload.selections;
+    }
+};

--- a/src/app/static/src/app/store/plotSelections/plotSelections.ts
+++ b/src/app/static/src/app/store/plotSelections/plotSelections.ts
@@ -1,0 +1,26 @@
+import { CalibrateMetadataResponse, FilterOption } from "../../generated";
+import { mutations } from "./mutations";
+
+export type PlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
+const plotNames: PlotName[] = ["barchart", "choropleth", "bubble", "table"]
+
+export type PlotSelectionsState = {
+    [P in PlotName]: {
+        controls: Record<string, FilterOption[]>
+        filterSelections: Record<string, FilterOption[]>
+    }
+}
+
+export const initialPlotSelectionsState = (): PlotSelectionsState => {
+    const emptySelections = {
+        controls: {},
+        filterSelections: {}
+    };
+    return Object.fromEntries(plotNames.map(plot => [plot, emptySelections])) as PlotSelectionsState;
+}
+
+export const plotSelections = {
+    namespaced: true,
+    state: initialPlotSelectionsState(),
+    mutations
+};

--- a/src/app/static/src/app/store/plotSelections/plotSelections.ts
+++ b/src/app/static/src/app/store/plotSelections/plotSelections.ts
@@ -4,10 +4,17 @@ import { mutations } from "./mutations";
 export type PlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
 const plotNames: PlotName[] = ["barchart", "choropleth", "bubble", "table"]
 
+type FilterConfigValue = {
+    filterId: string
+    label: string
+    multiple: boolean
+}
+
 export type PlotSelectionsState = {
     [P in PlotName]: {
         controls: Record<string, FilterOption[]>
-        filterSelections: Record<string, FilterOption[]>
+        filterSelections: Record<string, FilterOption[]>,
+        filterConfig: Record<string, FilterConfigValue>
     }
 }
 

--- a/src/app/static/src/app/store/plotSelections/plotSelections.ts
+++ b/src/app/static/src/app/store/plotSelections/plotSelections.ts
@@ -1,28 +1,29 @@
-import { CalibrateMetadataResponse, FilterOption } from "../../generated";
+import { CalibrateMetadataResponse, FilterOption, FilterRef } from "../../generated";
 import { mutations } from "./mutations";
 
 export type PlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
 const plotNames: PlotName[] = ["barchart", "choropleth", "bubble", "table"]
 
-type FilterConfigValue = {
-    filterId: string
-    label: string
+export type FilterSelection = {
     multiple: boolean
+    selection: FilterOption[]
+} & FilterRef
+
+export type ControlSelection = {
+    id: string,
+    label: string,
+    selection: FilterOption[]
 }
 
 export type PlotSelectionsState = {
     [P in PlotName]: {
-        controls: Record<string, FilterOption[]>
-        filterSelections: Record<string, FilterOption[]>,
-        filterConfig: Record<string, FilterConfigValue>
+        controls: ControlSelection[]
+        filters: FilterSelection[]
     }
 }
 
 export const initialPlotSelectionsState = (): PlotSelectionsState => {
-    const emptySelections = {
-        controls: {},
-        filterSelections: {}
-    };
+    const emptySelections: PlotSelectionsState[PlotName] = { controls: [], filters: [] };
     return Object.fromEntries(plotNames.map(plot => [plot, emptySelections])) as PlotSelectionsState;
 }
 

--- a/src/app/static/src/app/store/plotSelections/utils.ts
+++ b/src/app/static/src/app/store/plotSelections/utils.ts
@@ -24,23 +24,14 @@ type NestedFilterOption = {
     children?: NestedFilterOption[]
 }
 
-class Q {
-    items: NestedFilterOption[]
-    constructor() { this.items = [] }
-    enqueue(item: NestedFilterOption) { this.items.push(item) }
-    dequeue() { return this.items.pop()! }
-    isEmpty() { return this.items.length === 0 }
-}
-
 const getFullNestedFilters = (filterOptions: NestedFilterOption[]) => {
     const fullFilterOptions: NestedFilterOption[] = [];
-    const q = new Q();
-    filterOptions.forEach(op => q.enqueue(op));
-    while (!q.isEmpty()) {
-        const currentOption = q.dequeue();
+    const q = [...filterOptions];
+    while (q.length !== 0) {
+        const currentOption = q.pop()!;
         fullFilterOptions.push(currentOption);
         if (currentOption.children && currentOption.children.length > 0) {
-            currentOption.children.forEach(op => q.enqueue(op));
+            currentOption.children.forEach(op => q.push(op));
         }
     }
     return fullFilterOptions;

--- a/src/app/static/src/app/store/plotSelections/utils.ts
+++ b/src/app/static/src/app/store/plotSelections/utils.ts
@@ -1,0 +1,91 @@
+import { Commit } from "vuex";
+import { CalibrateMetadataResponse, FilterOption, FilterTypes } from "../../generated";
+import { PlotName } from "./plotSelections";
+import { PlotSelectionUpdate, PlotSelectionsMutations } from "./mutations";
+import { RootState } from "../../root";
+
+export const filtersAfterUseShapeRegions = (filterTypes: FilterTypes[], rootState: RootState) => {
+    const filters = [...filterTypes];
+    const area = filters.find(f => f.id == "area");
+    if (area && area.use_shape_regions) {
+        const regions: FilterOption[] = rootState.baseline.shape!.filters!.regions ?
+            [rootState.baseline.shape!.filters!.regions] : [];
+
+        const index = filters.findIndex(f => f.id === "area");
+        const { use_shape_regions, ...areaFilterConfig } = area;
+        filters[index] = { ...areaFilterConfig, options: regions };
+    }
+    return filters;
+};
+
+export const commitPlotDefaultSelections = (metadata: CalibrateMetadataResponse, commit: Commit, rootState: RootState) => {
+    const plotControl = metadata.plotSettingsControl;
+    const filters = filtersAfterUseShapeRegions(metadata.filterTypes, rootState);
+    for (const plotName in plotControl) {
+        const name = plotName as PlotName;
+        const selectionsInState: PlotSelectionUpdate = {
+            plot: name,
+            selections: {
+                controls: {},
+                filterSelections: {}
+            }
+        };
+        const control = plotControl[plotName as PlotName];
+        let filterTypes = control.defaultFilterTypes;
+        let multiFitlers: string[] = [];
+        let filterValues: Record<string, string[]> = {}
+
+        // add default control options to state object and get filters
+        control.plotSettings.forEach(setting => {
+            const defaultOption = setting.options[0];
+            if (setting.id !== "default") {
+                selectionsInState.selections.controls[setting.id] = [{ id: defaultOption.id, label: defaultOption.label }];
+            }
+
+            // resolve effects
+            const effect = defaultOption.effect;
+            if (effect.setFilters) {
+                filterTypes = effect.setFilters;
+            }
+            if (effect.setMultiple) {
+                // remove dupes just in case
+                multiFitlers = [...new Set([...multiFitlers, ...effect.setMultiple])];
+            }
+            if (effect.setFilterValues) {
+                filterValues = {...filterValues, ...effect.setFilterValues};
+            }
+        });
+
+        // we can now combine all the data to get filterSelections
+        filterTypes!.forEach(f => {
+            const filter = filters.find(filterType => filterType.id === f.filterId)!;
+            
+            // TODO need to consider nested children
+            if (multiFitlers.includes(f.stateFilterId)) {
+                selectionsInState.selections.filterSelections[f.stateFilterId] = filter.options;
+            } else {
+                selectionsInState.selections.filterSelections[f.stateFilterId] = [filter.options[0]];
+            }
+
+            if (f.stateFilterId in filterValues) {
+                const optionIds = filterValues[f.stateFilterId];
+                const filterOptions = [];
+                for (let i = 0; i < filter.options.length; i++) {
+                    if (optionIds.includes(filter.options[i].id)) {
+                        filterOptions.push(filter.options[i]);
+                    }
+                    if (filterOptions.length === optionIds.length) {
+                        break;
+                    }
+                }
+                selectionsInState.selections.filterSelections[f.stateFilterId] = filterOptions;
+            }
+        });
+
+        commit(
+            `plotSelections/${PlotSelectionsMutations.updatePlotSelection}`,
+            { payload: selectionsInState },
+            { root: true }
+        );
+    }
+};

--- a/src/app/static/src/tests/plotSelections/mutations.test.ts
+++ b/src/app/static/src/tests/plotSelections/mutations.test.ts
@@ -1,0 +1,19 @@
+import { mutations } from "../../app/store/plotSelections/mutations";
+
+describe("Plot selections mutations", () => {
+    it("commits plot selections as expected", () => {
+        const testState = {
+            barchart: {},
+            choropleth: {}
+        };
+        const payload = {
+            plot: "barchart",
+            selections: { filter: "testFilter" }
+        };
+        mutations.updatePlotSelection(testState as any, { payload });
+        expect(testState).toStrictEqual({
+            barchart: { filter: "testFilter" },
+            choropleth: {}
+        });
+    });
+});

--- a/src/app/static/src/tests/plotSelections/utils.test.ts
+++ b/src/app/static/src/tests/plotSelections/utils.test.ts
@@ -1,0 +1,24 @@
+import { filtersAfterUseShapeRegions } from "../../app/store/plotSelections/utils";
+
+describe("Plot selections utils", () => {
+    it("filtersAfterUseShapeRegions works as expected", () => {
+        const filters = [
+            {id: "area", options: null, use_shape_regions: true},
+            {id: "other", options: []}
+        ];
+        const rootState = {
+            baseline: {
+                shape: {
+                    filters: {
+                        regions: { id: "testRegions" }
+                    }
+                }
+            }
+        };
+        expect(filtersAfterUseShapeRegions(filters as any, rootState as any))
+            .toStrictEqual([
+                {id: "area", options: [{id: "testRegions"}]},
+                {id: "other", options: []}
+            ])
+    });
+});

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-mrc-4959
+tmp-epic-plot-cleanup


### PR DESCRIPTION
## Description

For now just take a look at functionality changes, will add tests once all the choices are settled (we have changed approaches a couple times already).

### Key changes

* Add new `plotSelections` state
* Commit default selections into state as soon as metadata is received (this involved computing all effects logic too)

Note: We initially were going to do empty plotControls for choropleth since it doesn't have any plot controls but we want certain effect to be default such as the area being multiselect so have included a plot control with id "default" but this approach is up for debate!

For reference of the metadata structure see https://github.com/mrc-ide/hintr/pull/491, I will address the comments in that PR soon too!

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
