### PR TITLE
Update duckdb version to stable release

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation "org.simplejavamail:simple-java-mail:6.5.0"
     implementation 'jakarta.mail:jakarta.mail-api:1.6.7'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
-    implementation 'org.duckdb:duckdb_jdbc:0.9.1'
+    implementation 'org.duckdb:duckdb_jdbc:0.10.0'
 
     implementation project(":databaseInterface")
 


### PR DESCRIPTION
## Description

DuckDB have released version 0.10.0 which brings backwards compatibility and forwards compatibility! See https://duckdb.org/2024/02/13/announcing-duckdb-0100.html

This will help with quite an annoying dependency which we have pinned in the R impl, if we update everything to 0.10.0 should hopefully be simpler to install and going forwards mean we don't have to pin our version in R to the same as in the backend

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
