### PR TITLE
Mrc 5233 Add input time series

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/HintrAPIClient.kt
@@ -32,6 +32,7 @@ interface HintrAPIClient
     fun calibrateSubmit(runId: String, calibrationOptions: ModelOptions): ResponseEntity<String>
     fun getCalibrateStatus(id: String): ResponseEntity<String>
     fun getCalibrateResultMetadata(id: String): ResponseEntity<String>
+    fun getReviewInputMetadata(iso3: String, files: Map<String, VersionFileWithPath>): ResponseEntity<String>
     fun getCalibrateResultData(id: String): ResponseEntity<String>
     fun getCalibratePlot(id: String): ResponseEntity<String>
     fun getComparisonPlot(id: String): ResponseEntity<String>
@@ -152,6 +153,13 @@ class HintrFuelAPIClient(
     override fun getCalibrateResultMetadata(id: String): ResponseEntity<String>
     {
         return get("calibrate/result/metadata/${id}")
+    }
+
+    override fun getReviewInputMetadata(iso3: String, files: Map<String, VersionFileWithPath>): ResponseEntity<String>
+    {
+        val json = objectMapper.writeValueAsString(
+                mapOf("data" to files, "iso3" to iso3))
+        return postJson("review-input/metadata", json)
     }
 
     override fun getCalibrateResultData(id: String): ResponseEntity<String>

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
@@ -54,6 +54,7 @@ class MetadataController(val apiClient: HintrAPIClient,
                 "anc" -> FileType.ANC
                 "programme" -> FileType.Programme
                 "survey" -> FileType.Survey
+                "shape" -> FileType.Shape
                 else -> throw HintException("unknownReviewInputFileType", HttpStatus.BAD_REQUEST)
             }
             it to fileManager.getFile(fileType)!!

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
@@ -8,13 +8,18 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import org.imperial.mrc.hint.clients.HintrAPIClient
 import org.imperial.mrc.hint.models.SuccessResponse
 import org.imperial.mrc.hint.models.asResponseEntity
+import org.imperial.mrc.hint.FileManager
+import org.imperial.mrc.hint.FileType
+import org.imperial.mrc.hint.exceptions.HintException
 import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/meta")
 class MetadataController(val apiClient: HintrAPIClient,
-                         private val classLoader: ClassLoader = MetadataController::class.java.classLoader)
+                         private val classLoader: ClassLoader = MetadataController::class.java.classLoader,
+                         val fileManager: FileManager)
 {
     @GetMapping("/plotting/{iso3}")
     @ResponseBody
@@ -36,6 +41,26 @@ class MetadataController(val apiClient: HintrAPIClient,
     {
         return apiClient.getUploadMetadata(id)
     }
+
+    data class TypesPayload(val types: Array<String>)
+
+    @PostMapping("/review-inputs/{iso3}")
+    @ResponseBody
+    fun reviewInputMetadata(@PathVariable("iso3") iso3: String,
+                            @RequestBody req: TypesPayload): ResponseEntity<String>
+    {
+        val files = req.types.map {
+            val fileType = when(it.lowercase()) {
+                "anc" -> FileType.ANC
+                "programme" -> FileType.Programme
+                "survey" -> FileType.Survey
+                "shape" -> FileType.Shape
+                else -> throw HintException("unknownInputTimeSeriesType", HttpStatus.BAD_REQUEST)
+            }
+            it to fileManager.getFile(fileType)!!
+        }.toMap()
+        return apiClient.getReviewInputMetadata(iso3, files)
+    } 
 
     @GetMapping("/generic-chart")
     @ResponseBody

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/MetadataController.kt
@@ -54,8 +54,7 @@ class MetadataController(val apiClient: HintrAPIClient,
                 "anc" -> FileType.ANC
                 "programme" -> FileType.Programme
                 "survey" -> FileType.Survey
-                "shape" -> FileType.Shape
-                else -> throw HintException("unknownInputTimeSeriesType", HttpStatus.BAD_REQUEST)
+                else -> throw HintException("unknownReviewInputFileType", HttpStatus.BAD_REQUEST)
             }
             it to fileManager.getFile(fileType)!!
         }.toMap()

--- a/src/app/src/main/resources/ErrorMessageBundle.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle.properties
@@ -16,3 +16,4 @@ noPermissionToAccessResource=You do not have permission to load this resource fr
 adrResourceError=Unable to load resource, check resource in ADR {0}.
 adrFetchingDatasetsError=There was an error fetching datasets from ADR.
 adrFetchingDatasetsNoAccountError=Cannot fetch datasets from the ADR as you do not yet have an account. Please login to the ADR with your Auth0 credentials and then return here and try again.
+unknownReviewInputFileType=Unknown review input plot file type.

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -17,3 +17,4 @@ noPermissionToAccessResource=Vous n''êtes pas autorisé à charger cette ressou
 adrResourceError=Impossible de charger la ressource, vérifiez la ressource dans ADR {0}.
 adrFetchingDatasetsError=Une erreur s'est produite lors de la récupération des ensembles de données à partir d'ADR
 adrFetchingDatasetsNoAccountError=Impossible de récupérer les ensembles de données de l'ADR car vous n'avez pas encore de compte. Veuillez vous connecter à l'ADR avec vos informations d'identification Auth0, puis revenir ici et réessayer.
+unknownReviewInputFileType=Type de fichier de tracé d'entrée de révision inconnu.

--- a/src/app/src/main/resources/ErrorMessageBundle_pt.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_pt.properties
@@ -16,3 +16,4 @@ noPermissionToAccessResource=Você não tem permissão para carregar este recurs
 adrResourceError=Não é possível carregar o recurso, verifique o recurso no ADR {0}.
 adrFetchingDatasetsError=Ocorreu um erro ao obter conjuntos de dados do ADR
 adrFetchingDatasetsNoAccountError=Não é possível buscar conjuntos de dados do ADR porque você ainda não possui uma conta. Faça login no ADR com suas credenciais Auth0, retorne aqui e tente novamente.
+unknownReviewInputFileType=Tipo de arquivo de plotagem de entrada de revisão desconhecido.

--- a/src/app/src/main/resources/metadata/generic-chart.json
+++ b/src/app/src/main/resources/metadata/generic-chart.json
@@ -159,8 +159,8 @@
     "subplots": {
       "columns": 3,
       "distinctColumn": "area_id",
-      "heightPerRow": 140,
-      "subplotsPerPage": 99
+      "heightPerRow": 160,
+      "subplotsPerPage": 12
     },
     "valueFormatColumn": "plot_type",
     "chartConfig": [

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -31,7 +31,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private readonly _commit: Commit;
     private readonly _headers: any;
 
-    constructor(context: ActionContext<any, TranslatableState>) {
+    constructor(context: APIContext) {
         this._commit = context.commit;
         this._headers = {"Accept-Language": context.rootState.language};
     }
@@ -221,5 +221,10 @@ export class APIService<S extends string, E extends string> implements API<S, E>
 
 }
 
+type APIContext = {
+    commit: Commit,
+    rootState: TranslatableState
+}
+
 export const api =
-    <S extends string, E extends string>(context: ActionContext<any, TranslatableState>) => new APIService<S, E>(context);
+    <S extends string, E extends string>(context: APIContext) => new APIService<S, E>(context);

--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <ul class="nav nav-tabs">
-            <li v-for="plotName of plotNames" :key="plotName">
+            <li v-for="plotName of outputPlotNames" :key="plotName">
                 <a class="nav-link"
                    :class="selectedPlot === plotName ? 'active': ''"
                    v-translate="plotName"
@@ -10,9 +10,9 @@
         </ul>
         <div class="row">
             <div class="mt-2 col-md-3">
-                <plot-control-set/>
+                <plot-control-set :plot="selectedPlot"/>
                 <h4 v-translate="'filters'"/>
-                <filter-set/>
+                <filter-set :plot="selectedPlot"/>
             </div>
             <choropleth class="col-md-9" v-if="selectedPlot === 'choropleth'"/>
             <bubble class="col-md-9" v-if="selectedPlot === 'bubble'"/>
@@ -24,7 +24,7 @@
 import {computed, defineComponent} from "vue";
 import FilterSet from "../plots/FilterSet.vue";
 import PlotControlSet from "../plots/PlotControlSet.vue";
-import {PlotName, plotNames} from "../../store/plotSelections/plotSelections";
+import {OutputPlotName, outputPlotNames, PlotName} from "../../store/plotSelections/plotSelections";
 import {useStore} from "vuex";
 import {RootState} from "../../root";
 import { ModelOutputMutation } from "../../store/modelOutput/mutations";
@@ -36,9 +36,9 @@ export default defineComponent({
     setup() {
         const store = useStore<RootState>();
         const selectedPlot = computed(() => store.state.modelOutput.selectedTab);
-        const switchTab = (plotName: PlotName) => store.commit(`modelOutput/${ModelOutputMutation.TabSelected}`, {payload: plotName});
+        const switchTab = (plotName: OutputPlotName) => store.commit(`modelOutput/${ModelOutputMutation.TabSelected}`, {payload: plotName});
         return {
-            plotNames,
+            outputPlotNames,
             selectedPlot,
             switchTab,
         }

--- a/src/app/static/src/app/components/plots/Filter.vue
+++ b/src/app/static/src/app/components/plots/Filter.vue
@@ -57,7 +57,7 @@ export default defineComponent({
                     plot: props.plot,
                     selection: {
                         filter: {
-                            filterId: props.stateFilterId,
+                            id: props.stateFilterId,
                             options: Array.isArray(newSelection) ? newSelection : [newSelection]
                         }
                     }

--- a/src/app/static/src/app/components/plots/FilterSet.vue
+++ b/src/app/static/src/app/components/plots/FilterSet.vue
@@ -4,13 +4,13 @@
         <label class="font-weight-bold">{{f.label}}</label>
         <!-- For some reason using filter is saying no component registered
         with this name, no idea why so using capital Filter -->
-        <Filter :state-filter-id="f.stateFilterId"/>
+        <Filter :state-filter-id="f.stateFilterId" :plot="plot"/>
     </div>
 
 </template>
 
 <script lang="ts">
-import {computed, defineComponent} from 'vue';
+import {PropType, computed, defineComponent} from 'vue';
 import {useStore} from "vuex";
 import {RootState} from "../../root";
 import Filter from "./Filter.vue";
@@ -20,11 +20,16 @@ export default defineComponent({
     components: {
         Filter
     },
-    setup() {
+    props: {
+        plot:{
+            type: String as PropType<PlotName>,
+            required: true
+        }
+    },
+    setup(props) {
         const store = useStore<RootState>();
         const filters = computed(() => {
-            const plotName: PlotName = store.state.modelOutput.selectedTab
-            return store.state.plotSelections[plotName].filters;
+            return store.state.plotSelections[props.plot].filters;
         });
 
         return {

--- a/src/app/static/src/app/components/plots/PlotControl.vue
+++ b/src/app/static/src/app/components/plots/PlotControl.vue
@@ -13,34 +13,37 @@ import {useStore} from "vuex";
 import {RootState} from "../../root";
 import {FilterOption} from "../../generated";
 import {PlotName} from "../../store/plotSelections/plotSelections";
-import { PlotSelectionActionUpdate } from "../../store/plotSelections/actions";
+import { getMetadataFromPlotName, PlotSelectionActionUpdate } from "../../store/plotSelections/actions";
 
 export default defineComponent({
     props: {
-        plotControlId: String,
+        plotControlId: {
+            type: String,
+            required: true
+        },
+        plot: {
+            type: String as PropType<PlotName>,
+            required: true
+        }
     },
     setup(props) {
         const store = useStore<RootState>();
 
-        const activePlot = computed(() => {
-            return store.state.modelOutput.selectedTab;
-        });
-
         const controlOptions = computed(() => {
-            return store.state.modelCalibrate.metadata!.plotSettingsControl[activePlot.value].plotSettings
+            const metadata = getMetadataFromPlotName(store.state, props.plot);
+            return metadata.plotSettingsControl[props.plot].plotSettings
                 .find(f => f.id === props.plotControlId)!.options;
         });
 
         const selected = computed(() => {
-            const plotName: PlotName = store.state.modelOutput.selectedTab;
-            const controls =  store.state.plotSelections[plotName].controls
+            const controls =  store.state.plotSelections[props.plot].controls
             return controls.find(control => control.id == props.plotControlId)!.selection[0]?.id;
         });
 
         const updateControlSelection = (newSelection: FilterOption) => {
             store.dispatch("plotSelections/updateSelections", {
                 payload: {
-                    plot: activePlot.value,
+                    plot: props.plot,
                     selection: {
                         plotSetting: {
                             id: props.plotControlId,

--- a/src/app/static/src/app/components/plots/PlotControlSet.vue
+++ b/src/app/static/src/app/components/plots/PlotControlSet.vue
@@ -2,34 +2,38 @@
 
     <div class="form-group" v-for="control of plotControls" :key="control.id">
         <label class="font-weight-bold">{{control.label}}</label>
-        <plot-control :plot-control-id="control.id"/>
+        <plot-control :plot-control-id="control.id" :plot="plot"/>
     </div>
     <hr v-if="plotControls.length > 0" class="mt-1 mb-2"/>
 
 </template>
 
 <script lang="ts">
-import {computed, defineComponent} from 'vue';
+import {PropType, computed, defineComponent} from 'vue';
 import {useStore} from "vuex";
 import {RootState} from "../../root";
 import PlotControl from "./PlotControl.vue";
 import {PlotName} from "../../store/plotSelections/plotSelections";
 
 export default defineComponent({
-    setup() {
+    components: {
+        PlotControl
+    },
+    props: {
+        plot: {
+            type: String as PropType<PlotName>,
+            required: true
+        }
+    },
+    setup(props) {
         const store = useStore<RootState>();
         const plotControls = computed(() => {
-            const plotName: PlotName = store.state.modelOutput.selectedTab
-            return store.state.plotSelections[plotName].controls;
+            return store.state.plotSelections[props.plot].controls;
         });
 
         return {
             plotControls
         }
-    },
-
-    components: {
-        PlotControl
     }
 })
 

--- a/src/app/static/src/app/components/plots/bar/utils.ts
+++ b/src/app/static/src/app/components/plots/bar/utils.ts
@@ -76,7 +76,7 @@ export const plotDataToChartData = function (plotData: PlotData,
     const datasets: any[] = [];
 
     let colorIdx = 0;
-    for (const row of plotData) {
+    for (const row of plotData as any) {
 
         const datasetValue = row[disaggregateId];
         const datasetLabel = disaggregateSelectionsMap[datasetValue];

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -3,7 +3,7 @@
         <l-map ref="map" style="height: 800px; width: 100%" @ready="updateBounds" @vue:updated="updateBounds">
             <l-geo-json v-for="feature in currentFeatures"
                         ref="featureRefs"
-                        :key="feature.properties.area_id"
+                        :key="feature.properties!.area_id"
                         :geojson="feature"
                         :options="createTooltips"
                         :options-style="() => {return {...style, fillColor: getColour(feature)}}">
@@ -13,7 +13,7 @@
                 <reset-map @reset-view="updateBounds"></reset-map>
                 <map-legend :indicator-metadata="indicatorMetadata"
                             :scale-levels="scaleLevels"
-                            :selected-scale="selectedScale"
+                            :selected-scale="selectedScale!"
                             @update:selected-scale="updateColourScales"></map-legend>
             </template>
         </l-map>

--- a/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
@@ -1,0 +1,80 @@
+<template>
+    <div id="page-controls" class="text-center">
+        <button id="previous-page"
+                class="btn btn-sm mr-2 btn-red"
+                v-translate:aria-label="'previousPage'"
+                :disabled="pageNumber === 0"
+                @click="$emit('back')">
+            <vue-feather type="chevron-left" size="20" class="pagination-icon"></vue-feather>
+        </button>
+        <span id="page-number" class="page-text">
+            {{ pageNumberText }}
+        </span>
+        <button id="next-page"
+                class="btn btn-sm ml-2 btn-red"
+                v-translate:aria-label="'nextPage'"
+                :disabled="totalPages === pageNumber + 1"
+                @click="$emit('next')">
+            <vue-feather type="chevron-right" size="20" class="pagination-icon"></vue-feather>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import i18next from "i18next";
+import { computed, defineComponent } from "vue";
+import VueFeather from "vue-feather";
+import { useStore } from "vuex";
+import { RootState } from "../../../root";
+
+export default defineComponent({
+    emits: ["back", "next"],
+    components: {
+        VueFeather
+    },
+    props: {
+        pageNumber: {
+            type: Number,
+            required: true
+        },
+        totalPages: {
+            type: Number,
+            required: true
+        }
+    },
+    setup(props) {
+        const store = useStore<RootState>();
+        const pageNumberText = computed(() => {
+            return i18next.t("pageNumber", {
+                currentPage: props.pageNumber + 1,
+                totalPages: props.totalPages,
+                lng: store.state.language
+            })
+        });
+        return { pageNumberText };
+    }
+})
+</script>
+
+<style scoped>
+.pagination-icon {
+    vertical-align: sub;
+}
+
+.btn-red, .btn-red:hover, .btn-red:disabled, .btn-red:focus, .btn-red:active {
+    border-color: transparent;
+}
+
+.btn-red:focus, .btn-red:active {
+    box-shadow: none;
+    background-color: #e31837;
+}
+
+.btn-red:disabled {
+    background-color: darkgray;
+}
+
+.page-text {
+    color: #636668;
+}
+</style>

--- a/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
@@ -47,7 +47,6 @@ export default defineComponent({
 
         const drawChart = async () => {
             const drawData = getData();
-            console.log(drawData.data)
             await Plotly.newPlot(chart.value!, drawData.data, drawData.layout, drawConfig as any);
         };
 

--- a/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
@@ -1,0 +1,62 @@
+<template>
+    <div id="chart" ref="chart" style="width: 100%; height: 100%;"></div>
+</template>
+
+<script lang="ts">
+import { PropType, computed, defineComponent, onMounted, onUpdated, ref, watch } from 'vue';
+import { InputTimeSeriesData, InputTimeSeriesRow } from '../../../generated';
+import { useStore } from 'vuex';
+import { RootState } from '../../../root';
+import { drawConfig, getScatterPointsFromAreaIds, Layout, getLayoutFromData } from "./utils";
+import Plotly from "plotly.js-basic-dist";
+
+
+export default defineComponent({
+    props: {
+        chartData: {
+            type: Object as PropType<InputTimeSeriesData>,
+            required: true
+        },
+        layout: {
+            type: Object as PropType<Layout>,
+            required: true
+        },
+        pageNumber: {
+            type: Number,
+            required: true
+        }
+    },
+    setup(props) {
+        const store = useStore<RootState>();
+        const currentLanguage = computed(() => store.state.language);
+
+        const getData = () => {
+            if (!props.chartData) return { data: [], layout: {} };
+            const dataByArea = props.chartData.reduce((obj, data) => {
+                obj[data.area_id] = obj[data.area_id] || [];
+                obj[data.area_id].push(data);
+                return obj;
+            }, {} as Record<string, InputTimeSeriesData>);
+            const areaIds = Object.keys(dataByArea);
+            const data = getScatterPointsFromAreaIds(areaIds, dataByArea, currentLanguage.value);
+            const layout = getLayoutFromData(areaIds, dataByArea, props.layout, props.chartData);    
+            return { data, layout };
+        }
+
+        const chart = ref<HTMLElement | null>(null);
+
+        const drawChart = async () => {
+            const drawData = getData();
+            console.log(drawData.data)
+            await Plotly.newPlot(chart.value!, drawData.data, drawData.layout, drawConfig as any);
+        };
+
+        onMounted(drawChart);
+        watch(() => [store.state.plotSelections.timeSeries, props.pageNumber], drawChart);
+
+        return {
+            chart
+        }
+    }
+});
+</script>

--- a/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/Plotly.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import { PropType, computed, defineComponent, onMounted, onUpdated, ref, watch } from 'vue';
-import { InputTimeSeriesData, InputTimeSeriesRow } from '../../../generated';
+import { PropType, computed, defineComponent, onMounted, ref, watch } from 'vue';
+import { InputTimeSeriesData } from '../../../generated';
 import { useStore } from 'vuex';
 import { RootState } from '../../../root';
 import { drawConfig, getScatterPointsFromAreaIds, Layout, getLayoutFromData } from "./utils";

--- a/src/app/static/src/app/components/plots/timeSeries/TimeSeries.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/TimeSeries.vue
@@ -1,0 +1,99 @@
+<template>
+    <div class="col-9" style="position: relative;">
+        <div class="chart-container" ref="chartContainer" style="height: 600px;">
+            <plotly class="chart"
+                    :chart-data="chartDataForPage"
+                    :layout="layout"
+                    :style="{ height: scrollHeight }"
+                    :page-number="pageNumber"/>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref } from 'vue';
+import { useStore } from 'vuex';
+import { RootState } from '../../../root';
+import { InputPlotName } from '../../../store/plotSelections/plotSelections';
+import { GenericChartColumnValue } from '../../../types';
+import { numeralJsToD3format } from "./utils";
+import Plotly from "./Plotly.vue";
+
+const plot = "timeSeries" as InputPlotName;
+
+export default defineComponent({
+    components: {
+        Plotly
+    },
+    setup() {
+        const store = useStore<RootState>();
+        const pageNumber = ref<number>(0);
+        const chartMetadata = computed(() => {
+            // TODO change metadata so it has key of timeSeries
+            return store.state.genericChart.genericChartMetadata!["input-time-series"];
+        });
+
+        const valueFormat = computed(() => {
+            const { valueFormatColumn } = chartMetadata.value;
+            if (!valueFormatColumn) return "";
+            const plotTypeFilter = store.state.plotSelections[plot].filters.find(f => f.stateFilterId === "plotType")!;
+            const selectionId = plotTypeFilter.selection[0].id;
+            const filterType = store.state.metadata.reviewInputMetadata!.filterTypes.find(ft => ft.id === plotTypeFilter.filterId)!;
+            const { format } = filterType.options.find(op => op.id === selectionId) as GenericChartColumnValue;
+            if (!format) return "";
+            return numeralJsToD3format(format);
+        });
+
+        const visiblePlots = computed(() => {
+            const chartData = store.state.plotData[plot];
+            if (!chartMetadata.value.subplots) return [];
+            const { distinctColumn, subplotsPerPage } = chartMetadata.value.subplots;
+            const startIndex = pageNumber.value * subplotsPerPage;
+            const endIndex = (pageNumber.value + 1) * subplotsPerPage;
+            const distinctPlots = chartData.reduce((dp, data) => {
+                const value = data[distinctColumn];
+                return [...dp, ...dp.includes(value) ? [] : [value]];
+            }, [] as any[]);
+            return distinctPlots.slice(startIndex, endIndex);
+        });
+
+        const chartDataForPage = computed(() => {
+            const chartData = store.state.plotData[plot];
+            if (!chartMetadata.value.subplots) return chartData;
+            const { distinctColumn } = chartMetadata.value.subplots;
+            return chartData.reduce((vcd, data) => {
+                const value = data[distinctColumn];
+                return [...vcd, ...visiblePlots.value.includes(value) ? [data] : []];
+            }, [] as any[]);
+        })
+
+        const rows = computed(() => {
+            return chartMetadata.value.subplots ?
+                Math.ceil(visiblePlots.value.length / chartMetadata.value.subplots.columns) :
+                null;
+        });
+
+        const scrollHeight = computed(() => {
+            return chartMetadata.value.subplots ?
+                `${(chartMetadata.value.subplots.heightPerRow * rows.value!) + 70}px` :
+                "100%";
+        });
+
+        const layout = computed(() => {
+            return {
+                yAxisFormat: valueFormat.value,
+                ...chartMetadata.value.subplots ?
+                    { subplots: {...chartMetadata.value.subplots, rows: rows.value} } :
+                    {}
+            };
+        });
+
+        return {
+            chartDataForPage,
+            layout,
+            scrollHeight,
+            pageNumber
+        }
+    }
+})
+</script>

--- a/src/app/static/src/app/components/plots/timeSeries/utils.ts
+++ b/src/app/static/src/app/components/plots/timeSeries/utils.ts
@@ -80,7 +80,7 @@ export const PlotColours = Object.freeze({
 });
 
 export const getScatterPoints = (plotData: (InputTimeSeriesRow | null)[], areaData: InputTimeSeriesRow, index: number,
-                                 isHighlight: boolean, currentLanguage: string, isFirstPointHighlight: boolean = false) => {
+                                 isHighlight: boolean, currentLanguage: string, isFirstPointHighlight = false) => {
     const { area_hierarchy, area_name } = areaData;
     const colours = isHighlight ? PlotColours.HIGHLIGHT : PlotColours.NORMAL;
     const markerFillColors = plotData.map((x, i) => {
@@ -134,7 +134,7 @@ export const getScatterPointsFromAreaIds = (areaIds: string[], dataByArea: Dict<
             pointsInfo.push({isHighlight: isNextLineSegmentHighlighted, point: areaData[i]});
         }
         let isPreviousLineHighlight = pointsInfo[0].isHighlight;
-        let lineSegmentsInfo: LineSegmentsInfo[] = [{
+        const lineSegmentsInfo: LineSegmentsInfo[] = [{
             isHighlight: isPreviousLineHighlight, points: []
         }];
         for (let i = 0; i < pointsInfo.length; i++) {
@@ -166,7 +166,8 @@ export const getLayoutFromData = (areaIds: string[], dataByArea: Dict<InputTimeS
         grid: {
             columns: layout.subplots.columns,
             rows: layout.subplots.rows,
-            pattern: 'independent'
+            pattern: 'independent',
+            xgap: 0.25, ygap: 0.4
         },
         annotations: areaIds.map((id, index) => {
             return {
@@ -204,6 +205,5 @@ export const getLayoutFromData = (areaIds: string[], dataByArea: Dict<InputTimeS
             type: "category"
         };
     }
-
     return baseLayout;
 }

--- a/src/app/static/src/app/components/plots/timeSeries/utils.ts
+++ b/src/app/static/src/app/components/plots/timeSeries/utils.ts
@@ -1,0 +1,209 @@
+import i18next from "i18next";
+import { InputTimeSeriesData, InputTimeSeriesRow } from "../../../generated";
+import { Dict } from "../../../types";
+
+export function numeralJsToD3format(numeralJsFormat: string) {
+    // Convert hintr metadata format (which are numeralJs style) to d3 format to be used by Plotly
+    // We currently support only numeric, large number, and percentage formats, and will return 
+    // empty string for any other formats received, for default formatting in Plotly.
+
+    // The first part of this regex (before the |) captures formats with decimal precision and optional percentage
+    // The second part captures format with thousands separator for large integers
+    const regex = /^0(\.0+)?(%)?$|^0(,0)$/; //This will always return four matches
+
+    const match = numeralJsFormat.match(regex);
+    if (match === null) {
+        return "";
+    }
+
+    if (match[3] !== undefined) {
+        return ",";
+    }
+
+    const decPl = match[1] == undefined ? 0 : match[1].length - 1;
+    const percent = match[2] !== undefined;
+    const suffix = percent ? "%" : "f";
+    return `.${decPl}${suffix}`;
+}
+
+export const drawConfig = {
+    responsive: false,
+    scrollZoom: false,
+    modeBarButtonsToRemove: [
+        'zoom2d',
+        'pan2d',
+        'select2d',
+        'lasso2d',
+        'autoScale2d',
+        'resetScale2d',
+        'zoomIn2d',
+        'zoomOut2d'
+    ]
+};
+
+export const translate = (word: string, currentLanguage: string, args: any = null) => {
+    return i18next.t(word, {...args, lng: currentLanguage})
+}
+
+export const getTooltipTemplate = (plotData: (InputTimeSeriesRow | null)[], areaHierarchy: string,
+                                   currentLanguage: string) => {
+    const hierarchyText = areaHierarchy ? "<br>" + areaHierarchy : "";
+    const tooltip = "%{x}, %{y}" + hierarchyText;
+    return plotData.map((entry: InputTimeSeriesRow | null) => {
+        let missingIdsText = "";
+        if (entry?.missing_ids?.length) {
+            // If the area ID matches the missing_id then this is a synthetic value we have appended
+            // rather than an aggregate with some missing data. Show this with a slightly different
+            // message
+            if (entry.missing_ids.length == 1 && entry.missing_ids[0] == entry.area_id) {
+                missingIdsText = "<br>" + translate("timeSeriesMissingValue", currentLanguage);
+            } else {
+                missingIdsText = "<br>" + translate("timeSeriesMissingAggregate", currentLanguage,
+                    {count: entry.missing_ids.length});
+            }
+        }
+        // Empty <extra></extra> tag removes the part of the hover where trace name is displayed in
+        // contrasting colour. See https://plotly.com/python/hover-text-and-formatting/
+        return tooltip + missingIdsText + "<extra></extra>";
+    })
+}
+
+export const PlotColours = Object.freeze({
+    HIGHLIGHT: {
+        MISSING: "rgb(255,214,214)",
+        BASE: "rgb(255, 51, 51)"
+    },
+    NORMAL: {
+        MISSING: "rgb(220,220,220)",
+        BASE: "rgb(51, 51, 51)"
+    }
+});
+
+export const getScatterPoints = (plotData: (InputTimeSeriesRow | null)[], areaData: InputTimeSeriesRow, index: number,
+                                 isHighlight: boolean, currentLanguage: string, isFirstPointHighlight: boolean = false) => {
+    const { area_hierarchy, area_name } = areaData;
+    const colours = isHighlight ? PlotColours.HIGHLIGHT : PlotColours.NORMAL;
+    const markerFillColors = plotData.map((x, i) => {
+        if (isFirstPointHighlight && i === 0) {
+            return x?.missing_ids?.length ? PlotColours.HIGHLIGHT.MISSING : PlotColours.HIGHLIGHT.BASE;
+        }
+        return x?.missing_ids?.length ? colours.MISSING : colours.BASE;
+    });
+    const markerOutlineColors = plotData.map((x, i) => {
+        return isFirstPointHighlight && i === 0 ? PlotColours.HIGHLIGHT.BASE : colours.BASE;
+    });
+    const points: any = {
+        name: area_name, showlegend: false,
+        x: plotData.map(x => x?.time_period),
+        y: plotData.map(x => x?.value),
+        xaxis: `x${index+1}`, yaxis: `y${index+1}`,
+        type: "scatter",
+        marker: {
+            color: markerFillColors,
+            line: { width: 0.5, color: markerOutlineColors },
+        },
+        line: { color: colours.BASE },
+        hovertemplate: getTooltipTemplate(plotData, area_hierarchy, currentLanguage)
+    }
+    return points
+};
+
+type PointInfo = {
+    isHighlight: boolean,
+    point: InputTimeSeriesRow
+};
+
+type LineSegmentsInfo = {
+    isHighlight: boolean,
+    points: InputTimeSeriesRow[]
+};
+
+export const getScatterPointsFromAreaIds = (areaIds: string[], dataByArea: Dict<InputTimeSeriesData>, currentLanguage: string) => {
+    return areaIds.reduce((r, id, index) => {
+        const areaData = dataByArea[id];
+        const pointsInfo: PointInfo[] = [];
+        for (let i = 0; i < areaData.length; i++) {
+            if (i === areaData.length - 1) {
+                pointsInfo.push({isHighlight: pointsInfo.at(-1)!.isHighlight, point: areaData[i]});
+                continue;
+            }
+            const currPointValue = areaData[i].value;
+            const nextPointValue = areaData[i + 1].value;
+            const isNextLineSegmentHighlighted = !!((currPointValue != null && nextPointValue != null && nextPointValue > 0)
+            && (nextPointValue > 1.25 * currPointValue || nextPointValue < 0.75 * currPointValue));
+            pointsInfo.push({isHighlight: isNextLineSegmentHighlighted, point: areaData[i]});
+        }
+        let isPreviousLineHighlight = pointsInfo[0].isHighlight;
+        let lineSegmentsInfo: LineSegmentsInfo[] = [{
+            isHighlight: isPreviousLineHighlight, points: []
+        }];
+        for (let i = 0; i < pointsInfo.length; i++) {
+            const { isHighlight, point } = pointsInfo[i];
+            lineSegmentsInfo.at(-1)!.points.push(point);
+            if (isHighlight !== isPreviousLineHighlight) {
+                lineSegmentsInfo.push({ isHighlight, points: [point] });
+            }
+            isPreviousLineHighlight = isHighlight;
+        }
+        const colouredLines = lineSegmentsInfo.map(({isHighlight, points}, lineNum) => {
+            if (isHighlight) return getScatterPoints(points, areaData[0], index, true, currentLanguage);
+            // Need to make sure that the first point in a non highlighted segment is red following a highlighted
+            // segment. In the case lineNum = 0, prevHighlight will be false anyway so our special case won't
+            // be triggered
+            const prevHighlight = lineSegmentsInfo[Math.max(lineNum - 1, 0)].isHighlight;
+            return getScatterPoints(points, areaData[0], index, false, currentLanguage, prevHighlight);
+        });
+        return [...r, ...colouredLines];
+    }, [] as any[]);
+};
+
+export type Layout = Record<string, any>
+
+export const getLayoutFromData = (areaIds: string[], dataByArea: Dict<InputTimeSeriesData>,
+                                  layout: Layout, chartData: InputTimeSeriesData) => {
+    const baseLayout: Record<string, any> = {
+        margin: {t: 32}, dragmode: false,
+        grid: {
+            columns: layout.subplots.columns,
+            rows: layout.subplots.rows,
+            pattern: 'independent'
+        },
+        annotations: areaIds.map((id, index) => {
+            return {
+                x: 0.5, y: 1.1,
+                xanchor: "middle", yanchor: "middle",
+                xref: `x${index+1} domain`, yref: `y${index+1} domain`,
+                text: `${dataByArea[id][0].area_name} (${id})`,
+                showarrow: false, textfont: {}
+            }
+        })
+    };
+
+    const subPlotHeight = 1 / (layout.subplots?.rows || 1) * 0.6;
+    const timePeriods = chartData.map(dataPoint => dataPoint.time_period).sort() || [];
+    const firstXAxisVal = timePeriods[0];
+    const lastXAxisVal = timePeriods[timePeriods.length - 1];
+
+    for (let i = 0; i < areaIds.length; i++) {
+        const row = Math.floor(i / layout.subplots.columns);
+        const maxOfData = Math.max(...dataByArea[areaIds[i]].map(d => d.value || 0));
+        const yStart = 1 - (row / layout.subplots.rows);
+        baseLayout[`yaxis${i + 1}`] = {
+            zeroline: false,
+            tickformat: layout.yAxisFormat,
+            tickfont: { color: "grey" },
+            domain: [yStart, yStart - subPlotHeight],
+            range: [-maxOfData * 0.1, maxOfData * 1.1],
+            type: "linear"
+        };
+        baseLayout[`xaxis${i + 1}`] = {
+            zeroline: false,
+            tickvals: [firstXAxisVal, lastXAxisVal],
+            tickfont: { color: "grey" },
+            autorange: true,
+            type: "category"
+        };
+    }
+
+    return baseLayout;
+}

--- a/src/app/static/src/app/components/plots/utils.ts
+++ b/src/app/static/src/app/components/plots/utils.ts
@@ -1,8 +1,7 @@
-import {IndicatorValuesDict, LevelLabel, NumericRange} from "../../types";
-import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
+import {NumericRange} from "../../types";
+import {CalibrateDataResponse, ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
 import * as d3ScaleChromatic from "d3-scale-chromatic";
 import {initialScaleSettings, ScaleSettings, ScaleType} from "../../store/plotState/plotState";
-import {PlotData} from "../../store/plotData/plotData";
 import {Feature} from "geojson";
 import numeral from "numeral";
 
@@ -151,11 +150,11 @@ export const formatOutput = function (value: number | string, format: string, sc
     } else return ans
 };
 
-const getPlotDataForIndicator = (indicatorMetadata: ChoroplethIndicatorMetadata, plotData: PlotData) => {
+const getPlotDataForIndicator = (indicatorMetadata: ChoroplethIndicatorMetadata, plotData: CalibrateDataResponse["data"]) => {
     return plotData.filter((row) => row.indicator == indicatorMetadata.indicator);
 }
 
-export const getIndicatorRange = (indicatorMetadata: ChoroplethIndicatorMetadata, scaleSettings: ScaleSettings, plotData: PlotData): NumericRange => {
+export const getIndicatorRange = (indicatorMetadata: ChoroplethIndicatorMetadata, scaleSettings: ScaleSettings, plotData: CalibrateDataResponse["data"]): NumericRange => {
     if (!indicatorMetadata) {
         return {max: 1, min: 0};
     }
@@ -174,7 +173,7 @@ export const getIndicatorRange = (indicatorMetadata: ChoroplethIndicatorMetadata
     }
 }
 
-const getDynamicRange = function (data: PlotData,
+const getDynamicRange = function (data: CalibrateDataResponse["data"],
                                   indicatorMeta: ChoroplethIndicatorMetadata): NumericRange {
     let result = {} as NumericRange;
     for (const row of data) {

--- a/src/app/static/src/app/components/reviewInputs/ReviewInputs.vue
+++ b/src/app/static/src/app/components/reviewInputs/ReviewInputs.vue
@@ -1,11 +1,59 @@
 <template>
     <div>
-        <!-- TODO:PC -->
+        <ul class="nav nav-tabs">
+            <li v-for="plotName of inputPlotNames" :key="plotName">
+                <a class="nav-link"
+                   :class="activePlot === plotName ? 'active': ''"
+                   v-translate="plotName === 'inputChoropleth' ? 'choropleth' : plotName"
+                   @click="changePlot(plotName)"></a>
+            </li>
+        </ul>
+        <div class="row" v-if="fetched">
+            <div class="mt-2 col-md-3">
+                <plot-control-set :plot="activePlot"/>
+                <h4 v-translate="'filters'"/>
+                <filter-set :plot="activePlot"/>
+            </div>
+            <time-series v-if="activePlot === 'timeSeries'" class="col-md-9"/>
+            <!-- <choropleth class="col-md-9"/> -->
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent, onBeforeMount, onMounted, ref } from 'vue';
+import { useStore } from 'vuex';
+import { RootState } from '../../root';
+import { FileType } from "../../store/surveyAndProgram/surveyAndProgram"
+import PlotControlSet from '../plots/PlotControlSet.vue';
+import FilterSet from '../plots/FilterSet.vue';
+import { InputPlotName, inputPlotNames } from '../../store/plotSelections/plotSelections';
+import TimeSeries from "../plots/timeSeries/TimeSeries.vue";
 
-export default defineComponent({})
+export default defineComponent({
+    components: {
+        PlotControlSet,
+        FilterSet,
+        TimeSeries
+    },
+    setup() {
+        const store = useStore<RootState>();
+        const activePlot = ref<InputPlotName>(inputPlotNames[0]);
+        const changePlot = (plot: InputPlotName) => {
+            activePlot.value = plot;
+        }
+        const fetched = computed(() => store.state.metadata.reviewInputMetadataFetched);
+
+        onBeforeMount(async () => {
+            await store.dispatch("metadata/getReviewInputMetadata", {}, { root: true });
+        });
+
+        return {
+            inputPlotNames,
+            activePlot,
+            changePlot,
+            fetched
+        }
+    }
+})
 </script>

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -1552,6 +1552,124 @@ export interface Response {
     [k: string]: any;
   };
 }
+export interface ReviewInputFilterMetadataRequest {
+  iso3: string;
+  data: {
+    shape?: {
+      path: string | null;
+      hash: string;
+      filename: string;
+      fromADR?: boolean;
+      resource_url?: string | null;
+    };
+    programme?: {
+      path: string | null;
+      hash: string;
+      filename: string;
+      fromADR?: boolean;
+      resource_url?: string | null;
+    };
+    anc?: {
+      path: string | null;
+      hash: string;
+      filename: string;
+      fromADR?: boolean;
+      resource_url?: string | null;
+    };
+    survey?: {
+      path: string | null;
+      hash: string;
+      filename: string;
+      fromADR?: boolean;
+      resource_url?: string | null;
+    };
+    [k: string]: any;
+  };
+}
+export interface ReviewInputFilterMetadataResponse {
+  filterTypes: {
+    id: string;
+    column_id: string;
+    options: {
+      label: string;
+      id: string;
+      description?: string;
+    }[];
+    use_shape_regions?: boolean;
+  }[];
+  indicators: {
+    indicator: string;
+    value_column: string;
+    error_low_column?: string;
+    error_high_column?: string;
+    indicator_column?: string;
+    indicator_value?: string;
+    indicator_sort_order?: number;
+    name: string;
+    min: number;
+    max: number;
+    colour: string;
+    invert_scale: boolean;
+    scale: number;
+    accuracy: number | null;
+    format: string;
+  }[];
+  plotSettingsControl: {
+    timeSeries: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
+    inputChoropleth: {
+      defaultFilterTypes?: {
+        filterId: string;
+        label: string;
+        stateFilterId: string;
+      }[];
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+      }[];
+    };
+  };
+  [k: string]: any;
+}
 export interface SessionFile {
   path: string | null;
   hash: string;

--- a/src/app/static/src/app/store/dataExploration/dataExploration.ts
+++ b/src/app/static/src/app/store/dataExploration/dataExploration.ts
@@ -79,7 +79,7 @@ export const storeOptions: StoreOptions<DataExplorationState> = {
         adr,
         genericChart,
         baseline: baseline(existingState),
-        metadata: metadata(existingState),
+        metadata: metadata(existingState) as any,
         surveyAndProgram: surveyAndProgram(existingState),
         plottingSelections: plottingSelections(existingState),
         stepper: dataExplorationStepper(existingState),

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -45,7 +45,7 @@ export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
         if (response) {
             const metadata = response.data;
             metadata.filterTypes = filtersAfterUseShapeRegions(metadata.filterTypes, rootState);
-            await commitPlotDefaultSelections(metadata, commit, rootState, PlotDataType.Input);
+            await commitPlotDefaultSelections(metadata, commit, rootState);
             commit({ type: MetadataMutations.ReviewInputsMetadataToggleComplete, payload: true });
         }
     },

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -27,7 +27,7 @@ export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
         const { commit, rootState, state } = context;
         const iso3 = rootState.baseline.iso3;
         const sap = rootState.surveyAndProgram;
-        const fileTypes = []
+        const fileTypes = [FileType.Shape]
         if (!sap.ancError && sap.anc) {
             fileTypes.push(FileType.ANC)
         }

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -2,20 +2,52 @@ import {ActionContext, ActionTree} from 'vuex';
 import {api} from "../../apiService";
 import {MetadataState} from "./metadata";
 import {MetadataMutations} from "./mutations";
-import {DataExplorationState} from "../dataExploration/dataExploration";
+import { FileType } from '../surveyAndProgram/surveyAndProgram';
+import { commitPlotDefaultSelections, filtersAfterUseShapeRegions } from '../plotSelections/utils';
+import { ReviewInputFilterMetadataResponse } from '../../generated';
+import { RootState } from '../../root';
+import { PlotDataType } from '../plotSelections/plotSelections';
 
 export interface MetadataActions {
-    getPlottingMetadata: (store: ActionContext<MetadataState, DataExplorationState>, country: string) => void
-    getAdrUploadMetadata: (store: ActionContext<MetadataState, DataExplorationState>, downloadId: string) => Promise<void>
+    getPlottingMetadata: (store: ActionContext<MetadataState, RootState>, country: string) => void
+    getReviewInputMetadata: (store: ActionContext<MetadataState, RootState>) => void
+    getAdrUploadMetadata: (store: ActionContext<MetadataState, RootState>, downloadId: string) => Promise<void>
 }
 
-export const actions: ActionTree<MetadataState, DataExplorationState> & MetadataActions = {
+export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
 
     async getPlottingMetadata(context, iso3) {
         await api<MetadataMutations, MetadataMutations>(context)
             .withSuccess(MetadataMutations.PlottingMetadataFetched)
             .withError(MetadataMutations.PlottingMetadataError)
             .get(`/meta/plotting/${iso3}`);
+    },
+
+    async getReviewInputMetadata(context) {
+        const { commit, rootState, state } = context;
+        const iso3 = rootState.baseline.iso3;
+        const sap = rootState.surveyAndProgram;
+        const fileTypes = [FileType.Shape]
+        if (!sap.ancError && sap.anc) {
+            fileTypes.push(FileType.ANC)
+        }
+        if (!sap.programError && sap.program) {
+            fileTypes.push(FileType.Programme)
+        }
+        if (!sap.surveyError && sap.survey) {
+            fileTypes.push(FileType.Survey)
+        }
+        commit({ type: MetadataMutations.ReviewInputsMetadataToggleComplete, payload: false });
+        const response = await api<MetadataMutations, MetadataMutations>(context)
+            .withSuccess(MetadataMutations.ReviewInputsMetadataFetched) 
+            .withError(MetadataMutations.ReviewInputsMetadataError)
+            .postAndReturn<ReviewInputFilterMetadataResponse>(`/meta/review-inputs/${iso3}`, { types: fileTypes });
+        if (response) {
+            const metadata = response.data;
+            metadata.filterTypes = filtersAfterUseShapeRegions(metadata.filterTypes, rootState);
+            await commitPlotDefaultSelections(metadata, commit, rootState, PlotDataType.Input);
+            commit({ type: MetadataMutations.ReviewInputsMetadataToggleComplete, payload: true });
+        }
     },
 
     async getAdrUploadMetadata(context, downloadId) {

--- a/src/app/static/src/app/store/metadata/actions.ts
+++ b/src/app/static/src/app/store/metadata/actions.ts
@@ -27,7 +27,7 @@ export const actions: ActionTree<MetadataState, RootState> & MetadataActions = {
         const { commit, rootState, state } = context;
         const iso3 = rootState.baseline.iso3;
         const sap = rootState.surveyAndProgram;
-        const fileTypes = [FileType.Shape]
+        const fileTypes = []
         if (!sap.ancError && sap.anc) {
             fileTypes.push(FileType.ANC)
         }

--- a/src/app/static/src/app/store/metadata/metadata.ts
+++ b/src/app/static/src/app/store/metadata/metadata.ts
@@ -5,14 +5,31 @@ import {
     PlottingMetadataResponse,
     Error,
     Metadata,
-    AdrMetadataResponse, FilterOption, ChoroplethIndicatorMetadata
+    AdrMetadataResponse,
+    FilterOption,
+    ChoroplethIndicatorMetadata,
+    ReviewInputFilterMetadataResponse,
+    FilterTypes,
+    PlotSettingsControl
 } from "../../generated";
 import {DataType} from "../surveyAndProgram/surveyAndProgram";
 import {DataExplorationState} from "../dataExploration/dataExploration";
+import { RootState } from '../../root';
+
+export type PlotMetadataFrame = {
+    filterTypes: FilterTypes[],
+    indicators: ChoroplethIndicatorMetadata[],
+    plotSettingsControl: {
+        [k: string]: PlotSettingsControl
+    }
+}
 
 export interface MetadataState {
     plottingMetadataError: Error | null
     plottingMetadata: PlottingMetadataResponse | null
+    reviewInputMetadata: ReviewInputFilterMetadataResponse | null
+    reviewInputMetadataError: Error | null
+    reviewInputMetadataFetched: boolean
     adrUploadMetadata: AdrMetadataResponse[]
     adrUploadMetadataError: Error | null
 }
@@ -21,6 +38,9 @@ export const initialMetadataState = (): MetadataState => {
     return {
         plottingMetadataError: null,
         plottingMetadata: null,
+        reviewInputMetadata: null,
+        reviewInputMetadataError: null,
+        reviewInputMetadataFetched: false,
         adrUploadMetadataError: null,
         adrUploadMetadata: [] as AdrMetadataResponse[]
     }
@@ -68,7 +88,7 @@ export const metadataGetters = {
 
 const namespaced = true;
 
-export const metadata = (existingState: Partial<DataExplorationState> | null): Module<MetadataState, DataExplorationState> => {
+export const metadata = (existingState: Partial<DataExplorationState> | null): Module<MetadataState, RootState> => {
     return {
         namespaced,
         state: {...initialMetadataState(), ...existingState && existingState.metadata},

--- a/src/app/static/src/app/store/metadata/mutations.ts
+++ b/src/app/static/src/app/store/metadata/mutations.ts
@@ -1,11 +1,14 @@
 import {MutationTree} from 'vuex';
 import {MetadataState} from "./metadata";
-import {PlottingMetadataResponse, Error, AdrMetadataResponse} from "../../generated";
+import {PlottingMetadataResponse, Error, AdrMetadataResponse, ReviewInputFilterMetadataResponse} from "../../generated";
 import {PayloadWithType} from "../../types";
 
 export enum MetadataMutations {
     PlottingMetadataFetched= "PlottingMetadataFetched",
     PlottingMetadataError = "PlottingMetadataError",
+    ReviewInputsMetadataFetched = "ReviewInputsMetadataFetched",
+    ReviewInputsMetadataError = "ReviewInputsMetadataError",
+    ReviewInputsMetadataToggleComplete = "ReviewInputsMetadataToggleComplete",
     AdrUploadMetadataFetched = "AdrUploadMetadataFetched",
     AdrUploadMetadataError = "AdrUploadMetadataError"
 }
@@ -19,6 +22,19 @@ export const mutations: MutationTree<MetadataState> = {
     [MetadataMutations.PlottingMetadataFetched](state: MetadataState, action: PayloadWithType<PlottingMetadataResponse>) {
         state.plottingMetadata = action.payload;
         state.plottingMetadataError = null;
+    },
+
+    [MetadataMutations.ReviewInputsMetadataFetched](state: MetadataState, action: PayloadWithType<ReviewInputFilterMetadataResponse>) {
+        state.reviewInputMetadata = action.payload;
+        state.reviewInputMetadataError = null;
+    },
+
+    [MetadataMutations.ReviewInputsMetadataError](state: MetadataState, action: PayloadWithType<Error>) {
+        state.reviewInputMetadataError = action.payload;
+    },
+
+    [MetadataMutations.ReviewInputsMetadataToggleComplete](state: MetadataState, action: PayloadWithType<boolean>) {
+        state.reviewInputMetadataFetched = action.payload;
     },
 
     [MetadataMutations.AdrUploadMetadataError](state: MetadataState, action: PayloadWithType<Error>) {

--- a/src/app/static/src/app/store/modelCalibrate/actions.ts
+++ b/src/app/static/src/app/store/modelCalibrate/actions.ts
@@ -19,6 +19,7 @@ import {CalibrateResultWithType, Dict, ModelOutputTabs} from "../../types";
 import {DownloadResultsMutation} from "../downloadResults/mutations";
 import { ModelOutputMutation } from "../modelOutput/mutations";
 import {commitPlotDefaultSelections, filtersAfterUseShapeRegions} from "../plotSelections/utils";
+import { PlotDataType } from "../plotSelections/plotSelections";
 
 type ResultDataPayload = {
     indicatorId: string,
@@ -188,7 +189,7 @@ export const getResultMetadata = async function (context: ActionContext<ModelCal
         data.filterTypes = filtersAfterUseShapeRegions(data.filterTypes, rootState);
         commit({type: ModelCalibrateMutation.MetadataFetched, payload: data});
 
-        commitPlotDefaultSelections(data, commit, rootState);
+        await commitPlotDefaultSelections(data, commit, rootState);
 
         commit(ModelCalibrateMutation.Calibrated);
 
@@ -212,25 +213,3 @@ export const getCalibrateStatus = async function (context: ActionContext<ModelCa
             }
         });
 };
-
-const selectFilterDefaults = (data: CalibrateMetadataResponse, commit: Commit, mutationName: string) => {
-    if (data?.plottingMetadata?.barchart?.defaults) {
-        const defaults = data.plottingMetadata.barchart.defaults;
-        const unfrozenDefaultOptions = Object.keys(defaults.selected_filter_options)
-            .reduce((dict, key) => {
-                dict[key] = [...defaults.selected_filter_options[key]];
-                return dict;
-            }, {} as Dict<FilterOption[]>);
-
-        commit({
-                type: `plottingSelections/${mutationName}`,
-                payload: {
-                    indicatorId: defaults.indicator_id,
-                    xAxisId: defaults.x_axis_id,
-                    disaggregateById: defaults.disaggregate_by_id,
-                    selectedFilterOptions: unfrozenDefaultOptions
-                }
-            },
-            {root: true});
-    }
-}

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -6,12 +6,12 @@ import {mutations} from "./mutations";
 import {actions} from "./actions";
 import {rootOptionChildren} from "../../utils";
 import {UnadjustedBarchartSelections} from "../plottingSelections/plottingSelections";
-import {PlotName, plotNames} from "../plotSelections/plotSelections";
+import {OutputPlotName, outputPlotNames} from "../plotSelections/plotSelections";
 
 const namespaced = true;
 
 export interface ModelOutputState {
-    selectedTab: PlotName,
+    selectedTab: OutputPlotName,
     loading: {
         [k in ModelOutputTabs]: boolean
     }
@@ -114,7 +114,7 @@ const outputPlotFilters = (rootState: RootState, resultName: "metadata" | "compa
 
 export const initialModelOutputState = (): ModelOutputState => {
     return {
-        selectedTab: plotNames[0],
+        selectedTab: outputPlotNames[0],
         loading: {
             [ModelOutputTabs.Map]: false,
             [ModelOutputTabs.Bar]: false,

--- a/src/app/static/src/app/store/modelOutput/mutations.ts
+++ b/src/app/static/src/app/store/modelOutput/mutations.ts
@@ -1,7 +1,7 @@
 import {MutationTree} from "vuex";
 import {ModelOutputState} from "./modelOutput";
 import {ModelOutputTabs, PayloadWithType} from "../../types";
-import {PlotName} from "../plotSelections/plotSelections";
+import {OutputPlotName} from "../plotSelections/plotSelections";
 
 export enum ModelOutputMutation {
     TabSelected = "TabSelected",
@@ -15,7 +15,7 @@ type TabLoading = {
 
 export const mutations: MutationTree<ModelOutputState> = {
 
-    [ModelOutputMutation.TabSelected](state: ModelOutputState, payload: PayloadWithType<PlotName>) {
+    [ModelOutputMutation.TabSelected](state: ModelOutputState, payload: PayloadWithType<OutputPlotName>) {
         state.selectedTab = payload.payload;
     },
 

--- a/src/app/static/src/app/store/plotData/plotData.ts
+++ b/src/app/static/src/app/store/plotData/plotData.ts
@@ -1,9 +1,9 @@
-import { CalibrateDataResponse } from "../../generated"
+import { CalibrateDataResponse, InputTimeSeriesData, InputTimeSeriesRow } from "../../generated"
 import { PlotName, plotNames } from "../plotSelections/plotSelections"
 import { mutations } from "./mutations"
 
-export type PlotData = CalibrateDataResponse["data"] | Record<string, string | number>[]
-
+export type PlotData = CalibrateDataResponse["data"] | InputTimeSeriesData
+export type InputTimeSeriesKey = keyof InputTimeSeriesRow;
 export type PlotDataState = {
     [P in PlotName]: PlotData
 }

--- a/src/app/static/src/app/store/plotData/plotData.ts
+++ b/src/app/static/src/app/store/plotData/plotData.ts
@@ -2,7 +2,7 @@ import { CalibrateDataResponse } from "../../generated"
 import { PlotName, plotNames } from "../plotSelections/plotSelections"
 import { mutations } from "./mutations"
 
-export type PlotData = CalibrateDataResponse["data"]
+export type PlotData = CalibrateDataResponse["data"] | Record<string, string | number>[]
 
 export type PlotDataState = {
     [P in PlotName]: PlotData

--- a/src/app/static/src/app/store/plotSelections/actions.ts
+++ b/src/app/static/src/app/store/plotSelections/actions.ts
@@ -11,17 +11,12 @@ import { PlotMetadataFrame } from "../metadata/metadata"
 import { GenericChartMutation } from "../genericChart/mutations"
 import { InputTimeSeriesKey } from "../plotData/plotData"
 
-type Selection = {
-    filter: {
-        filterId: string,
-        options: FilterOption[]
-    }
-} | {
-    plotSetting: {
-        id: string,
-        options: FilterOption[]
-    }
+type IdOptions = {
+    id: string,
+    options: FilterOption[]
 }
+
+type Selection = { filter: IdOptions } | { plotSetting: IdOptions }
 
 export type PlotSelectionActionUpdate = {
     plot: PlotName,
@@ -48,7 +43,7 @@ export const actions: ActionTree<PlotSelectionsState, RootState> & PlotSelection
         const metadata = getMetadataFromPlotName(rootState, plot);
         const updatedSelections: PlotSelectionsState[PlotName]  = {...state[plot]};
         if ("filter" in selection) {
-            const fIndex = updatedSelections.filters.findIndex(f => f.stateFilterId === selection.filter.filterId);
+            const fIndex = updatedSelections.filters.findIndex(f => f.stateFilterId === selection.filter.id);
             updatedSelections.filters[fIndex].selection = selection.filter.options;
         } else {
             const pIndex = updatedSelections.controls.findIndex(p => p.id === selection.plotSetting.id);

--- a/src/app/static/src/app/store/plotSelections/actions.ts
+++ b/src/app/static/src/app/store/plotSelections/actions.ts
@@ -1,12 +1,14 @@
 import { ActionContext, ActionTree, Commit } from "vuex"
-import { PlotName, PlotSelectionsState } from "./plotSelections"
+import { OutputPlotName, PlotDataType, PlotName, PlotSelectionsState, plotNameToDataType } from "./plotSelections"
 import { RootState } from "../../root"
-import { PayloadWithType } from "../../types"
+import { GenericChartDataset, PayloadWithType } from "../../types"
 import { CalibrateDataResponse, FilterOption, PlotSettingOption } from "../../generated"
 import { PlotSelectionUpdate, PlotSelectionsMutations } from "./mutations"
-import { filtersInfoFromPlotSettings } from "./utils"
+import { filtersInfoFromPlotSettings, getPlotData } from "./utils"
 import { api } from "../../apiService"
 import { PlotDataMutations, PlotDataUpdate } from "../plotData/mutations"
+import { PlotMetadataFrame } from "../metadata/metadata"
+import { GenericChartMutation } from "../genericChart/mutations"
 
 type Selection = {
     filter: {
@@ -29,10 +31,20 @@ export type PlotSelectionsActions = {
     updateSelections: (store: ActionContext<PlotSelectionsState, RootState>, payload: PayloadWithType<PlotSelectionActionUpdate>) => void
 }
 
+export const getMetadataFromPlotName = (rootState: RootState, plotName: PlotName): PlotMetadataFrame => {
+    const plotDataType = plotNameToDataType[plotName];
+    switch(plotDataType) {
+        case PlotDataType.Output: return rootState.modelCalibrate.metadata!;
+        case PlotDataType.Input: return rootState.metadata.reviewInputMetadata!;
+        case PlotDataType.TimeSeries: return rootState.metadata.reviewInputMetadata!;
+    }
+}
+
 export const actions: ActionTree<PlotSelectionsState, RootState> & PlotSelectionsActions = {
     async updateSelections(context, payload) {
         const { plot, selection } = payload.payload;
         const { state, commit, rootState } = context;
+        const metadata = getMetadataFromPlotName(rootState, plot);
         const updatedSelections: PlotSelectionsState[PlotName]  = {...state[plot]};
         if ("filter" in selection) {
             const fIndex = updatedSelections.filters.findIndex(f => f.stateFilterId === selection.filter.filterId);
@@ -40,18 +52,20 @@ export const actions: ActionTree<PlotSelectionsState, RootState> & PlotSelection
         } else {
             const pIndex = updatedSelections.controls.findIndex(p => p.id === selection.plotSetting.id);
             updatedSelections.controls[pIndex].selection = selection.plotSetting.options;
-            const metadata = rootState.modelCalibrate.metadata!;
             const plotSettingOptions: PlotSettingOption[] = updatedSelections.controls.map(c => {
                 const plotSetting = metadata.plotSettingsControl[plot].plotSettings.find(ps => ps.id === c.id);
                 return plotSetting!.options.find(op => op.id === c.selection[0].id)!;
             });
-            const filtersInfo = filtersInfoFromPlotSettings(plotSettingOptions, plot, rootState);
+            const filtersInfo = filtersInfoFromPlotSettings(plotSettingOptions, plot, rootState, metadata);
             updatedSelections.filters = filtersInfo;
         }
-        await getFilteredData(plot, updatedSelections.filters, context);
+
+        const updatePayload = { plot, selections: updatedSelections } as PlotSelectionUpdate;
+        await getPlotData(updatePayload, commit, rootState);
+
         commit({
             type: PlotSelectionsMutations.updatePlotSelection,
-            payload: { plot, selections: updatedSelections } as PlotSelectionUpdate
+            payload: updatePayload
         });
     }
 }
@@ -61,35 +75,79 @@ type FilteredDataContext = {
     rootState: RootState
 }
 
-export const outputPlots = ["barchart", "choropleth", "bubble", "table"];
+export const getFilteredData = async (plot: OutputPlotName, selections: PlotSelectionUpdate["selections"]["filters"], context: FilteredDataContext) => {
+    const { commit, rootState } = context;
+    const filterTypes = rootState.modelCalibrate.metadata!.filterTypes;
+    const dataFetchPayload: Record<string, string[]> = {};
+    selections.forEach(sel => {
+        const colId = filterTypes.find(f => f.id === sel.filterId)!.column_id;
+        const opIds = sel.selection.map(s => s.id);
+        if (colId in dataFetchPayload) {
+            dataFetchPayload[colId] = [...dataFetchPayload[colId], ...opIds];
+        } else {
+            dataFetchPayload[colId] = opIds;
+        }
+    });
 
-export const getFilteredData = async (plot: PlotName, selections: PlotSelectionUpdate["selections"]["filters"], context: FilteredDataContext) => {
-    if (outputPlots.includes(plot)) {
-        const { commit, rootState } = context;
-        const filterTypes = rootState.modelCalibrate.metadata!.filterTypes;
-        const dataFetchPayload: Record<string, string[]> = {};
-        selections.forEach(sel => {
-            const colId = filterTypes.find(f => f.id === sel.filterId)!.column_id;
-            const opIds = sel.selection.map(s => s.id);
-            if (colId in dataFetchPayload) {
-                dataFetchPayload[colId] = [...dataFetchPayload[colId], ...opIds];
-            } else {
-                dataFetchPayload[colId] = opIds;
-            }
-        });
+    const calibrateId = rootState.modelCalibrate.calibrateId;
+    const response = await api<any, PlotSelectionsMutations>(context as any)
+        .ignoreSuccess()
+        .withError(PlotSelectionsMutations.setError)
+        .freezeResponse()
+        .postAndReturn<CalibrateDataResponse["data"]>(`calibrate/result/filteredData/${calibrateId}`, dataFetchPayload);
+    
+    if (response) {
+        const data = response.data;
+        commit(`plotData/${PlotDataMutations.updatePlotData}`, {
+            payload: { plot, data } as PlotDataUpdate
+        }, { root: true });
+    }
+};
 
-        const calibrateId = rootState.modelCalibrate.calibrateId;
-        const response = await api<any, PlotSelectionsMutations>(context as any)
-            .ignoreSuccess()
-            .withError(PlotSelectionsMutations.setError)
-            .freezeResponse()
-            .postAndReturn<CalibrateDataResponse["data"]>(`calibrate/result/filteredData/${calibrateId}`, dataFetchPayload);
-        
+export const getTimeSeriesFilteredDataset = async (payload: PlotSelectionUpdate, commit: Commit, rootState: RootState) => {
+    commit(`genericChart/${GenericChartMutation.SetError}`, { payload: null }, { root: true });
+    const dataSource = payload.selections.controls.find(c => c.id === "time_series_data_source")!.selection[0].id;
+    // fetch dataset
+    if (!(dataSource in rootState.genericChart.datasets)) {
+        const response = await api<GenericChartMutation, GenericChartMutation>({commit, rootState})
+                            .ignoreSuccess()
+                            .withError(GenericChartMutation.SetError)
+                            .freezeResponse()
+                            .get(`chart-data/input-time-series/${dataSource}`);
         if (response) {
-            const data = response.data;
-            commit(`plotData/${PlotDataMutations.updatePlotData}`, {
-                payload: { plot, data } as PlotDataUpdate
-            }, { root: true });
+            const setDatasetPayload = {
+                datasetId: dataSource,
+                dataset: response.data
+            };
+            commit(`genericChart/${GenericChartMutation.SetDataset}`, { payload: setDatasetPayload }, { root: true });
+            const data = response.data as GenericChartDataset;
+            commit(`genericChart/${GenericChartMutation.WarningsFetched}`, { payload: data.warnings }, { root: true });
         }
     }
+    // filter
+    const metadata = getMetadataFromPlotName(rootState, payload.plot);
+    const { filters } = payload.selections;
+    const filterObject: Record<string, (string| number)[]> = {};
+    filters.forEach(f => {
+        const filterType = metadata.filterTypes.find(ft => ft.id === f.filterId)!;
+        filterObject[filterType.column_id] = filterType.column_id === "area_level" ?
+            f.selection.map(s => parseInt(s.id)) :
+            f.selection.map(s => s.id);
+    });
+    const { data } = rootState.genericChart.datasets[dataSource];
+    const filteredData: Record<string, string | number>[] = [];
+    outer: for (let i = 0; i < data.length; i++) {
+        const currRow = data[i] as Record<string, string | number>;
+        for (const column_id in filterObject) {
+            if (!filterObject[column_id].includes(currRow[column_id])) {
+                continue outer;
+            }
+        }
+        filteredData.push(currRow);
+    }
+    const plotDataPayload: PlotDataUpdate = {
+        plot: payload.plot,
+        data: filteredData
+    };
+    commit(`plotData/${PlotDataMutations.updatePlotData}`, { payload: plotDataPayload }, { root: true });
 };

--- a/src/app/static/src/app/store/plotSelections/plotSelections.ts
+++ b/src/app/static/src/app/store/plotSelections/plotSelections.ts
@@ -1,10 +1,27 @@
-import { CalibrateMetadataResponse, Error, FilterOption, FilterRef } from "../../generated";
+import { CalibrateMetadataResponse, Error, FilterOption, FilterRef, ReviewInputFilterMetadataResponse } from "../../generated";
 import { mutations } from "./mutations";
 import { actions } from "./actions";
 import { getters } from "./getters";
 
-export type PlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
-export const plotNames: PlotName[] = ["barchart", "choropleth", "bubble", "table"]
+export type OutputPlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
+export type InputPlotName = keyof ReviewInputFilterMetadataResponse["plotSettingsControl"]
+
+export const outputPlotNames: OutputPlotName[] = ["barchart", "bubble", "choropleth", "table"];
+export const inputPlotNames: InputPlotName[] = ["timeSeries", "inputChoropleth"];
+
+export type PlotName = OutputPlotName | InputPlotName
+export const plotNames = [...outputPlotNames, ...inputPlotNames];
+
+export enum PlotDataType { Output, TimeSeries, Input }
+
+export const plotNameToDataType: Record<PlotName, PlotDataType> = {
+    barchart: PlotDataType.Output,
+    bubble: PlotDataType.Output,
+    choropleth: PlotDataType.Output,
+    table: PlotDataType.Output,
+    timeSeries: PlotDataType.TimeSeries,
+    inputChoropleth: PlotDataType.Input
+}
 
 export type FilterSelection = {
     multiple: boolean

--- a/src/app/static/src/app/store/plotSelections/utils.ts
+++ b/src/app/static/src/app/store/plotSelections/utils.ts
@@ -1,9 +1,10 @@
-import { ActionContext, Commit } from "vuex";
-import { CalibrateMetadataResponse, FilterOption, FilterTypes, PlotSettingOption } from "../../generated";
-import { PlotName } from "./plotSelections";
+import { Commit } from "vuex";
+import { FilterOption, FilterTypes, PlotSettingOption } from "../../generated";
+import { OutputPlotName, PlotDataType, PlotName, outputPlotNames, plotNameToDataType } from "./plotSelections";
 import { PlotSelectionUpdate, PlotSelectionsMutations } from "./mutations";
 import { RootState } from "../../root";
-import { getFilteredData } from "./actions";
+import { getFilteredData, getTimeSeriesFilteredDataset } from "./actions";
+import { PlotMetadataFrame } from "../metadata/metadata";
 
 export const filtersAfterUseShapeRegions = (filterTypes: FilterTypes[], rootState: RootState) => {
     const filters = [...filterTypes];
@@ -41,9 +42,9 @@ const getFullNestedFilters = (filterOptions: NestedFilterOption[]) => {
 export const filtersInfoFromPlotSettings = (
     settings: PlotSettingOption[],
     plotName: PlotName,
-    rootState: RootState
+    rootState: RootState,
+    metadata: PlotMetadataFrame
 ) => {
-    const metadata = rootState.modelCalibrate.metadata!;
     const filterTypes = filtersAfterUseShapeRegions(metadata.filterTypes, rootState);
     let filterRefs = metadata.plotSettingsControl[plotName].defaultFilterTypes;
     let multiFilters: string[] = [];
@@ -96,8 +97,18 @@ export const filtersInfoFromPlotSettings = (
     return filters;
 }
 
-export const commitPlotDefaultSelections = (
-    metadata: CalibrateMetadataResponse,
+export const getPlotData = async (payload: PlotSelectionUpdate, commit: Commit, rootState: RootState) => {
+    const name = payload.plot;
+    const plotDataType = plotNameToDataType[name];
+    if (plotDataType === PlotDataType.Output) {
+        await getFilteredData(name as OutputPlotName, payload.selections.filters, { commit, rootState });
+    } else if (plotDataType === PlotDataType.TimeSeries) {
+        await getTimeSeriesFilteredDataset(payload, commit, rootState);
+    }
+}
+
+export const commitPlotDefaultSelections = async (
+    metadata: PlotMetadataFrame,
     commit: Commit,
     rootState: RootState
 ) => {
@@ -122,10 +133,10 @@ export const commitPlotDefaultSelections = (
             }
         });
 
-        const filtersInfo = filtersInfoFromPlotSettings(defaultSettingOptions, name, rootState);
+        const filtersInfo = filtersInfoFromPlotSettings(defaultSettingOptions, name, rootState, metadata);
         payload.selections.filters = filtersInfo;
 
-        getFilteredData(name, payload.selections.filters, { commit, rootState })
+        await getPlotData(payload, commit, rootState);
 
         commit(
             `plotSelections/${PlotSelectionsMutations.updatePlotSelection}`,

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -8,6 +8,13 @@ import {DataExplorationState} from "../dataExploration/dataExploration";
 
 export enum DataType { ANC, Program, Survey, Vmmc}
 
+export enum FileType {
+    ANC = "anc",
+    Programme = "programme",
+    Survey = "survey",
+    Shape = "shape"
+}
+
 export interface SAPWarnings {
     type: string,
     warnings: Warning[]

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-tmp-epic-plot-cleanup
+tmp-epic-plot-cleanup-input


### PR DESCRIPTION
This one might be painful, might be worth talking through it in person. Summary of changes:
* new endpoint to fetch review inputs metadata, this metadata comes from https://github.com/mrc-ide/hintr/pull/501
* the metadata is constructed from what data sources are available (the available data sources is sent in the request)
* height per plot increased and subplots are limited to 12 per page, no more scrolling!
* separation of output plot names and input plot names
* make filter components and plot control components general to any plot (they had some hardcoding about pulling active plot from modelOutput state)
* New time series plot components, we should definitely chat about the change in algorithm, will be better explaining in person
* Write filtering for input time series data