### PR TITLE
mrc-4696: Use relative path to read calibrate result data

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -31,6 +31,7 @@ interface AppProperties
     val emailPassword: String
     val tokenIssuer: String
     val uploadDirectory: String
+    val resultsDirectory: String
     val dbUser: String
     val dbPassword: String
     val dbUrl: String
@@ -75,6 +76,7 @@ class ConfiguredAppProperties(private val props: HintProperties = properties) : 
     final override val emailPassword = propString("email_password")
     final override val tokenIssuer = propString("token_issuer")
     final override val uploadDirectory = propString("upload_dir")
+    final override val resultsDirectory = propString("results_dir")
     final override val dbUser: String = propString("db_user")
     final override val dbPassword: String = propString("db_password")
     final override val dbUrl: String = propString("db_url")

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/db/CalibrateDataRepository.kt
@@ -3,6 +3,7 @@ package org.imperial.mrc.hint.db
 import org.jooq.tools.json.JSONArray
 import org.springframework.stereotype.Component
 import org.imperial.mrc.hint.models.CalibrateResultRow
+import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.Statement
@@ -38,7 +39,7 @@ FROM data"""
 interface CalibrateDataRepository
 {
     fun getDataFromPath(
-        path: String,
+        path: Path,
         indicator: String): List<CalibrateResultRow>
 }
 
@@ -87,15 +88,15 @@ class JooqCalibrateDataRepository: CalibrateDataRepository
         return arrayList
     }
 
-    private fun getDBConnFromPathResponse(path: String): Connection {   
+    private fun getDBConnFromPathResponse(path: Path): Connection {
         val readOnlyProp = Properties()
         readOnlyProp.setProperty("duckdb.read_only", "true")
-        val conn = DriverManager.getConnection("jdbc:duckdb:.${path}", readOnlyProp)
+        val conn = DriverManager.getConnection("jdbc:duckdb:${path.toRealPath()}", readOnlyProp)
         return conn
     }
 
     override fun getDataFromPath(
-        path: String,
+        path: Path,
         indicator: String): List<CalibrateResultRow>
     {
         getDBConnFromPathResponse(path).use { conn ->

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLogger.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLogger.kt
@@ -13,6 +13,5 @@ interface GenericLogger
     fun error(request: HttpServletRequest, response: HttpServletResponse, message: String? = null)
     fun error(request: HttpServletRequest, error: Throwable?, status: HttpStatus)
     fun error(request: HttpServletRequest, error: HintException)
-
     fun <K, V> error(message: String, additionalData: Map<K, V>? = null)
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLogger.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLogger.kt
@@ -13,4 +13,6 @@ interface GenericLogger
     fun error(request: HttpServletRequest, response: HttpServletResponse, message: String? = null)
     fun error(request: HttpServletRequest, error: Throwable?, status: HttpStatus)
     fun error(request: HttpServletRequest, error: HintException)
+
+    fun <K, V> error(message: String, additionalData: Map<K, V>? = null)
 }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLoggerImpl.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/logging/GenericLoggerImpl.kt
@@ -37,6 +37,11 @@ class GenericLoggerImpl(
         logger.info("{}, {}", kv("msg", message), e(additionalData))
     }
 
+    override fun <K, V> error(message: String, additionalData: Map<K, V>?)
+    {
+        logger.error("{}, {}", kv("msg", message), e(additionalData))
+    }
+
     override fun error(request: HttpServletRequest, response: HttpServletResponse, message: String?)
     {
         val log = LogMetadata(

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
@@ -1,16 +1,19 @@
 package org.imperial.mrc.hint.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.clients.HintrAPIClient
 import org.imperial.mrc.hint.db.CalibrateDataRepository
+import org.imperial.mrc.hint.exceptions.HintException
 import org.imperial.mrc.hint.logging.GenericLoggerImpl
 import org.imperial.mrc.hint.logging.logDuration
 import org.imperial.mrc.hint.models.CalibrateResultRow
 import org.imperial.mrc.hint.security.Session
-import org.jooq.tools.json.JSONObject
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import kotlin.system.measureTimeMillis
+import java.nio.file.Paths
+import kotlin.io.path.exists
 
 interface CalibrateService
 {
@@ -23,7 +26,8 @@ interface CalibrateService
 class CalibrateDataService(
     private val apiClient: HintrAPIClient,
     private val calibrateDataRepository: CalibrateDataRepository,
-    private val session: Session
+    private val session: Session,
+    private val appProperties: AppProperties
 ) : CalibrateService
 {
 
@@ -35,7 +39,15 @@ class CalibrateDataService(
     {
         val res = apiClient.getCalibrateResultData(id)
         val jsonBody = ObjectMapper().readTree(res.body?.toString())
-        val path = jsonBody.get("data").get("path").textValue()
+        val filePath = jsonBody.get("data").get("path").textValue()
+        val path = Paths.get(appProperties.resultsDirectory, filePath)
+
+        if (!path.exists()) {
+            logger.error("Calibrate data missing where it should exist", mapOf(
+                "path" to path.toAbsolutePath(),
+                "calibrateId" to id))
+            throw HintException("missingCalibrateData", HttpStatus.BAD_REQUEST)
+        }
 
         val userId = this.session.getUserProfile().id
         val logData = mutableMapOf(

--- a/src/app/src/main/resources/ErrorMessageBundle.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle.properties
@@ -16,3 +16,4 @@ noPermissionToAccessResource=You do not have permission to load this resource fr
 adrResourceError=Unable to load resource, check resource in ADR {0}.
 adrFetchingDatasetsError=There was an error fetching datasets from ADR.
 adrFetchingDatasetsNoAccountError=Cannot fetch datasets from the ADR as you do not yet have an account. Please login to the ADR with your Auth0 credentials and then return here and try again.
+missingCalibrateData=No calibration output found for this project, please report an issue or re-calibrate the model

--- a/src/app/src/main/resources/ErrorMessageBundle_fr.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_fr.properties
@@ -17,3 +17,4 @@ noPermissionToAccessResource=Vous n''êtes pas autorisé à charger cette ressou
 adrResourceError=Impossible de charger la ressource, vérifiez la ressource dans ADR {0}.
 adrFetchingDatasetsError=Une erreur s'est produite lors de la récupération des ensembles de données à partir d'ADR
 adrFetchingDatasetsNoAccountError=Impossible de récupérer les ensembles de données de l'ADR car vous n'avez pas encore de compte. Veuillez vous connecter à l'ADR avec vos informations d'identification Auth0, puis revenir ici et réessayer.
+missingCalibrateData=Aucune sortie de calibration n'a été trouvée pour ce projet, veuillez signaler un problème ou recalibrer le modèle.

--- a/src/app/src/main/resources/ErrorMessageBundle_pt.properties
+++ b/src/app/src/main/resources/ErrorMessageBundle_pt.properties
@@ -16,3 +16,4 @@ noPermissionToAccessResource=Você não tem permissão para carregar este recurs
 adrResourceError=Não é possível carregar o recurso, verifique o recurso no ADR {0}.
 adrFetchingDatasetsError=Ocorreu um erro ao obter conjuntos de dados do ADR
 adrFetchingDatasetsNoAccountError=Não é possível buscar conjuntos de dados do ADR porque você ainda não possui uma conta. Faça login no ADR com suas credenciais Auth0, retorne aqui e tente novamente.
+missingCalibrateData=Não foi encontrado nenhum resultado de calibração para este projeto, comunique um problema ou volte a calibrar o modelo

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -19,6 +19,7 @@ email_sender=naomi-notifications@imperial.ac.uk
 email_username=naomi
 email_password=
 upload_dir=uploads
+results_dir=results
 token_issuer=mrc-ide
 hintr_url=http://localhost:8888
 db_user=hintuser

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/database/CalibrateDataRepositoryTests.kt
@@ -7,6 +7,7 @@ import org.jooq.tools.json.JSONArray
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.assertThat
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
 import java.sql.SQLException
 
 class CalibrateDataRepositoryTests
@@ -51,7 +52,7 @@ class CalibrateDataRepositoryTests
             2
         )
     ))
-    val path = "/src/test/resources/duckdb/test.duckdb"
+    val path = Paths.get("src/test/resources/duckdb/test.duckdb")
     val sut = JooqCalibrateDataRepository()
 
     @Test
@@ -83,8 +84,8 @@ class CalibrateDataRepositoryTests
     fun `throws error if connection is invalid`()
     {
         assertThatThrownBy {
-            sut.getDataFromPath("/src/test/resources/duckdb/test1.duckdb", "all")
-        }.isInstanceOf(SQLException::class.java)
-            .hasMessageContaining("database does not exist")
+            sut.getDataFromPath(Paths.get("src/test/resources/duckdb/test1.duckdb"), "all")
+        }.isInstanceOf(java.nio.file.NoSuchFileException::class.java)
+            .hasMessageContaining("src/test/resources/duckdb/test1.duckdb")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/helpers/LogMemoryAppender.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/helpers/LogMemoryAppender.kt
@@ -7,22 +7,20 @@ import java.util.*
 import java.util.function.Predicate
 import java.util.stream.Collectors
 
-class MemoryAppender : ListAppender<ILoggingEvent?>() {
+class LogMemoryAppender : ListAppender<ILoggingEvent?>() {
     fun reset() {
-        list.clear()
+        this.list.clear()
     }
 
     fun contains(string: String, level: Level): Boolean {
-        return list.stream()
+        return this.list.stream()
             .anyMatch(Predicate { event: ILoggingEvent? ->
                 event!!.toString().contains(string) && event.level == level
             })
     }
 
     fun countEventsForLogger(loggerName: String): Int {
-        print(list)
-        print(list.count())
-        return list.stream()
+        return this.list.stream()
             .filter(Predicate { event: ILoggingEvent? ->
                 event!!.loggerName.contains(loggerName)
             })
@@ -30,6 +28,6 @@ class MemoryAppender : ListAppender<ILoggingEvent?>() {
     }
 
     fun get(index: Int): ILoggingEvent? {
-        return list[index]
+        return this.list[index]
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/GenericLoggerImplTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/GenericLoggerImplTests.kt
@@ -9,7 +9,7 @@ import com.nhaarman.mockito_kotlin.verify
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.exceptions.HintException
-import org.imperial.mrc.hint.helpers.MemoryAppender
+import org.imperial.mrc.hint.helpers.LogMemoryAppender
 import org.imperial.mrc.hint.logging.*
 import org.imperial.mrc.hint.models.ErrorDetail
 import org.junit.jupiter.api.BeforeAll
@@ -27,24 +27,24 @@ class GenericLoggerImplTests
     companion object {
 
         lateinit var testLogger: org.slf4j.Logger
-        lateinit var memoryAppender: MemoryAppender
+        lateinit var memoryAppender: LogMemoryAppender
 
         @BeforeAll
         @JvmStatic
         fun setup() {
             testLogger = LoggerFactory.getLogger(GenericLoggerImpl::class.java) as Logger
-            memoryAppender = MemoryAppender()
+            memoryAppender = LogMemoryAppender()
             memoryAppender.context = LoggerFactory.getILoggerFactory() as LoggerContext
-            (testLogger as Logger).setLevel(Level.DEBUG)
+            (testLogger as Logger).level = Level.DEBUG
             (testLogger as Logger).addAppender(memoryAppender)
             memoryAppender.start()
         }
+    }
 
-        @BeforeEach
-        fun resetAppender()
-        {
-            memoryAppender.reset()
-        }
+    @BeforeEach
+    fun resetAppender()
+    {
+        memoryAppender.reset()
     }
 
     private val mockLogger = mock<org.slf4j.Logger>()
@@ -135,9 +135,9 @@ class GenericLoggerImplTests
             "thing" to 423
         )
         val logger = GenericLoggerImpl(testLogger)
-        logger.info("My example message", additionalData)
+        logger.info("My info message", additionalData)
         Assertions.assertThat(memoryAppender.countEventsForLogger("org.imperial.mrc.hint.logging.GenericLoggerImpl")).isEqualTo(1)
-        Assertions.assertThat(memoryAppender.get(0).toString()).isEqualTo("[INFO] msg=My example message, {foo=bar, thing=423}")
+        Assertions.assertThat(memoryAppender.get(0).toString()).isEqualTo("[INFO] msg=My info message, {foo=bar, thing=423}")
     }
 
     @Test
@@ -148,9 +148,9 @@ class GenericLoggerImplTests
             "thing" to 423
         )
         val logger = GenericLoggerImpl(testLogger)
-        logger.error("My example message", additionalData)
+        logger.error("My err message", additionalData)
         Assertions.assertThat(memoryAppender.countEventsForLogger("org.imperial.mrc.hint.logging.GenericLoggerImpl")).isEqualTo(1)
-        Assertions.assertThat(memoryAppender.get(0).toString()).isEqualTo("[ERROR] msg=My example message, {foo=bar, thing=423}")
+        Assertions.assertThat(memoryAppender.get(0).toString()).isEqualTo("[ERROR] msg=My err message, {foo=bar, thing=423}")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/GenericLoggerImplTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/GenericLoggerImplTests.kt
@@ -141,6 +141,19 @@ class GenericLoggerImplTests
     }
 
     @Test
+    fun `can log error with generic additional data`()
+    {
+        val additionalData = mapOf(
+            "foo" to "bar",
+            "thing" to 423
+        )
+        val logger = GenericLoggerImpl(testLogger)
+        logger.error("My example message", additionalData)
+        Assertions.assertThat(memoryAppender.countEventsForLogger("org.imperial.mrc.hint.logging.GenericLoggerImpl")).isEqualTo(1)
+        Assertions.assertThat(memoryAppender.get(0).toString()).isEqualTo("[ERROR] msg=My example message, {foo=bar, thing=423}")
+    }
+
+    @Test
     fun `can log error with HttpRequest, HttpResponse and message`()
     {
         val loggedData = LogMetadata(

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/LogElapsedTimeCallbackTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/logging/LogElapsedTimeCallbackTests.kt
@@ -9,7 +9,7 @@ import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions
 import org.imperial.mrc.hint.clients.ADRClient
 import org.imperial.mrc.hint.clients.FuelClient
-import org.imperial.mrc.hint.helpers.MemoryAppender
+import org.imperial.mrc.hint.helpers.LogMemoryAppender
 import org.imperial.mrc.hint.logging.GenericLogger
 import org.imperial.mrc.hint.logging.GenericLoggerImpl
 import org.imperial.mrc.hint.logging.logADRRequestDuration
@@ -35,24 +35,24 @@ class LogElapsedTimeCallbackTests
     companion object {
 
         lateinit var testLogger: org.slf4j.Logger
-        lateinit var memoryAppender: MemoryAppender
+        lateinit var memoryAppender: LogMemoryAppender
 
         @BeforeAll
         @JvmStatic
         fun setup() {
             testLogger = LoggerFactory.getLogger(GenericLoggerImpl::class.java) as Logger
-            memoryAppender = MemoryAppender()
+            memoryAppender = LogMemoryAppender()
             memoryAppender.context = LoggerFactory.getILoggerFactory() as LoggerContext
             (testLogger as Logger).setLevel(Level.DEBUG)
             (testLogger as Logger).addAppender(memoryAppender)
             memoryAppender.start()
         }
+    }
 
-        @BeforeEach
-        fun resetAppender()
-        {
-            memoryAppender.reset()
-        }
+    @BeforeEach
+    fun resetAppender()
+    {
+        memoryAppender.reset()
     }
 
     @Test

--- a/src/app/static/scripts/test.properties
+++ b/src/app/static/scripts/test.properties
@@ -1,3 +1,4 @@
 hintr_url=http://hintr:8888
 upload_dir=/uploads
+results_dir=/results
 db_url=jdbc:postgresql://hint_db/hint

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.7.1";
+export const currentHintVersion = "3.7.2";

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-master
+relative-path


### PR DESCRIPTION
## Description

This PR will update calibrate data to use path relative to the mounted results dir. Should make testing and deployment a bit simpler as we no longer have to have the results mounted at the same place.

Before this is merged we need to merge
* https://github.com/mrc-ide/hintr/pull/471
* https://github.com/mrc-ide/hint-deploy/pull/76
* Remove branch pin here

Getting this moving again now as I think we will want it to pass through the path to the downloads so that we can have a progress bar on them. See https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-5218/Show-native-browser-progress-on-download for some context

## Type of version change
_Delete as appropriate_

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
