### PR TITLE
Mrc 4840 Fix tests part 1

### DIFF
--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -9,7 +9,7 @@
     "build": "rm -rf public && vue-cli-service build ./src/app/index.ts",
     "serve": "rm -rf public && VUE_CLI_SERVICE_CONFIG_PATH=$PWD/vue.config.js vue-cli-service serve ./src/app/index.ts",
     "copy": "cp -r ./templates/*.ftl ./public && cp -r ./assets/* ./public",
-    "test": "vitest --run",
+    "test": "vitest",
     "browser-test": "npx playwright test",
     "integration-test": "jest --testPathIgnorePatterns adr-dataset -c jest.integration.config.js",
     "adr-integration-test": "jest --testPathPattern adr-dataset -c jest.integration.adr.config.js",

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -15,6 +15,7 @@ import {UploadFile} from "../../app/types";
 import Vuex from "vuex";
 import {RootState} from "../../app/root";
 import {mutations as baselineMutations} from "../../app/store/baseline/mutations";
+import { Mock } from "vitest";
 
 describe("ADR upload actions", () => {
     const state = mockADRUploadState();
@@ -26,7 +27,7 @@ describe("ADR upload actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("getUploadFiles does nothing if no selected dataset", async () => {

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -8,6 +8,7 @@ import {
     mockSuccess
 } from "./mocks";
 import {freezer} from '../app/utils';
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 
@@ -20,8 +21,8 @@ describe("ApiService", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
-        (console.warn as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
+        (console.warn as Mock).mockClear();
         vi.clearAllMocks();
     });
 
@@ -35,9 +36,9 @@ describe("ApiService", () => {
         } catch (e) {
 
         }
-        expect((console.warn as vi.Mock).mock.calls[0][0])
+        expect((console.warn as Mock).mock.calls[0][0])
             .toBe("No error handler registered for request /baseline/.");
-        expect((console.log as vi.Mock).mock.calls[0][0].errors[0].detail)
+        expect((console.log as Mock).mock.calls[0][0].errors[0].detail)
             .toBe("some error message");
     });
 
@@ -51,7 +52,7 @@ describe("ApiService", () => {
         await api({commit, rootState} as any)
             .get("/unusual/");
 
-        expect((console.warn as vi.Mock).mock.calls[0][0])
+        expect((console.warn as Mock).mock.calls[0][0])
             .toBe("No error handler registered for request /unusual/.");
 
         expect(commit.mock.calls.length).toBe(1);
@@ -77,7 +78,7 @@ describe("ApiService", () => {
         await api({commit, rootState} as any)
             .get("/unusual/");
 
-        expect((console.warn as vi.Mock).mock.calls[0][0])
+        expect((console.warn as Mock).mock.calls[0][0])
             .toBe("No error handler registered for request /unusual/.");
 
         expect(commit.mock.calls.length).toBe(1);
@@ -381,7 +382,7 @@ describe("ApiService", () => {
             .ignoreErrors()
             .get("/baseline/");
 
-        expect((console.warn as vi.Mock).mock.calls.length).toBe(0);
+        expect((console.warn as Mock).mock.calls.length).toBe(0);
     });
 
     it("warns if error and success handlers are not set", async () => {
@@ -392,7 +393,7 @@ describe("ApiService", () => {
         await api({commit: vi.fn(), rootState} as any)
             .get("/baseline/");
 
-        const warnings = (console.warn as vi.Mock).mock.calls;
+        const warnings = (console.warn as Mock).mock.calls;
 
         expect(warnings[0][0]).toBe("No error handler registered for request /baseline/.");
         expect(warnings[1][0]).toBe("No success handler registered for request /baseline/.");

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -17,8 +17,8 @@ import {actions} from "../../app/store/baseline/actions";
 import {BaselineMutation} from "../../app/store/baseline/mutations";
 import {expectEqualsFrozen, testUploadErrorCommitted} from "../testHelpers";
 import {ADRSchemas} from "../../app/types";
-import Mock = vi.Mock;
 import {initialChorplethSelections} from "../../app/store/plottingSelections/plottingSelections";
+import { Mock } from "vitest";
 
 const adrSchemas: ADRSchemas = {
     baseUrl: "adr.com",
@@ -174,7 +174,7 @@ describe("Baseline actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("sets country and iso3 after PJNZ file upload, and fetches plotting metadata, and validates", async () => {

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -27,9 +27,9 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {expectTranslatedWithStoreType, mountWithTranslate, shallowMountWithTranslate} from "../../testHelpers";
 import {ADRState} from "../../../app/store/adr/adr";
 import ResetConfirmation from "../../../app/components/resetConfirmation/ResetConfirmation.vue";
-import Mock = vi.Mock;
 import HintTreeSelect from "../../../app/components/HintTreeSelect.vue";
 import {getters} from "../../../app/store/root/getters";
+import { Mock } from "vitest";
 
 describe("select dataset", () => {
 

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -55,6 +55,7 @@ import {ModelCalibrateMutation} from "../../app/store/modelCalibrate/mutations";
 import {LanguageMutation} from "../../app/store/language/mutations";
 import {Language} from "../../app/store/translations/locales";
 import { nextTick } from 'vue';
+import { Mock } from 'vitest';
 
 describe("App", () => {
 
@@ -64,8 +65,8 @@ describe("App", () => {
     });
 
     afterAll(() => {
-        (console.log as vi.Mock).mockClear();
-        (console.error as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
+        (console.error as Mock).mockClear();
     });
 
     const getStore = (ready: boolean = false) => {
@@ -82,24 +83,21 @@ describe("App", () => {
         return new Vuex.Store<RootState>(localStoreOptions);
     };
 
-    it("loads input data on mount", (done) => {
+    it("loads input data on mount", async () => {
         const store = getStore();
         mount(Hint, {
             global: {
                 plugins: [store]
             }
         });
-
-        setTimeout(() => {
-            expect(baselineActions.getBaselineData).toHaveBeenCalled();
-            expect(surveyAndProgramActions.getSurveyAndProgramData).toHaveBeenCalled();
-            expect(modelRunActions.getResult).toHaveBeenCalled();
-            expect(modelCalibrateActions.getResult).toHaveBeenCalled();
-            expect(adrActions.getSchemas).toHaveBeenCalled();
-            expect(projectsActions.getCurrentProject).toHaveBeenCalled();
-            expect(genericChartActions.getGenericChartMetadata).toHaveBeenCalled();
-            done();
-        });
+        await nextTick();
+        expect(baselineActions.getBaselineData).toHaveBeenCalled();
+        expect(surveyAndProgramActions.getSurveyAndProgramData).toHaveBeenCalled();
+        expect(modelRunActions.getResult).toHaveBeenCalled();
+        expect(modelCalibrateActions.getResult).toHaveBeenCalled();
+        expect(adrActions.getSchemas).toHaveBeenCalled();
+        expect(projectsActions.getCurrentProject).toHaveBeenCalled();
+        expect(genericChartActions.getGenericChartMetadata).toHaveBeenCalled();
     });
 
     it("gets language from state", () => {

--- a/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
+++ b/src/app/static/src/tests/components/files/fileUploadWithEditConfirmation.test.ts
@@ -6,6 +6,7 @@ import {mockFile, mockRootState} from "../../mocks";
 import {emptyState, RootState} from "../../../app/root";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {getters} from "../../../app/store/root/getters";
+import { nextTick } from "vue";
 
 describe("File upload component", () => {
 
@@ -65,7 +66,7 @@ describe("File upload component", () => {
         expect(uploadConfirmationModal(wrapper).props("open")).toBe(true);
     });
 
-    it("uploads file if user confirms edit", (done) => {
+    it("uploads file if user confirms edit", async () => {
         const uploader = vi.fn();
         const wrapper = createSut({
             upload: uploader
@@ -80,14 +81,12 @@ describe("File upload component", () => {
         (wrapper.vm as any).handleFileSelect();
         uploadConfirmationModal(wrapper).find(".btn-red").trigger("click");
 
-        setTimeout(() => {
-            expect(uploader.mock.calls.length).toBe(1);
-            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
-            done();
-        });
+        await nextTick();
+        expect(uploader.mock.calls.length).toBe(1);
+        expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
     });
 
-    it("does not upload file if user cancels edit", (done) => {
+    it("does not upload file if user cancels edit", async () => {
         const uploader = vi.fn();
         const wrapper = createSut({
             upload: uploader
@@ -100,11 +99,9 @@ describe("File upload component", () => {
         (wrapper.vm as any).handleFileSelect();
         uploadConfirmationModal(wrapper).find(".btn-white").trigger("click");
 
-        setTimeout(() => {
-            expect(uploader.mock.calls.length).toBe(0);
-            expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
-            done();
-        });
+        await nextTick();
+        expect(uploader.mock.calls.length).toBe(0);
+        expect(uploadConfirmationModal(wrapper).props("open")).toBe(false);
     });
 
 });

--- a/src/app/static/src/tests/components/genericChart/genericChart.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChart.test.ts
@@ -197,7 +197,7 @@ describe("GenericChart component", () => {
         return shallowMountWithTranslate(GenericChart, store, {global: {plugins: [store]}, props});
     };
 
-    it("renders as expected without chart data", (done) => {
+    it("renders as expected without chart data", async () => {
         mockAxios.onGet(`/dataset1`)
             .reply(200, mockSuccess({metadata: {defaults: {}}}));
         mockAxios.onGet(`/dataset2`)
@@ -206,109 +206,103 @@ describe("GenericChart component", () => {
             .reply(200, mockSuccess({metadata: {defaults: {}}}));
 
         const wrapper = getWrapper();
-        setTimeout(() => {
-            expect(wrapper.findAllComponents(DataSource).length).toBe(0);
-            expect(wrapper.findAllComponents(FiltersComp).length).toBe(0);
-            expect(wrapper.findComponent(Plotly).exists()).toBe(false);
-            expect(wrapper.findComponent(LoadingSpinner).attributes("size")).toBe("lg");
-            expectTranslated(wrapper.find("h2"), "Loading your data", "Chargement de vos données",
-                "A carregar os seus dados", wrapper.vm.$store);
-            done();
-        });
+        await flushPromises();
+        expect(wrapper.findAllComponents(DataSource).length).toBe(0);
+        expect(wrapper.findAllComponents(FiltersComp).length).toBe(0);
+        expect(wrapper.findComponent(Plotly).exists()).toBe(false);
+        expect(wrapper.findComponent(LoadingSpinner).attributes("size")).toBe("lg");
+        expectTranslated(wrapper.find("h2"), "Loading your data", "Chargement de vos données",
+            "A carregar os seus dados", wrapper.vm.$store);
     });
 
-    it("renders as expected with chart data", (done) => {
+    it("renders as expected with chart data", async () => {
         const state = {datasets};
         const wrapper = getWrapper(state);
+        await flushPromises();
+        const dataSources = wrapper.findAllComponents(DataSource);
+        expect(dataSources.length).toBe(2); //It should not show non-editable data sources
 
-        setTimeout(() => {
-            const dataSources = wrapper.findAllComponents(DataSource);
-            expect(dataSources.length).toBe(2); //It should not show non-editable data sources
+        expect(dataSources[0].props("config")).toStrictEqual(
+            {
+                id: "visible1",
+                type: "editable",
+                label: "First",
+                datasetId: "dataset1",
+                showFilters: true,
+                showIndicators: false
+            }
+        );
+        expect(dataSources[0].props("datasets")).toStrictEqual(metadata["test-chart"].datasets);
+        expect(dataSources[0].props("value")).toBe("dataset1");
 
-            expect(dataSources[0].props("config")).toStrictEqual(
-                {
-                    id: "visible1",
-                    type: "editable",
-                    label: "First",
-                    datasetId: "dataset1",
-                    showFilters: true,
-                    showIndicators: false
-                }
-            );
-            expect(dataSources[0].props("datasets")).toStrictEqual(metadata["test-chart"].datasets);
-            expect(dataSources[0].props("value")).toBe("dataset1");
+        expect(dataSources[1].props("config")).toStrictEqual(
+            {
+                id: "visible2",
+                type: "editable",
+                label: "Second",
+                datasetId: "dataset2",
+                showFilters: false,
+                showIndicators: false
+            }
+        );
+        expect(dataSources[1].props("datasets")).toStrictEqual(metadata["test-chart"].datasets);
+        expect(dataSources[1].props("value")).toBe("dataset2");
 
-            expect(dataSources[1].props("config")).toStrictEqual(
-                {
-                    id: "visible2",
-                    type: "editable",
-                    label: "Second",
-                    datasetId: "dataset2",
-                    showFilters: false,
-                    showIndicators: false
-                }
-            );
-            expect(dataSources[1].props("datasets")).toStrictEqual(metadata["test-chart"].datasets);
-            expect(dataSources[1].props("value")).toBe("dataset2");
+        const filters = wrapper.findAllComponents(FiltersComp);
+        expect(filters.length).toBe(2);
+        expect(filters[0].props("filters")).toStrictEqual([
+            {
+                id: "age",
+                column_id: "age",
+                label: "Age",
+                allowMultiple: false,
+                options: [
+                    {id: "1", label: "1"},
+                    {id: "2", label: "2"}
+                ]
+            },
+            {
+                id: "year",
+                column_id: "year",
+                label: "Year",
+                allowMultiple: true,
+                options: [
+                    {id: "2020", label: "2020"},
+                    {id: "2021", label: "2021"}
+                ]
+            }
+        ],);
+        expect(filters[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
+        expect(filters[1].props("filters")).toStrictEqual( [
+            {
+                id: "type",
+                column_id: "type",
+                label: "Type",
+                allowMultiple: false,
+                options: [{id: "test", label: "test"}]
+            }
+        ]);
+        expect(filters[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset3.metadata.defaults.selected_filter_options);
 
-            const filters = wrapper.findAllComponents(FiltersComp);
-            expect(filters.length).toBe(2);
-            expect(filters[0].props("filters")).toStrictEqual([
-                {
-                    id: "age",
-                    column_id: "age",
-                    label: "Age",
-                    allowMultiple: false,
-                    options: [
-                        {id: "1", label: "1"},
-                        {id: "2", label: "2"}
-                    ]
-                },
-                {
-                    id: "year",
-                    column_id: "year",
-                    label: "Year",
-                    allowMultiple: true,
-                    options: [
-                        {id: "2020", label: "2020"},
-                        {id: "2021", label: "2021"}
-                    ]
-                }
-            ],);
-            expect(filters[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
-            expect(filters[1].props("filters")).toStrictEqual( [
-                {
-                    id: "type",
-                    column_id: "type",
-                    label: "Type",
-                    allowMultiple: false,
-                    options: [{id: "test", label: "test"}]
-                }
-            ]);
-            expect(filters[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset3.metadata.defaults.selected_filter_options);
-
-            const plotly = wrapper.findComponent(Plotly);
-            expect(plotly.props("chartData")).toStrictEqual({
-                visible1: [{age: "1", year: "2021", value: 2}],
-                visible2: [
-                    {age: "10", year: "2020", value: 10},
-                    {age: "20", year: "2020", value: 30}
-                ],
-                hidden: [{type: "test", value: "test"}]
-            });
-            expect(plotly.props("layoutData")).toStrictEqual({yAxisFormat: ""});
-            expect((plotly.element as HTMLElement).style.height).toBe("100%");
-
-            expect(wrapper.findComponent(ErrorAlert).exists()).toBe(false);
-            expect(wrapper.find("#empty-generic-chart-data").exists()).toBe(false);
-
-            expect(wrapper.find("#page-controls").exists()).toBe(false);
-
-            done();
+        const plotly = wrapper.findComponent(Plotly);
+        expect(plotly.props("chartData")).toStrictEqual({
+            visible1: [{age: "1", year: "2021", value: 2}],
+            visible2: [
+                {age: "10", year: "2020", value: 10},
+                {age: "20", year: "2020", value: 30}
+            ],
+            hidden: [{type: "test", value: "test"}]
         });
+        expect(plotly.props("layoutData")).toStrictEqual({yAxisFormat: ""});
+        expect((plotly.element as HTMLElement).style.height).toBe("100%");
+
+        expect(wrapper.findComponent(ErrorAlert).exists()).toBe(false);
+        expect(wrapper.find("#empty-generic-chart-data").exists()).toBe(false);
+
+        expect(wrapper.find("#page-controls").exists()).toBe(false);
     });
 
-    it("renders as expected with empty chart data", (done) => {
+    it("renders as expected with empty chart data", async () => {
         const datasetsWithNoMatchingData = {
             dataset1: {
                 metadata: datasets.dataset1.metadata,
@@ -338,55 +332,52 @@ describe("GenericChart component", () => {
         };
         const state = {datasets: datasetsWithNoMatchingData};
         const wrapper = getWrapper(state);
-        setTimeout(() => {
-            expect(wrapper.findComponent(Plotly).exists()).toBe(false);
-            const noDataDiv = wrapper.find("#empty-generic-chart-data");
-            expectTranslated(noDataDiv,
-                "No data are available for the selected combination. Please review the combination of filter values selected.",
-               "Aucune donnée n'est disponible pour la combinaison sélectionnée. Veuillez examiner la combinaison de valeurs de filtre sélectionnée.",
-                "Não existem dados disponíveis para a combinação selecionada. Por favor, reveja a combinação dos valores de filtro selecionados.",
-                wrapper.vm.$store
-            );
+        await flushPromises();
+        expect(wrapper.findComponent(Plotly).exists()).toBe(false);
+        const noDataDiv = wrapper.find("#empty-generic-chart-data");
+        expectTranslated(noDataDiv,
+            "No data are available for the selected combination. Please review the combination of filter values selected.",
+            "Aucune donnée n'est disponible pour la combinaison sélectionnée. Veuillez examiner la combinaison de valeurs de filtre sélectionnée.",
+            "Não existem dados disponíveis para a combinação selecionada. Por favor, reveja a combinação dos valores de filtro selecionados.",
+            wrapper.vm.$store
+        );
 
-            expect(wrapper.findAllComponents(DataSource).length).toBe(2);
-            const filters = wrapper.findAllComponents(FiltersComp);
-            expect(filters.length).toBe(2);
-            expect(filters[0].props("filters")).toStrictEqual([
-                {
-                    id: "age",
-                    column_id: "age",
-                    label: "Age",
-                    allowMultiple: false,
-                    options: [
-                        {id: "1", label: "1"},
-                        {id: "2", label: "2"}
-                    ]
-                },
-                {
-                    id: "year",
-                    column_id: "year",
-                    label: "Year",
-                    allowMultiple: true,
-                    options: [
-                        {id: "2020", label: "2020"},
-                        {id: "2021", label: "2021"}
-                    ]
-                }
-            ],);
-            expect(filters[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
-            expect(filters[1].props("filters")).toStrictEqual( [
-                {
-                    id: "type",
-                    column_id: "type",
-                    label: "Type",
-                    allowMultiple: false,
-                    options: [{id: "test", label: "test"}]
-                }
-            ]);
-            expect(filters[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset3.metadata.defaults.selected_filter_options);
-
-            done();
-        });
+        expect(wrapper.findAllComponents(DataSource).length).toBe(2);
+        const filters = wrapper.findAllComponents(FiltersComp);
+        expect(filters.length).toBe(2);
+        expect(filters[0].props("filters")).toStrictEqual([
+            {
+                id: "age",
+                column_id: "age",
+                label: "Age",
+                allowMultiple: false,
+                options: [
+                    {id: "1", label: "1"},
+                    {id: "2", label: "2"}
+                ]
+            },
+            {
+                id: "year",
+                column_id: "year",
+                label: "Year",
+                allowMultiple: true,
+                options: [
+                    {id: "2020", label: "2020"},
+                    {id: "2021", label: "2021"}
+                ]
+            }
+        ],);
+        expect(filters[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
+        expect(filters[1].props("filters")).toStrictEqual( [
+            {
+                id: "type",
+                column_id: "type",
+                label: "Type",
+                allowMultiple: false,
+                options: [{id: "test", label: "test"}]
+            }
+        ]);
+        expect(filters[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset3.metadata.defaults.selected_filter_options);
     });
 
     it("does not render DataSource component when available datasetIds length is not greater than 1", async () => {
@@ -451,35 +442,31 @@ describe("GenericChart component", () => {
         expect(vm.dataSourceSelections.hidden.datasetId).toEqual("dataset2")
     });
 
-    it("updates filter selections and chart data on filters update", (done) => {
+    it("updates filter selections and chart data on filters update", async () => {
         const state = {datasets};
         const wrapper = getWrapper(state);
+        await flushPromises();
+        const dataset1Filters = wrapper.findAllComponents(FiltersComp)[0];
+        const newFilterSelections = {
+            age: [{id: "2", label: "2"}],
+            year: [{id: "2020", label: "2020"}]
+        };
+        dataset1Filters.vm.$emit("update:filters", newFilterSelections);
 
-        setTimeout(() => {
-            const dataset1Filters = wrapper.findAllComponents(FiltersComp)[0];
-            const newFilterSelections = {
-                age: [{id: "2", label: "2"}],
-                year: [{id: "2020", label: "2020"}]
-            };
-            dataset1Filters.vm.$emit("update:filters", newFilterSelections);
-
-            setTimeout(() => {
-                expect(dataset1Filters.props("selectedFilterOptions")).toStrictEqual(newFilterSelections);
-                const chartData = wrapper.findComponent(Plotly).props("chartData");
-                expect(chartData).toStrictEqual({
-                    visible1: [{age: "2", year: "2020", value: 3}],
-                    visible2: [
-                        {age: "10", year: "2020", value: 10},
-                        {age: "20", year: "2020", value: 30}
-                    ],
-                    hidden: [{type: "test", value: "test"}]
-                });
-                done();
-            });
+        await nextTick();
+        expect(dataset1Filters.props("selectedFilterOptions")).toStrictEqual(newFilterSelections);
+        const chartData = wrapper.findComponent(Plotly).props("chartData");
+        expect(chartData).toStrictEqual({
+            visible1: [{age: "2", year: "2020", value: 3}],
+            visible2: [
+                {age: "10", year: "2020", value: 10},
+                {age: "20", year: "2020", value: 30}
+            ],
+            hidden: [{type: "test", value: "test"}]
         });
     });
 
-    it("sets plotly layoutData and height based on subplot config", (done) => {
+    it("sets plotly layoutData and height based on subplot config", async () => {
         const subplotsMetadata: GenericChartMetadataResponse = {
             "test-chart": {
                 datasets: [
@@ -535,30 +522,28 @@ describe("GenericChart component", () => {
         const state = {datasets: subplotDatasets};
 
         const wrapper = getWrapper(state, subplotsMetadata);
-        setTimeout(() => {
-            const dataSources = wrapper.findAllComponents(DataSource);
-            expect(dataSources.length).toBe(1);
-            const filters = wrapper.findAllComponents(FiltersComp);
-            expect(filters.length).toBe(1);
+        await flushPromises();
+        const dataSources = wrapper.findAllComponents(DataSource);
+        expect(dataSources.length).toBe(1);
+        const filters = wrapper.findAllComponents(FiltersComp);
+        expect(filters.length).toBe(1);
 
-            const plotly = wrapper.findComponent(Plotly);
-            // 5 values of distinctColumn, so should be 3 rows of 2 columns
-            expect(plotly.props("layoutData")).toStrictEqual({
-                subplots: {
-                    columns: 2,
-                    distinctColumn: "area",
-                    heightPerRow: 100,
-                    subplotsPerPage: 99,
-                    rows: 3
-                },
-                yAxisFormat: ""
-            });
-            expect((plotly.element as HTMLElement).style.height).toBe("370px");
-            done();
+        const plotly = wrapper.findComponent(Plotly);
+        // 5 values of distinctColumn, so should be 3 rows of 2 columns
+        expect(plotly.props("layoutData")).toStrictEqual({
+            subplots: {
+                columns: 2,
+                distinctColumn: "area",
+                heightPerRow: 100,
+                subplotsPerPage: 99,
+                rows: 3
+            },
+            yAxisFormat: ""
         });
+        expect((plotly.element as HTMLElement).style.height).toBe("370px");
     });
 
-    it("sets plotly and table Format based on configured valueFormatColumn selected option", (done) => {
+    it("sets plotly and table Format based on configured valueFormatColumn selected option", async () => {
         const valueFormatMetadata: GenericChartMetadataResponse = {
             "test-chart": {
                 datasets: [
@@ -616,44 +601,43 @@ describe("GenericChart component", () => {
         const state = {datasets: valueFormatDatasets};
 
         const wrapper = getWrapper(state, valueFormatMetadata);
-        setTimeout(() => {
-            const plotly = wrapper.findComponent(Plotly);
-            expect(plotly.props("layoutData")).toStrictEqual({
-                yAxisFormat: ".1%"
-            });
-            expect(wrapper.findComponent(GenericChartTable).props("valueFormat")).toBe(".1%");
-            expect(wrapper.findComponent(DownloadIndicator).props()).toEqual(
-                {
-                    unfilteredData: [
-                        {
-                            area: "a",
-                            plot_type: "p1",
-                            type: "test"
-                        },
-                        {
-                            area: "b",
-                            plot_type: "p2",
-                            type: "test"
-                        }
-                    ],
-                    filteredData: [
-                        {
-                            area: "a",
-                            plot_type: "p1",
-                            type: "test"
-                        },
-                        {
-                            area: "b",
-                            plot_type: "p2",
-                            type: "test"
-                        }
-                    ]
-                })
-            done();
+        await flushPromises();
+        const plotly = wrapper.findComponent(Plotly);
+        expect(plotly.props("layoutData")).toStrictEqual({
+            yAxisFormat: ".1%"
         });
+        expect(wrapper.findComponent(GenericChartTable).props("valueFormat")).toBe(".1%");
+        expect(wrapper.findComponent(DownloadIndicator).props()).toEqual(
+            {
+                unfilteredData: [
+                    {
+                        area: "a",
+                        plot_type: "p1",
+                        type: "test"
+                    },
+                    {
+                        area: "b",
+                        plot_type: "p2",
+                        type: "test"
+                    }
+                ],
+                filteredData: [
+                    {
+                        area: "a",
+                        plot_type: "p1",
+                        type: "test"
+                    },
+                    {
+                        area: "b",
+                        plot_type: "p2",
+                        type: "test"
+                    }
+                ]
+            }
+        )
     });
 
-    it("fetches default datasets, and sets default selections, on mount", (done) => {
+    it("fetches default datasets, and sets default selections, on mount", async () => {
         mockAxios.onGet(`/dataset1`)
             .reply(200, mockSuccess(datasets.dataset1));
         mockAxios.onGet(`/dataset2`)
@@ -662,40 +646,37 @@ describe("GenericChart component", () => {
             .reply(200, mockSuccess(datasets.dataset3));
 
         const wrapper = getWrapper();
-        setTimeout(() => {
-            expect(mockAxios.history.get.length).toBe(3);
-            expect(mockAxios.history.get[0].url).toBe("/dataset1");
-            expect(mockAxios.history.get[1].url).toBe("/dataset2");
-            expect(mockAxios.history.get[2].url).toBe("/dataset3");
+        await flushPromises();
+        expect(mockAxios.history.get.length).toBe(3);
+        expect(mockAxios.history.get[0].url).toBe("/dataset1");
+        expect(mockAxios.history.get[1].url).toBe("/dataset2");
+        expect(mockAxios.history.get[2].url).toBe("/dataset3");
 
-            expect((wrapper.vm as any).$data.dataSourceSelections).toStrictEqual({
-                visible1: {
-                    datasetId: "dataset1",
-                    selectedFilterOptions: {
-                        age: [{id: "1", label: "1"}],
-                        year: [{id: "2021", label: "2021"}]
-                    }
-                },
-                visible2: {
-                    datasetId: "dataset2",
-                    selectedFilterOptions: {
-                        age: [{id: "10", label: "10"}],
-                        year: [{id: "2020", label: "2020"}]
-                    }
-                },
-                hidden: {
-                    datasetId: "dataset3",
-                    selectedFilterOptions: {
-                        type: [{id: "test", label: "test"}]
-                    }
+        expect((wrapper.vm as any).$data.dataSourceSelections).toStrictEqual({
+            visible1: {
+                datasetId: "dataset1",
+                selectedFilterOptions: {
+                    age: [{id: "1", label: "1"}],
+                    year: [{id: "2021", label: "2021"}]
                 }
-            });
-
-            done();
+            },
+            visible2: {
+                datasetId: "dataset2",
+                selectedFilterOptions: {
+                    age: [{id: "10", label: "10"}],
+                    year: [{id: "2020", label: "2020"}]
+                }
+            },
+            hidden: {
+                datasetId: "dataset3",
+                selectedFilterOptions: {
+                    type: [{id: "test", label: "test"}]
+                }
+            }
         });
     });
 
-    it("fetches dataset on data source value change, and sets default selections, if dataset does not exist in state", (done) => {
+    it("fetches dataset on data source value change, and sets default selections, if dataset does not exist in state", async () => {
         const datasets1And3 = {
             dataset1: datasets.dataset1,
             dataset3: datasets.dataset3
@@ -717,31 +698,28 @@ describe("GenericChart component", () => {
             .reply(200, mockSuccess(datasets.dataset2));
 
         const wrapper = getWrapper({datasets: datasets1And3}, reducedMetadata);
-        setTimeout(async () => {
-            await wrapper.findAllComponents(DataSource)[0].vm.$emit("update", "dataset2");
+        await flushPromises();
+        await wrapper.findAllComponents(DataSource)[0].vm.$emit("update", "dataset2");
 
-            // expect filter selections to have been set to null while ensure dataset
-            expect((wrapper.vm as any).$data.dataSourceSelections.visible1.selectedFilterOptions).toBe(null);
-            setTimeout(() => {
-                expect(mockAxios.history.get.length).toBe(1);
-                expect(mockAxios.history.get[0].url).toBe("/dataset2");
-                expect((wrapper.vm as any).$data.dataSourceSelections).toStrictEqual({
-                    visible1: {
-                        datasetId: "dataset2",
-                        selectedFilterOptions: {
-                            age: [{id: "10", label: "10"}],
-                            year: [{id: "2020", label: "2020"}]
-                        }
-                    },
-                    hidden: {
-                        datasetId: "dataset3",
-                        selectedFilterOptions: {
-                            type: [{id: "test", label: "test"}]
-                        }
-                    }
-                });
-                done();
-            });
+        // expect filter selections to have been set to null while ensure dataset
+        expect((wrapper.vm as any).$data.dataSourceSelections.visible1.selectedFilterOptions).toBe(null);
+        await flushPromises();
+        expect(mockAxios.history.get.length).toBe(1);
+        expect(mockAxios.history.get[0].url).toBe("/dataset2");
+        expect((wrapper.vm as any).$data.dataSourceSelections).toStrictEqual({
+            visible1: {
+                datasetId: "dataset2",
+                selectedFilterOptions: {
+                    age: [{id: "10", label: "10"}],
+                    year: [{id: "2020", label: "2020"}]
+                }
+            },
+            hidden: {
+                datasetId: "dataset3",
+                selectedFilterOptions: {
+                    type: [{id: "test", label: "test"}]
+                }
+            }
         });
     });
 
@@ -753,16 +731,13 @@ describe("GenericChart component", () => {
         });
     });
 
-    it("does not fetch default dataset on data source value change if it already exists in state", (done) => {
+    it("does not fetch default dataset on data source value change if it already exists in state", async () => {
         const state = {datasets};
         const wrapper = getWrapper(state);
-        setTimeout(() => {
-            wrapper.findAllComponents(DataSource)[0].vm.$emit("update", "dataset2");
-            setTimeout(() => {
-                expect(mockAxios.history.get.length).toBe(0);
-                done();
-            });
-        });
+        await flushPromises();
+        wrapper.findAllComponents(DataSource)[0].vm.$emit("update", "dataset2");
+        await nextTick();
+        expect(mockAxios.history.get.length).toBe(0);
     });
 
     it("renders error", () => {
@@ -780,7 +755,7 @@ describe("GenericChart component", () => {
         });
     });
 
-    it("renders table if table config exists for data source's dataset", (done) => {
+    it("renders table if table config exists for data source's dataset", async () => {
         const tableConfig1 = {
             columns: [
                 {
@@ -811,26 +786,23 @@ describe("GenericChart component", () => {
         const state = {datasets};
         const wrapper = getWrapper(state, customMetadata);
 
-        setTimeout(() => {
-            const tables = wrapper.findAllComponents(GenericChartTable);
-            expect(tables.length).toBe(2);
-            expect(tables[0].props("tableConfig")).toStrictEqual(tableConfig1);
-            expect(tables[0].props("filteredData")).toStrictEqual([{age: "1", year: "2021", value: 2}]);
-            expect(tables[0].props("columns")).toStrictEqual(datasets.dataset1.metadata.columns);
-            expect(tables[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
-            expect(tables[0].props("valueFormat")).toBe("");
+        await flushPromises();
+        const tables = wrapper.findAllComponents(GenericChartTable);
+        expect(tables.length).toBe(2);
+        expect(tables[0].props("tableConfig")).toStrictEqual(tableConfig1);
+        expect(tables[0].props("filteredData")).toStrictEqual([{age: "1", year: "2021", value: 2}]);
+        expect(tables[0].props("columns")).toStrictEqual(datasets.dataset1.metadata.columns);
+        expect(tables[0].props("selectedFilterOptions")).toStrictEqual(datasets.dataset1.metadata.defaults.selected_filter_options);
+        expect(tables[0].props("valueFormat")).toBe("");
 
-            expect(tables[1].props("tableConfig")).toStrictEqual(tableConfig2);
-            expect(tables[1].props("filteredData")).toStrictEqual([
-                {age: "10", year: "2020", value: 10},
-                {age: "20", year: "2020", value: 30}
-            ]);
-            expect(tables[1].props("columns")).toStrictEqual(datasets.dataset2.metadata.columns);
-            expect(tables[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset2.metadata.defaults.selected_filter_options);
-            expect(tables[0].props("valueFormat")).toBe("");
-
-            done();
-        });
+        expect(tables[1].props("tableConfig")).toStrictEqual(tableConfig2);
+        expect(tables[1].props("filteredData")).toStrictEqual([
+            {age: "10", year: "2020", value: 10},
+            {age: "20", year: "2020", value: 30}
+        ]);
+        expect(tables[1].props("columns")).toStrictEqual(datasets.dataset2.metadata.columns);
+        expect(tables[1].props("selectedFilterOptions")).toStrictEqual(datasets.dataset2.metadata.defaults.selected_filter_options);
+        expect(tables[0].props("valueFormat")).toBe("");
     });
 
     const pagedMetadata: GenericChartMetadataResponse = {
@@ -898,58 +870,55 @@ describe("GenericChart component", () => {
         }
     } as any;
 
-    it("renders paging controls and first page of data when there are multiple pages", (done) => {
+    it("renders paging controls and first page of data when there are multiple pages", async () => {
         const state = {datasets: pagedDatasets};
 
         const wrapper = getWrapper(state, pagedMetadata);
-        setTimeout(() => {
-            const store = wrapper.vm.$store;
-            const dataSources = wrapper.findAllComponents(DataSource);
-            expect(dataSources.length).toBe(1);
-            const filters = wrapper.findAllComponents(FiltersComp);
-            expect(filters.length).toBe(1);
+        await flushPromises();
+        const store = wrapper.vm.$store;
+        const dataSources = wrapper.findAllComponents(DataSource);
+        expect(dataSources.length).toBe(1);
+        const filters = wrapper.findAllComponents(FiltersComp);
+        expect(filters.length).toBe(1);
 
-            const pageControls = wrapper.find("#page-controls");
-            const previous = pageControls.find("button#previous-page");
-            const feather = previous.findComponent(VueFeather);
-            expect(feather.attributes("type")).toBe("chevron-left");
-            expect(feather.attributes("size")).toBe("20");
-            expectTranslated(previous, "Previous page",
-                "Page précédente", "Página anterior", store, "aria-label");
-            expect((previous.element as HTMLButtonElement).disabled).toBe(true);
+        const pageControls = wrapper.find("#page-controls");
+        const previous = pageControls.find("button#previous-page");
+        const feather = previous.findComponent(VueFeather);
+        expect(feather.attributes("type")).toBe("chevron-left");
+        expect(feather.attributes("size")).toBe("20");
+        expectTranslated(previous, "Previous page",
+            "Page précédente", "Página anterior", store, "aria-label");
+        expect((previous.element as HTMLButtonElement).disabled).toBe(true);
 
-            const next = pageControls.find("button#next-page");
-            const feather2 = next.findComponent(VueFeather);
-            expect(feather2.attributes("type")).toBe("chevron-right");
-            expect(feather2.attributes("size")).toBe("20");
-            expectTranslated(next, "Next page",
-                "Page suivante", "Próxima página", store, "aria-label");
-            expect((next.element as HTMLButtonElement).disabled).toBe(false);
+        const next = pageControls.find("button#next-page");
+        const feather2 = next.findComponent(VueFeather);
+        expect(feather2.attributes("type")).toBe("chevron-right");
+        expect(feather2.attributes("size")).toBe("20");
+        expectTranslated(next, "Next page",
+            "Page suivante", "Próxima página", store, "aria-label");
+        expect((next.element as HTMLButtonElement).disabled).toBe(false);
 
-            expectTranslated(pageControls.find("#page-number"), "Page 1 of 3",
-                "Page 1 sur 3", "Pagina 1 de 3", store);
+        expectTranslated(pageControls.find("#page-number"), "Page 1 of 3",
+            "Page 1 sur 3", "Pagina 1 de 3", store);
 
-            const plotly = wrapper.findComponent(Plotly);
-            expect(plotly.props("chartData")).toStrictEqual({
-                data: [
-                    {type: "test", area:"a", year: "2020", value: 1, page: 1},
-                    {type: "test", area:"b", year: "2020", value: 2, page: 1},
-                    {type: "test", area:"a", year: "2021", value: 1.1, page: 1},
-                    {type: "test", area:"b", year: "2021", value: 2.1 ,page: 1}
-                ]
-            });
-            expect(plotly.props("layoutData")).toStrictEqual({
-                subplots: {
-                    columns: 2,
-                    distinctColumn: "area",
-                    heightPerRow: 100,
-                    subplotsPerPage: 2,
-                    rows: 1
-                },
-                yAxisFormat: ""
-            });
-
-            done();
+        const plotly = wrapper.findComponent(Plotly);
+        expect(plotly.props("chartData")).toStrictEqual({
+            data: [
+                {type: "test", area:"a", year: "2020", value: 1, page: 1},
+                {type: "test", area:"b", year: "2020", value: 2, page: 1},
+                {type: "test", area:"a", year: "2021", value: 1.1, page: 1},
+                {type: "test", area:"b", year: "2021", value: 2.1 ,page: 1}
+            ]
+        });
+        expect(plotly.props("layoutData")).toStrictEqual({
+            subplots: {
+                columns: 2,
+                distinctColumn: "area",
+                heightPerRow: 100,
+                subplotsPerPage: 2,
+                rows: 1
+            },
+            yAxisFormat: ""
         });
     });
 
@@ -1140,7 +1109,7 @@ describe("GenericChart component", () => {
     });
 
 
-    it("no paging is applied when subplots not defined", (done) => {
+    it("no paging is applied when subplots not defined", async () => {
         const state = {datasets: pagedDatasets};
 
         const metadataWithoutSubplots = {
@@ -1150,52 +1119,47 @@ describe("GenericChart component", () => {
             }
         };
         const wrapper = getWrapper(state, metadataWithoutSubplots);
-        setTimeout(() => {
-            const store = wrapper.vm.$store;
-            const dataSources = wrapper.findAllComponents(DataSource);
-            expect(dataSources.length).toBe(1);
-            const filters = wrapper.findAllComponents(FiltersComp);
-            expect(filters.length).toBe(1);
+        await flushPromises();
+        const store = wrapper.vm.$store;
+        const dataSources = wrapper.findAllComponents(DataSource);
+        expect(dataSources.length).toBe(1);
+        const filters = wrapper.findAllComponents(FiltersComp);
+        expect(filters.length).toBe(1);
 
-            expect(wrapper.find("#page-controls").exists()).toBe(false);
+        expect(wrapper.find("#page-controls").exists()).toBe(false);
 
-            const plotly = wrapper.findComponent(Plotly);
-            expect(plotly.props("chartData")).toStrictEqual({
-                data:  [
-                    {type: "test", area:"a", year: "2020", value: 1},
-                    {type: "test", area:"b", year: "2020", value: 2},
-                    {type: "test", area:"c", year: "2020", value: 3},
-                    {type: "test", area:"d", year: "2020", value: 4},
-                    {type: "test", area:"e", year: "2020", value: 5},
-                    {type: "test", area:"a", year: "2021", value: 1.1},
-                    {type: "test", area:"b", year: "2021", value: 2.1},
-                    {type: "test", area:"c", year: "2021", value: 3.1},
-                    {type: "test", area:"d", year: "2021", value: 4.1},
-                    {type: "test", area:"e", year: "2021", value: 5.1}
-                ]
-            });
-
-            done();
+        const plotly = wrapper.findComponent(Plotly);
+        expect(plotly.props("chartData")).toStrictEqual({
+            data:  [
+                {type: "test", area:"a", year: "2020", value: 1},
+                {type: "test", area:"b", year: "2020", value: 2},
+                {type: "test", area:"c", year: "2020", value: 3},
+                {type: "test", area:"d", year: "2020", value: 4},
+                {type: "test", area:"e", year: "2020", value: 5},
+                {type: "test", area:"a", year: "2021", value: 1.1},
+                {type: "test", area:"b", year: "2021", value: 2.1},
+                {type: "test", area:"c", year: "2021", value: 3.1},
+                {type: "test", area:"d", year: "2021", value: 4.1},
+                {type: "test", area:"e", year: "2021", value: 5.1}
+            ]
         });
     });
 
-    it("displays chart description", (done) => {
+    it("displays chart description", async () => {
         const state = {datasets};
         const wrapper = getWrapper(state);
 
-        setTimeout(() => {
-            const description = wrapper.find("#chart-description");
-            expectTranslated(description,
-                "Values are shown in red when they differ from the previous or subsequent value by more than 25%, and in black otherwise.",
-                "Les valeurs sont affichées en rouge lorsqu'elles diffèrent de la valeur précédente ou suivante de plus de 25 %, et en noir dans le cas contraire.",
-                "Os valores são mostrados em vermelho quando diferem do valor anterior ou subsequente em mais de 25% e em preto, caso contrário.",
-                wrapper.vm.$store);
-            expect(description.classes()).toContain("text-muted");
-            done();
-        });
+        await flushPromises();
+        const description = wrapper.find("#chart-description");
+        expectTranslated(description,
+            "Values are shown in red when they differ from the previous or subsequent value by more than 25%, and in black otherwise.",
+            "Les valeurs sont affichées en rouge lorsqu'elles diffèrent de la valeur précédente ou suivante de plus de 25 %, et en noir dans le cas contraire.",
+            "Os valores são mostrados em vermelho quando diferem do valor anterior ou subsequente em mais de 25% e em preto, caso contrário.",
+            wrapper.vm.$store);
+        expect(description.classes()).toContain("text-muted");
     });
 
-    it("does not show chart description if none in config", (done) => {
+    it("does not show chart description if none in config", async () => {
         const noDescMetadata = {
             "test-chart": {
                 ...metadata["test-chart"],
@@ -1209,10 +1173,8 @@ describe("GenericChart component", () => {
         const state = {datasets};
         const wrapper = getWrapper(state, noDescMetadata);
 
-        setTimeout(() => {
-            expect(wrapper.find("#chart-description").exists()).toBe(false);
-            done();
-        });
+        await nextTick();
+        expect(wrapper.find("#chart-description").exists()).toBe(false);
     });
 
 });

--- a/src/app/static/src/tests/components/genericChart/genericChart.test.ts
+++ b/src/app/static/src/tests/components/genericChart/genericChart.test.ts
@@ -736,7 +736,7 @@ describe("GenericChart component", () => {
         const wrapper = getWrapper(state);
         await flushPromises();
         wrapper.findAllComponents(DataSource)[0].vm.$emit("update", "dataset2");
-        await nextTick();
+        await flushPromises();
         expect(mockAxios.history.get.length).toBe(0);
     });
 

--- a/src/app/static/src/tests/components/genericChart/plotly.test.ts
+++ b/src/app/static/src/tests/components/genericChart/plotly.test.ts
@@ -241,20 +241,16 @@ describe("Plotly", () => {
         expect(plotlyParams[3]).toStrictEqual(expectedConfig);
     };
 
-    it("invokes Plotly on render with expected parameters", (done) => {
+    it("invokes Plotly on render with expected parameters", async () => {
         const props = { chartData: chartData(), layoutData } as any;
         const wrapper = shallowMount(Plotly, { props, store });
 
         // Rendering flag should be set while rendering proceeds
         expect((wrapper.vm as any).rendering).toBe(true);
-
-        setTimeout(() => {
-            expect(mockPlotlyReact.mock.calls.length).toBe(1);
-            expectPlotlyParams(mockPlotlyReact.mock.calls[0]);
-            expect((wrapper.vm as any).rendering).toBe(false);
-
-            done();
-        });
+        await nextTick();
+        expect(mockPlotlyReact.mock.calls.length).toBe(1);
+        expectPlotlyParams(mockPlotlyReact.mock.calls[0]);
+        expect((wrapper.vm as any).rendering).toBe(false);
     });
 
     it("invokes Plotly newPlot when layout subplot rows has changed", async () => {
@@ -283,54 +279,44 @@ describe("Plotly", () => {
         expect((wrapper.vm as any).rendering).toBe(false);
     });
 
-    it("invokes plotly again on data change", (done) => {
-       const props = { chartData: chartData(), layoutData } as any;
-       const wrapper = shallowMount(Plotly, { props, store });
-
-       setTimeout(async () => {
-            await wrapper.setProps({
-                chartData: chartData("date111", 1.5),
-                layoutData
-            });
-
-            (wrapper.vm as any).$options.watch.chartData.handler.call(wrapper.vm);
-            await nextTick();
-
-            setTimeout(() => {
-                expect(mockPlotlyReact.mock.calls.length).toBe(3);
-                const plotlyParams = mockPlotlyReact.mock.calls[1];
-                expect(plotlyParams[0].constructor.name).toBe("HTMLDivElement");
-                expect(plotlyParams[1]).toStrictEqual(expectedData("date111", 1.5));
-                expect(plotlyParams[2]).toStrictEqual(expectedLayout(2, "date111"));
-                expect(plotlyParams[3]).toStrictEqual(expectedConfig);
-
-                done();
-            });
-       });
-    });
-
-    it("invokes plotly again on layout change", (done) => {
+    it("invokes plotly again on data change", async () => {
         const props = { chartData: chartData(), layoutData } as any;
         const wrapper = shallowMount(Plotly, { props, store });
-        setTimeout(async () => {
-            await wrapper.setProps({
-                chartData: chartData(),
-                layoutData: {...layoutData, responsive: false}
-            });
-
-            (wrapper.vm as any).$options.watch.layoutData.call(wrapper.vm);
-            await nextTick();
-
-            setTimeout(() => {
-                expect(mockPlotlyReact.mock.calls.length).toBe(2);
-                const plotlyParams = mockPlotlyReact.mock.calls[1];
-                expect(plotlyParams[0].constructor.name).toBe("HTMLDivElement");
-                expect(plotlyParams[1]).toStrictEqual(expectedData());
-                expect(plotlyParams[2]).toStrictEqual(expectedLayout(2));
-                expect(plotlyParams[3]).toStrictEqual(expectedConfig);
-                done();
-            });
+        await nextTick(); 
+        await wrapper.setProps({
+            chartData: chartData("date111", 1.5),
+            layoutData
         });
+
+        (wrapper.vm as any).$options.watch.chartData.handler.call(wrapper.vm);
+        await nextTick();
+
+        expect(mockPlotlyReact.mock.calls.length).toBe(3);
+        const plotlyParams = mockPlotlyReact.mock.calls[1];
+        expect(plotlyParams[0].constructor.name).toBe("HTMLDivElement");
+        expect(plotlyParams[1]).toStrictEqual(expectedData("date111", 1.5));
+        expect(plotlyParams[2]).toStrictEqual(expectedLayout(2, "date111"));
+        expect(plotlyParams[3]).toStrictEqual(expectedConfig);
+    });
+
+    it("invokes plotly again on layout change", async () => {
+        const props = { chartData: chartData(), layoutData } as any;
+        const wrapper = shallowMount(Plotly, { props, store });
+        await nextTick();
+        await wrapper.setProps({
+            chartData: chartData(),
+            layoutData: {...layoutData, responsive: false}
+        });
+
+        (wrapper.vm as any).$options.watch.layoutData.call(wrapper.vm);
+        await nextTick();
+
+        expect(mockPlotlyReact.mock.calls.length).toBe(2);
+        const plotlyParams = mockPlotlyReact.mock.calls[1];
+        expect(plotlyParams[0].constructor.name).toBe("HTMLDivElement");
+        expect(plotlyParams[1]).toStrictEqual(expectedData());
+        expect(plotlyParams[2]).toStrictEqual(expectedLayout(2));
+        expect(plotlyParams[3]).toStrictEqual(expectedConfig);
     });
 
     it("does not render loading spinner when rendering flag is false", () => {

--- a/src/app/static/src/tests/components/genericChart/plotly.test.ts
+++ b/src/app/static/src/tests/components/genericChart/plotly.test.ts
@@ -2,16 +2,10 @@
 // before importing Plotly
 import Vuex from "vuex";
 import plotly from "plotly.js-basic-dist";
-const mocks = vi.hoisted(() => {
-    return {
-        newPlot: vi.fn(),
-        react: vi.fn()
-    }
-});
 vi.mock("plotly.js-basic-dist", () => ({
     default: {
-        newPlot: mocks.newPlot,
-        react: mocks.react
+        newPlot: vi.fn(),
+        react: vi.fn()
     }
 }));
 import Vue, { nextTick } from "vue";
@@ -254,7 +248,7 @@ describe("Plotly", () => {
 
         // Rendering flag should be set while rendering proceeds
         expect((wrapper.vm as any).rendering).toBe(true);
-        await nextTick();
+        await flushPromises();
         expect(mockPlotlyReact.mock.calls.length).toBe(1);
         expectPlotlyParams(mockPlotlyReact.mock.calls[0]);
         expect((wrapper.vm as any).rendering).toBe(false);
@@ -280,7 +274,7 @@ describe("Plotly", () => {
                 rows: 3
             }
         }, layoutData)
-        await nextTick();
+        await flushPromises();
         expect(mockPlotlyNewPlot.mock.calls.length).toBe(1);
         expectPlotlyParams(mockPlotlyNewPlot.mock.calls[0], 3);
         expect((wrapper.vm as any).rendering).toBe(false);
@@ -296,7 +290,7 @@ describe("Plotly", () => {
         });
 
         (wrapper.vm as any).$options.watch.chartData.handler.call(wrapper.vm);
-        await nextTick();
+        await flushPromises();
 
         expect(mockPlotlyReact.mock.calls.length).toBe(3);
         const plotlyParams = mockPlotlyReact.mock.calls[1];
@@ -316,7 +310,7 @@ describe("Plotly", () => {
         });
 
         (wrapper.vm as any).$options.watch.layoutData.call(wrapper.vm);
-        await nextTick();
+        await flushPromises();
 
         expect(mockPlotlyReact.mock.calls.length).toBe(2);
         const plotlyParams = mockPlotlyReact.mock.calls[1];

--- a/src/app/static/src/tests/components/genericChart/plotly.test.ts
+++ b/src/app/static/src/tests/components/genericChart/plotly.test.ts
@@ -1,12 +1,19 @@
 // Mock the import of plotly so that we can spy on its exported 'newPlot' method - need to do this
 // before importing Plotly
 import Vuex from "vuex";
-
+import plotly from "plotly.js-basic-dist";
+const mocks = vi.hoisted(() => {
+    return {
+        newPlot: vi.fn(),
+        react: vi.fn()
+    }
+});
 vi.mock("plotly.js-basic-dist", () => ({
-    newPlot: vi.fn(),
-    react: vi.fn()
+    default: {
+        newPlot: mocks.newPlot,
+        react: mocks.react
+    }
 }));
-import * as plotly from "plotly.js-basic-dist";
 import Vue, { nextTick } from "vue";
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import Plotly from "../../../app/components/genericChart/Plotly.vue";

--- a/src/app/static/src/tests/components/modelRun/modelRun.test.ts
+++ b/src/app/static/src/tests/components/modelRun/modelRun.test.ts
@@ -1,4 +1,4 @@
-import {shallowMount} from '@vue/test-utils';
+import {flushPromises, shallowMount} from '@vue/test-utils';
 import Vuex, {Store} from 'vuex';
 import { nextTick } from 'vue';
 import {
@@ -82,8 +82,15 @@ describe("Model run component", () => {
         mockAxios.reset();
     });
 
-    it("run models and polls for status", (done) => {
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
 
+    afterAll(() => {
+        vi.useRealTimers();
+    })
+
+    it("run models and polls for status", async () => {
         const store = createStore();
         const wrapper = shallowMountWithTranslate(ModelRun, store, {
             global: {
@@ -93,27 +100,22 @@ describe("Model run component", () => {
         const button = wrapper.find("button");
         expect(button.text()).toBe("Fit model");
         button.trigger("click");
-
-        setTimeout(() => {
-            expect(wrapper.find("button").attributes().disabled).toBe("");
-            expect(store.state.modelRun.status).toStrictEqual({id: "1234"});
-            expect(store.state.modelRun.modelRunId).toBe("1234");
-            expect(store.state.modelRun.statusPollId).not.toBe(-1);
-            expect(wrapper.findComponent(Modal).props().open).toBe(true);
-
-            setTimeout(() => {
-                expect(wrapper.find("button").attributes().disabled).toBeUndefined();
-                expect(store.state.modelRun.status).toStrictEqual(mockStatus);
-                expect(store.state.modelRun.modelRunId).toBe("1234");
-                expect(store.state.modelRun.statusPollId).toBe(-1);
-                expect(wrapper.findComponent(Modal).props().open).toBe(false);
-                done();
-            }, 2500);
-        });
+        await flushPromises();
+        expect(wrapper.find("button").attributes().disabled).toBe("");
+        expect(store.state.modelRun.status).toStrictEqual({id: "1234"});
+        expect(store.state.modelRun.modelRunId).toBe("1234");
+        expect(store.state.modelRun.statusPollId).not.toBe(-1);
+        expect(wrapper.findComponent(Modal).props().open).toBe(true);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(wrapper.find("button").attributes().disabled).toBeUndefined();
+        expect(store.state.modelRun.status).toStrictEqual(mockStatus);
+        expect(store.state.modelRun.modelRunId).toBe("1234");
+        expect(store.state.modelRun.statusPollId).toBe(-1);
+        expect(wrapper.findComponent(Modal).props().open).toBe(false);
     });
 
-    it("does not immediately run model if edits require confirmation", (done) => {
-
+    it("does not immediately run model if edits require confirmation", async () => {
         const store = createStore({}, {}, {...stepperGetters, editsRequireConfirmation: () => true});
         const wrapper = shallowMountWithTranslate(ModelRun, store, {
             global: {
@@ -123,19 +125,16 @@ describe("Model run component", () => {
         const button = wrapper.find("button");
         expect(button.text()).toBe("Fit model");
         button.trigger("click");
-
-        setTimeout(() => {
-            expect((wrapper.vm as any).$data.showReRunConfirmation).toStrictEqual(true);
-            expect(wrapper.find("button").attributes().disabled).toBeUndefined();
-            expect(store.state.modelRun.status).toStrictEqual({});
-            expect(store.state.modelRun.modelRunId).toBe("");
-            expect(store.state.modelRun.statusPollId).toBe(-1);
-            expect(wrapper.findComponent(Modal).props().open).toBe(false);
-            done();
-        });
+        await nextTick();
+        expect((wrapper.vm as any).$data.showReRunConfirmation).toStrictEqual(true);
+        expect(wrapper.find("button").attributes().disabled).toBeUndefined();
+        expect(store.state.modelRun.status).toStrictEqual({});
+        expect(store.state.modelRun.modelRunId).toBe("");
+        expect(store.state.modelRun.statusPollId).toBe(-1);
+        expect(wrapper.findComponent(Modal).props().open).toBe(false);
     });
 
-    it("polls for status if runId already exists, pollId does not, and still running", (done) => {
+    it("polls for status if runId already exists, pollId does not, and still running", async () => {
         const store = createStore({
             modelRunId: "1234",
             status: {
@@ -152,20 +151,18 @@ describe("Model run component", () => {
                 plugins: [store]
             }
         });
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(mockAxios.history.get[0].url).toBe(`/model/status/1234`);
 
-        setTimeout(() => {
-            expect(mockAxios.history.get[0].url).toBe(`/model/status/1234`);
-
-            expect(wrapper.find("button").attributes().disabled).toBeUndefined();
-            expect(store.state.modelRun.status).toStrictEqual(mockStatus);
-            expect(store.state.modelRun.modelRunId).toBe("1234");
-            expect(store.state.modelRun.statusPollId).toBe(-1);
-            expect(wrapper.findComponent(Modal).props().open).toBe(false);
-            done();
-        }, 2500);
+        expect(wrapper.find("button").attributes().disabled).toBeUndefined();
+        expect(store.state.modelRun.status).toStrictEqual(mockStatus);
+        expect(store.state.modelRun.modelRunId).toBe("1234");
+        expect(store.state.modelRun.statusPollId).toBe(-1);
+        expect(wrapper.findComponent(Modal).props().open).toBe(false);
     });
 
-    it("does not poll for status if runId exists, pollId does not, and run completed successfully", (done) => {
+    it("does not poll for status if runId exists, pollId does not, and run completed successfully", async () => {
         const store = createStore({
             modelRunId: "1234",
             status: {
@@ -181,17 +178,15 @@ describe("Model run component", () => {
                 plugins: [store]
             }
         });
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(mockAxios.history.get.length).toBe(0);
 
-        setTimeout(() => {
-            expect(mockAxios.history.get.length).toBe(0);
-
-            expect(wrapper.find("button").attributes().disabled).toBeUndefined();
-            expect(wrapper.findComponent(Modal).props().open).toBe(false);
-            done();
-        }, 2500);
+        expect(wrapper.find("button").attributes().disabled).toBeUndefined();
+        expect(wrapper.findComponent(Modal).props().open).toBe(false);
     });
 
-    it("does not poll for status if runId exists, pollId does not, and run failed", (done) => {
+    it("does not poll for status if runId exists, pollId does not, and run failed", async () => {
         const store = createStore({
             modelRunId: "1234",
             status: {
@@ -207,18 +202,16 @@ describe("Model run component", () => {
                 plugins: [store]
             }
         });
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(mockAxios.history.get.length).toBe(0);
 
-        setTimeout(() => {
-            expect(mockAxios.history.get.length).toBe(0);
-
-            expect(wrapper.find("button").attributes().disabled).toBeUndefined();
-            expect(wrapper.findComponent(Modal).props().open).toBe(false);
-            done();
-        }, 2500);
+        expect(wrapper.find("button").attributes().disabled).toBeUndefined();
+        expect(wrapper.findComponent(Modal).props().open).toBe(false);
     });
 
 
-    it("modal does not close until run result fetched", (done) => {
+    it("modal does not close until run result fetched", async () => {
         const getResultMock = vi.fn();
         const store = createStore({}, {...actions, getResult: getResultMock});
         const wrapper = shallowMountWithTranslate(ModelRun, store, {
@@ -227,43 +220,35 @@ describe("Model run component", () => {
             }
         });
         wrapper.find("button").trigger("click");
-
-        setTimeout(() => {
-            expect(wrapper.find("button").attributes().disabled).toBe("");
-            expect(store.state.modelRun.status).toStrictEqual({id: "1234"});
-            expect(store.state.modelRun.modelRunId).toBe("1234");
-            expect(store.state.modelRun.statusPollId).not.toBe(-1);
-            expect(wrapper.findComponent(Modal).props().open).toBe(true);
-
-            setTimeout(() => {
-                // it should still be open because the result is missing
-                expect(wrapper.find("button").attributes().disabled).toBe("");
-                expect(store.state.modelRun.result).toBe(null);
-                expect(store.state.modelRun.status.success).toBe(true);
-                expect(wrapper.findComponent(Modal).props().open).toBe(true);
-                clearInterval(store.state.modelRun.statusPollId);
-                done();
-            }, 2500);
-        });
+        await flushPromises();
+        expect(wrapper.find("button").attributes().disabled).toBe("");
+        expect(store.state.modelRun.status).toStrictEqual({id: "1234"});
+        expect(store.state.modelRun.modelRunId).toBe("1234");
+        expect(store.state.modelRun.statusPollId).not.toBe(-1);
+        expect(wrapper.findComponent(Modal).props().open).toBe(true);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        // it should still be open because the result is missing
+        expect(wrapper.find("button").attributes().disabled).toBe("");
+        expect(store.state.modelRun.result).toBe(null);
+        expect(store.state.modelRun.status.success).toBe(true);
+        expect(wrapper.findComponent(Modal).props().open).toBe(true);
+        clearInterval(store.state.modelRun.statusPollId);
     });
 
-    it("does not start polling on created if pollId already exists", (done) => {
+    it("does not start polling on created if pollId already exists", async () => {
         const store = createStore({modelRunId: "1234", statusPollId: 1});
         shallowMount(ModelRun, {global: {plugins: [store]}});
-
-        setTimeout(() => {
-            expect(mockAxios.history.get.length).toBe(0);
-            done();
-        }, 2500);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(mockAxios.history.get.length).toBe(0);
     });
 
     it("button is disabled and modal shown if status is started", () => {
-
         const store = createStore({
             status: {done: false} as ModelStatusResponse,
             startedRunning: true
         });
-
         const wrapper = shallowMountWithTranslate(ModelRun, store, {
             global: {
                 plugins: [store]

--- a/src/app/static/src/tests/components/password/forgotPassword.test.ts
+++ b/src/app/static/src/tests/components/password/forgotPassword.test.ts
@@ -11,10 +11,11 @@ import {expectTranslatedWithStoreType, shallowMountWithTranslate} from "../../te
 import {LanguageMutation, mutations} from "../../../app/store/language/mutations";
 import {Language} from "../../../app/store/translations/locales";
 import { nextTick } from "vue";
+import { Mocked } from "vitest";
 
 describe("Forgot password component", () => {
 
-    let actions: vi.Mocked<PasswordActions>;
+    let actions: Mocked<PasswordActions>;
 
     const createStore = (passwordState?: Partial<PasswordState>) => {
         actions = {

--- a/src/app/static/src/tests/components/password/resetPassword.test.ts
+++ b/src/app/static/src/tests/components/password/resetPassword.test.ts
@@ -10,10 +10,11 @@ import {LanguageMutation, mutations} from "../../../app/store/language/mutations
 import {Language} from "../../../app/store/translations/locales";
 import ErrorAlert from "../../../app/components/ErrorAlert.vue";
 import { nextTick } from "vue";
+import { Mocked } from "vitest";
 
 describe("Reset password component", () => {
 
-    let actions: vi.Mocked<PasswordActions>;
+    let actions: Mocked<PasswordActions>;
 
     const createStore = (passwordState?: Partial<PasswordState>) => {
         actions = {

--- a/src/app/static/src/tests/components/plots/utils.test.ts
+++ b/src/app/static/src/tests/components/plots/utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../app/components/plots/utils";
 import {interpolateMagma, interpolateWarm} from "d3-scale-chromatic";
 import {Filter} from "../../../app/generated";
+import { Mock } from "vitest";
 
 describe("plot utils", () => {
 
@@ -17,7 +18,7 @@ describe("plot utils", () => {
     });
 
     afterEach(() => {
-        (console.warn as vi.Mock).mockClear();
+        (console.warn as Mock).mockClear();
     });
 
     it("colorFunctionFromName returns color function", () => {

--- a/src/app/static/src/tests/components/stepper.test.ts
+++ b/src/app/static/src/tests/components/stepper.test.ts
@@ -450,7 +450,7 @@ describe("Stepper component", () => {
         expect(steps[0].props().active).toBe(true);
     });
 
-    it("updates from completed state when active step data is populated", (done) => {
+    it("updates from completed state when active step data is populated", async () => {
         const baselineState = {
             country: "Malawi",
             iso3: "MWI",
@@ -469,11 +469,8 @@ describe("Stepper component", () => {
             "type": "Validated",
             "payload": mockValidateBaselineResponse()
         });
-
-        nextTick().then(() => {
-            expect(vm.navigationProps.nextDisabled).toBe(false);
-            done();
-        });
+        await nextTick();
+        expect(vm.navigationProps.nextDisabled).toBe(false);
     });
 
     it("active step only becomes active once state becomes ready", async () => {

--- a/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
+++ b/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
@@ -12,10 +12,11 @@ import {
 } from "../../mocks";
 import UploadInputs from "../../../app/components/uploadInputs/UploadInputs.vue";
 import { shallowMountWithTranslate } from '../../testHelpers';
+import { Mocked } from 'vitest';
 
 export function testUploadComponent(name: string, position: number) {
 
-    let actions: vi.Mocked<SurveyAndProgramActions>;
+    let actions: Mocked<SurveyAndProgramActions>;
     let mutations = {};
 
     let expectedUploadAction: any;

--- a/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
+++ b/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
@@ -1,4 +1,4 @@
-import {shallowMount} from '@vue/test-utils';
+import {flushPromises, shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
 import ManageFile from "../../../app/components/files/ManageFile.vue";
 import {SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
@@ -152,7 +152,7 @@ export function testUploadComponent(name: string, position: number) {
         expect(wrapper.findAllComponents(ManageFile)[position].props().error).toStrictEqual(mockError("File upload went wrong"));
     });
 
-    it(`upload ${name} dispatches surveyAndProgram/upload${name}`, (done) => {
+    it(`upload ${name} dispatches surveyAndProgram/upload${name}`, async () => {
         const store = createSut();
         const wrapper = shallowMountWithTranslate(UploadInputs, store, {
             global: {
@@ -161,13 +161,11 @@ export function testUploadComponent(name: string, position: number) {
         });
 
         wrapper.findAllComponents(ManageFile)[position].props().upload({name: "TEST"});
-        setTimeout(() => {
-            expect(expectedUploadAction.mock.calls[0][1]).toStrictEqual({name: "TEST"});
-            done();
-        });
+        await flushPromises();
+        expect(expectedUploadAction.mock.calls[0][1]).toStrictEqual({name: "TEST"});
     });
 
-    it(`delete ${name} dispatches surveyAndProgram/delete${name}`, (done) => {
+    it(`delete ${name} dispatches surveyAndProgram/delete${name}`, async () => {
         const store = createSut();
         const wrapper = shallowMountWithTranslate(UploadInputs, store, {
             global: {
@@ -176,9 +174,7 @@ export function testUploadComponent(name: string, position: number) {
         });
 
         wrapper.findAllComponents(ManageFile)[position].props().deleteFile();
-        setTimeout(() => {
-            expect(expectedDeleteAction.mock.calls.length).toBe(1);
-            done();
-        });
+        await flushPromises();
+        expect(expectedDeleteAction.mock.calls.length).toBe(1);
     });
 }

--- a/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
+++ b/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
@@ -21,9 +21,10 @@ import {expectTranslatedWithStoreType, mountWithTranslate, shallowMountWithTrans
 import {SurveyAndProgramActions} from "../../../app/store/surveyAndProgram/actions";
 import {getters} from "../../../app/store/surveyAndProgram/getters";
 import {DataType, SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
-import {testUploadComponent} from "./fileUploads";
+import {testUploadComponent} from "./fileUploads.";
 import {RootState} from "../../../app/root";
-import { Mocked } from 'vitest';
+import { MockInstance, Mocked } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
 
 describe("UploadInputs upload component", () => {
 
@@ -378,28 +379,28 @@ describe("UploadInputs upload component", () => {
         expect(wrapper.findAllComponents(ManageFile)[2].props("existingFileName")).toBe("errored file");
     });
 
-    it("upload pjnz dispatches baseline/uploadPJNZ", (done) => {
-        expectUploadToDispatchAction(0, () => actions.uploadPJNZ, done);
+    it("upload pjnz dispatches baseline/uploadPJNZ", async () => {
+        await expectUploadToDispatchAction(0, () => actions.uploadPJNZ);
     });
 
-    it("upload shape dispatches baseline/uploadShape", (done) => {
-        expectUploadToDispatchAction(1, () => actions.uploadShape, done);
+    it("upload shape dispatches baseline/uploadShape", async () => {
+        await expectUploadToDispatchAction(1, () => actions.uploadShape);
     });
 
-    it("upload population dispatches baseline/uploadPopulation", (done) => {
-        expectUploadToDispatchAction(2, () => actions.uploadPopulation, done);
+    it("upload population dispatches baseline/uploadPopulation", async () => {
+        await expectUploadToDispatchAction(2, () => actions.uploadPopulation);
     });
 
-    it("remove pjnz dispatches baseline/deletePJNZ", (done) => {
-        expectDeleteToDispatchAction(0, () => actions.deletePJNZ, done);
+    it("remove pjnz dispatches baseline/deletePJNZ", async () => {
+        await expectDeleteToDispatchAction(0, () => actions.deletePJNZ);
     });
 
-    it("remove shape dispatches baseline/deleteShape", (done) => {
-        expectDeleteToDispatchAction(1, () => actions.deleteShape, done);
+    it("remove shape dispatches baseline/deleteShape", async () => {
+        await expectDeleteToDispatchAction(1, () => actions.deleteShape);
     });
 
-    it("remove population dispatches baseline/deletePopulation", (done) => {
-        expectDeleteToDispatchAction(2, () => actions.deletePopulation, done);
+    it("remove population dispatches baseline/deletePopulation", async () => {
+        await expectDeleteToDispatchAction(2, () => actions.deletePopulation);
     });
 
     it("can return true when fromADR", async () => {
@@ -575,9 +576,8 @@ describe("UploadInputs upload component", () => {
 
     });
 
-    const expectUploadToDispatchAction = (index: number,
-                                          action: () => vi.MockInstance<any, any>,
-                                          done: vi.DoneCallback) => {
+    const expectUploadToDispatchAction = async (index: number,
+                                          action: () => MockInstance<any, any>) => {
         const store = createSut();
         const wrapper = shallowMountWithTranslate(UploadInputs, store, {
             global: {
@@ -586,15 +586,12 @@ describe("UploadInputs upload component", () => {
         });
 
         wrapper.findAllComponents(ManageFile)[index].props().upload({name: "TEST"});
-        setTimeout(() => {
-            expect(action().mock.calls[0][1]).toStrictEqual({name: "TEST"});
-            done();
-        });
+        await flushPromises();
+        expect(action().mock.calls[0][1]).toStrictEqual({name: "TEST"});
     };
 
-    const expectDeleteToDispatchAction = (index: number,
-                                          action: () => vi.MockInstance<any, any>,
-                                          done: vi.DoneCallback) => {
+    const expectDeleteToDispatchAction = async (index: number,
+                                          action: () => MockInstance<any, any>) => {
         const store = createSut();
         const wrapper = shallowMountWithTranslate(UploadInputs, store, {
             global: {
@@ -603,10 +600,8 @@ describe("UploadInputs upload component", () => {
         });
 
         wrapper.findAllComponents(ManageFile)[index].props().deleteFile();
-        setTimeout(() => {
-            expect(action().mock.calls.length).toBe(1);
-            done();
-        });
+        await flushPromises();
+        expect(action().mock.calls.length).toBe(1);
     }
 });
 

--- a/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
+++ b/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
@@ -23,13 +23,14 @@ import {getters} from "../../../app/store/surveyAndProgram/getters";
 import {DataType, SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
 import {testUploadComponent} from "./fileUploads";
 import {RootState} from "../../../app/root";
+import { Mocked } from 'vitest';
 
 describe("UploadInputs upload component", () => {
 
-    let actions: vi.Mocked<BaselineActions>;
+    let actions: Mocked<BaselineActions>;
     let mutations = {};
 
-    let sapActions: vi.Mocked<SurveyAndProgramActions>;
+    let sapActions: Mocked<SurveyAndProgramActions>;
     let sapMutations = {};
 
     const mockStepperGetters = {

--- a/src/app/static/src/tests/directives/translate.test.ts
+++ b/src/app/static/src/tests/directives/translate.test.ts
@@ -4,6 +4,7 @@ import registerTranslations from "../../app/store/translations/registerTranslati
 import {Language} from "../../app/store/translations/locales";
 import { mountWithTranslate, shallowMountWithTranslate } from "../testHelpers";
 import { nextTick } from "vue";
+import { Mock } from "vitest";
 
 describe("translate directive", () => {
 
@@ -12,7 +13,7 @@ describe("translate directive", () => {
     });
 
     afterAll(() => {
-        (console.warn as vi.Mock).mockClear();
+        (console.warn as Mock).mockClear();
     });
 
     const TranslateAttributeTest = {
@@ -190,7 +191,7 @@ describe("translate directive", () => {
             }, 
         });
         expect(rendered.find("h4").text()).toBe("");
-        expect((console.warn as vi.Mock).mock.calls[0][0])
+        expect((console.warn as Mock).mock.calls[0][0])
             .toBe("v-translate directive declared without a value");
     });
 

--- a/src/app/static/src/tests/downloadResults/actions.test.ts
+++ b/src/app/static/src/tests/downloadResults/actions.test.ts
@@ -8,6 +8,7 @@ import {actions} from "../../app/store/downloadResults/actions";
 import {DOWNLOAD_TYPE} from "../../app/types";
 import {DownloadStatusResponse} from "../../app/generated";
 import {switches} from "../../app/featureSwitches";
+import { flushPromises } from "@vue/test-utils";
 
 const RunningStatusResponse: DownloadStatusResponse = {
     id: "db0c4957aea4b32c507ac02d63930110",
@@ -33,6 +34,14 @@ describe(`download Results actions`, () => {
         // stop apiService logging to console
         console.log = vi.fn();
         mockAxios.reset();
+    });
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
     });
 
     it("prepare summary commits download id and starts polling for status", async () => {
@@ -84,7 +93,7 @@ describe(`download Results actions`, () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("can poll for summary status, get pollId and commit result", (done) => {
+    it("can poll for summary status, get pollId and commit result", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn()
         const partialDownloadResultsState = {downloadId: "1", status: CompleteStatusResponse};
@@ -97,17 +106,15 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
     it("does not poll for summary status when submission is unsuccessful", async () => {
@@ -139,7 +146,7 @@ describe(`download Results actions`, () => {
         await downloadReportAsExpected(actions.downloadSummaryReport, "SummaryOutputDownloadError")
     });
 
-    it("gets adr upload metadata if summary status is done", (done) => {
+    it("gets adr upload metadata if summary status is done", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -151,18 +158,16 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-            done()
-        }, 2100)
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
     });
 
-    it("does get adr upload metadata error for summary if metadata request is successful",  (done) => {
+    it("does get adr upload metadata error for summary if metadata request is successful",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -175,22 +180,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(commit.mock.calls[2][0]["type"]).toBe("SummaryMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toBeNull()
 
-            expect(commit.mock.calls[2][0]["type"]).toBe("SummaryMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toBeNull()
-
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-            done()
-        }, 2100)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
     });
 
-    it("can get adr upload metadata error for summary if metadata request is unsuccessful", (done) => {
+    it("can get adr upload metadata error for summary if metadata request is unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -209,22 +212,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState} as any, DOWNLOAD_TYPE.SUMMARY);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("SummaryMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("SummaryMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
     });
 
-    it("does not continue to poll summary status when unsuccessful", (done) => {
+    it("does not continue to poll summary status when unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const partialDownloadResultsState = mockDownloadResultsDependency({downloadId: "1"});
@@ -237,20 +238,18 @@ describe(`download Results actions`, () => {
             .reply(500, mockFailure("TEST FAILED"));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SUMMARY);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2)
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
 
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SUMMARY)
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "SummaryError",
-                payload: mockError("TEST FAILED")
-            });
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "SummaryError",
+            payload: mockError("TEST FAILED")
+        });
     });
 
     it("can submit spectrum download request, commits and starts polling", async () => {
@@ -306,7 +305,7 @@ describe(`download Results actions`, () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("can invoke spectrum poll action, gets pollId, commits PollingStatusStarted",  (done) => {
+    it("can invoke spectrum poll action, gets pollId, commits PollingStatusStarted",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -322,21 +321,18 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
-    it("can poll for spectrum output status", (done) => {
+    it("can poll for spectrum output status", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -348,17 +344,15 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
     it("renders spectrum report download error", async () => {
@@ -369,7 +363,7 @@ describe(`download Results actions`, () => {
         await downloadReportAsExpected(actions.downloadSpectrumOutput, "SpectrumOutputDownloadError")
     });
 
-    it("gets adr upload metadata if spectrum status is done",  (done) => {
+    it("gets adr upload metadata if spectrum status is done",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -381,18 +375,16 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-            done()
-        }, 2100)
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
     });
 
-    it("does get adr upload metadata error for spectrum if metadata request is successful", (done) => {
+    it("does get adr upload metadata error for spectrum if metadata request is successful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -405,22 +397,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("SpectrumMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toBeNull()
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("SpectrumMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toBeNull()
     });
 
-    it("can get adr upload metadata error for spectrum if metadata request is unsuccessful",  (done) => {
+    it("can get adr upload metadata error for spectrum if metadata request is unsuccessful",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -439,19 +429,17 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("SpectrumMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("SpectrumMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
     });
 
     it("does not start polling for spectrum output status when submission is unsuccessful", async () => {
@@ -477,7 +465,7 @@ describe(`download Results actions`, () => {
         });
     });
 
-    it("does not continue to poll spectrum status when unsuccessful", (done) => {
+    it("does not continue to poll spectrum status when unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -489,22 +477,18 @@ describe(`download Results actions`, () => {
             .reply(500, mockFailure("TEST FAILED"));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2)
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
 
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.SPECTRUM)
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "SpectrumError",
-                payload: mockError("TEST FAILED")
-            });
-
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "SpectrumError",
+            payload: mockError("TEST FAILED")
+        });
     });
 
     it("can prepare coarse output, commits and starts polling", async () => {
@@ -556,7 +540,7 @@ describe(`download Results actions`, () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("gets adr upload metadata if coarse output status is done",  (done) => {
+    it("gets adr upload metadata if coarse output status is done",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -568,15 +552,13 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-            done()
-        }, 2100)
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
     });
 
 
@@ -588,7 +570,7 @@ describe(`download Results actions`, () => {
         await downloadReportAsExpected(actions.downloadCoarseOutput, "CoarseOutputDownloadError")
     });
 
-    it("does get adr upload metadata error for coarseOutput if metadata request is successful",  (done) => {
+    it("does get adr upload metadata error for coarseOutput if metadata request is successful",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -601,22 +583,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("CoarseOutputMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toBeNull()
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("CoarseOutputMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toBeNull()
     });
 
-    it("can get adr upload metadata error for coarseOutput if metadata request is unsuccessful",  (done) => {
+    it("can get adr upload metadata error for coarseOutput if metadata request is unsuccessful",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -635,22 +615,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("CoarseOutputMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("CoarseOutputMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
     });
 
-    it("can invoke coarse output poll action, get pollId and commit PollingStatusStarted",  (done) => {
+    it("can invoke coarse output poll action, get pollId and commit PollingStatusStarted", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -662,20 +640,18 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
-    it("can get coarse output status results",  (done) => {
+    it("can get coarse output status results",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -687,18 +663,15 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
     it("does not poll for coarse output status when submission is unsuccessful", async () => {
@@ -721,7 +694,7 @@ describe(`download Results actions`, () => {
         });
     });
 
-    it("does not continue to poll coarse output status when unsuccessful",  (done) => {
+    it("does not continue to poll coarse output status when unsuccessful",  async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const partialDownloadResultsState = mockDownloadResultsDependency({downloadId: "1"});
@@ -734,20 +707,17 @@ describe(`download Results actions`, () => {
             .reply(500, mockFailure("TEST FAILED"));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2)
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2)
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COARSE)
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "CoarseOutputError",
-                payload: mockError("TEST FAILED")
-            });
-
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "CoarseOutputError",
+            payload: mockError("TEST FAILED")
+        });
     });
 
     it("can submit comparison download request, commits and starts polling", async () => {
@@ -808,7 +778,7 @@ describe(`download Results actions`, () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("can invoke comparison poll action, gets pollId, commits PollingStatusStarted",  (done) => {
+    it("can invoke comparison poll action, gets pollId, commits PollingStatusStarted", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -824,21 +794,18 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
-    it("can poll for comparison output status", (done) => {
+    it("can poll for comparison output status", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -850,20 +817,18 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
-    it("gets adr upload metadata if comparison status is done",  (done) => {
+    it("gets adr upload metadata if comparison status is done", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -875,19 +840,17 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COMPARISON);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-            done()
-        }, 2100)
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
     });
 
 
-    it("does get adr upload metadata error for comparison if metadata request is successful",  (done) => {
+    it("does get adr upload metadata error for comparison if metadata request is successful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -900,22 +863,20 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("ComparisonOutputMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toBeNull()
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("ComparisonOutputMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toBeNull()
     });
 
-    it("can get adr upload metadata error for comparison if metadata request is unsuccessful",  (done) => {
+    it("can get adr upload metadata error for comparison if metadata request is unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -934,19 +895,17 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(CompleteStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
 
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(CompleteStatusResponse)
+        expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
+        expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
+        expect(dispatch.mock.calls[0][2]).toEqual({root: true})
 
-            expect(dispatch.mock.calls[0][0]).toBe("metadata/getAdrUploadMetadata")
-            expect(dispatch.mock.calls[0][1]).toBe(CompleteStatusResponse.id)
-            expect(dispatch.mock.calls[0][2]).toEqual({root: true})
-
-            expect(commit.mock.calls[2][0]["type"]).toBe("ComparisonOutputMetadataError")
-            expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
-            done()
-        }, 2100)
+        expect(commit.mock.calls[2][0]["type"]).toBe("ComparisonOutputMetadataError")
+        expect(commit.mock.calls[2][0]["payload"]).toEqual(mockError("METADATA REQUEST FAILED"))
     });
 
     it("does not start polling for comparison output status when submission is unsuccessful", async () => {
@@ -970,7 +929,7 @@ describe(`download Results actions`, () => {
         });
     });
 
-    it("does not continue to poll comparison status when unsuccessful",  (done) => {
+    it("does not continue to poll comparison status when unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -982,22 +941,18 @@ describe(`download Results actions`, () => {
             .reply(500, mockFailure("TEST FAILED"));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2)
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
 
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.COMPARISON)
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "ComparisonError",
-                payload: mockError("TEST FAILED")
-            });
-
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "ComparisonError",
+            payload: mockError("TEST FAILED")
+        });
     });
 
     it("can submit AGYW download request, commits and starts polling", async () => {
@@ -1058,7 +1013,7 @@ describe(`download Results actions`, () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("can invoke AGYW poll action, gets pollId, commits PollingStatusStarted",  (done) => {
+    it("can invoke AGYW poll action, gets pollId, commits PollingStatusStarted", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -1074,18 +1029,15 @@ describe(`download Results actions`, () => {
             .reply(200, mockSuccess(RunningStatusResponse));
 
         actions.poll({commit, state, dispatch, rootState: root} as any, DOWNLOAD_TYPE.AGYW);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.AGYW)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.AGYW)
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("AgywStatusUpdated")
-            expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("AgywStatusUpdated")
+        expect(commit.mock.calls[1][0]["payload"]).toEqual(RunningStatusResponse)
     });
 
     it("does not start polling for AGYW download status when submission is unsuccessful", async () => {
@@ -1109,7 +1061,7 @@ describe(`download Results actions`, () => {
         });
     });
 
-    it("does not continue to poll AGYW status when unsuccessful",  (done) => {
+    it("does not continue to poll AGYW status when unsuccessful", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
 
@@ -1121,22 +1073,18 @@ describe(`download Results actions`, () => {
             .reply(500, mockFailure("TEST FAILED"));
 
         actions.poll({commit, state, dispatch, rootState: mockRootState()} as any, DOWNLOAD_TYPE.AGYW);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2)
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2)
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.AGYW)
 
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted")
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1)
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toEqual(DOWNLOAD_TYPE.AGYW)
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "AgywError",
-                payload: mockError("TEST FAILED")
-            });
-
-            done()
-
-        }, 2100)
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "AgywError",
+            payload: mockError("TEST FAILED")
+        });
     });
 
     it("can prepare all outputs and optionally AGYW", async () => {

--- a/src/app/static/src/tests/genericChart/actions.test.ts
+++ b/src/app/static/src/tests/genericChart/actions.test.ts
@@ -2,6 +2,7 @@ import {mockAxios, mockFailure, mockGenericChartState, mockRootState, mockSucces
 import {actions} from "../../app/store/genericChart/actions";
 import {GenericChartMutation} from "../../app/store/genericChart/mutations";
 import {freezer} from "../../app/utils";
+import { Mock } from "vitest";
 
 describe("genericChart actions", () => {
     beforeEach(() => {
@@ -12,7 +13,7 @@ describe("genericChart actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     const rootState = mockRootState();

--- a/src/app/static/src/tests/hintrVersion/actions.test.ts
+++ b/src/app/static/src/tests/hintrVersion/actions.test.ts
@@ -1,6 +1,7 @@
 import {mockAxios, mockSuccess, mockFailure, mockRootState} from "../mocks";
 import {actions} from '../../app/store/hintrVersion/actions';
 import { HintrVersionMutation } from "../../app/store/hintrVersion/mutations";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 
@@ -13,7 +14,7 @@ describe("hintrVersion Actions ", ()=> {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("commits hintrVersion after successful fetch", async () => {

--- a/src/app/static/src/tests/integration/downloadResults.itest.ts
+++ b/src/app/static/src/tests/integration/downloadResults.itest.ts
@@ -2,8 +2,17 @@ import {actions} from "../../app/store/downloadResults/actions";
 import {rootState} from "./integrationTest";
 import {DOWNLOAD_TYPE} from "../../app/types";
 import {formatToLocalISODateTime} from "../../app/utils";
+import { flushPromises } from "@vue/test-utils";
 
 describe(`download results actions integration`, () => {
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
+
+    afterAll(() => {
+        vi.useRealTimers();
+    });
 
     it.skip(`can download comparison output report`, async () => {
         const commit = vi.fn();
@@ -43,7 +52,7 @@ describe(`download results actions integration`, () => {
         expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll summary report for status update`, (done) => {
+    it(`can poll summary report for status update`, async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const root = {
@@ -54,18 +63,15 @@ describe(`download results actions integration`, () => {
         const state = {summary: {downloadId: 123}}
 
         actions.poll({commit, dispatch, state, rootState: root} as any, DOWNLOAD_TYPE.SUMMARY);
+        vi.advanceTimersByTime(3000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.SUMMARY);
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.SUMMARY);
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated");
-            expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
-            done()
-
-        }, 3100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("SummaryReportStatusUpdated");
+        expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
     })
 
     it(`can prepare spectrum output for download`, async () => {
@@ -127,7 +133,7 @@ describe(`download results actions integration`, () => {
         expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll spectrum output for status update`, (done) => {
+    it(`can poll spectrum output for status update`, async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const root = {
@@ -138,18 +144,15 @@ describe(`download results actions integration`, () => {
         const state = {spectrum: {downloadId: 123}}
 
         actions.poll({commit, dispatch, state, rootState: root} as any, DOWNLOAD_TYPE.SPECTRUM);
+        vi.advanceTimersByTime(3000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.SPECTRUM);
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.SPECTRUM);
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated");
-            expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
-            done()
-
-        }, 3100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("SpectrumOutputStatusUpdated");
+        expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
     })
 
     it(`can prepare coarse output for download`, async () => {
@@ -169,7 +172,7 @@ describe(`download results actions integration`, () => {
         expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll coarseOutput for status update`, (done) => {
+    it(`can poll coarseOutput for status update`, async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const root = {
@@ -180,18 +183,15 @@ describe(`download results actions integration`, () => {
         const state = {coarseOutput: {downloadId: 123}}
 
         actions.poll({commit, dispatch, state, rootState: root} as any, DOWNLOAD_TYPE.COARSE);
+        vi.advanceTimersByTime(3000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COARSE);
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COARSE);
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated");
-            expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
-            done()
-
-        }, 3100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("CoarseOutputStatusUpdated");
+        expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
     })
 
     it(`can prepare comparison output for download`, async () => {
@@ -211,7 +211,7 @@ describe(`download results actions integration`, () => {
         expect(commit.mock.calls[1][0]["payload"].detail).toBe("Failed to fetch result");
     })
 
-    it(`can poll comparison output for status update`, (done) => {
+    it(`can poll comparison output for status update`, async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const root = {
@@ -222,21 +222,18 @@ describe(`download results actions integration`, () => {
         const state = {comparison: {downloadId: 123}}
 
         actions.poll({commit, dispatch, state, rootState: root} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(3000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COMPARISON);
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COMPARISON);
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated");
-            expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
-            done()
-
-        }, 3100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonOutputStatusUpdated");
+        expect(commit.mock.calls[1][0]["payload"].status).toBe("MISSING");
     })
 
-    it(`does not poll comparison output for status update when downloadId is empty`, (done) => {
+    it(`does not poll comparison output for status update when downloadId is empty`, async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const root = {
@@ -247,17 +244,14 @@ describe(`download results actions integration`, () => {
         const state = {comparison: {downloadId: ""}}
 
         actions.poll({commit, dispatch, state, rootState: root} as any, DOWNLOAD_TYPE.COMPARISON);
+        vi.advanceTimersByTime(3000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
+        expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COMPARISON);
+        expect(+commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0]["type"]).toBe("PollingStatusStarted");
-            expect(commit.mock.calls[0][0]["payload"].downloadType).toBe(DOWNLOAD_TYPE.COMPARISON);
-            expect(commit.mock.calls[0][0]["payload"].pollId).toBeGreaterThan(-1);
-
-            expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonError");
-            expect(commit.mock.calls[1][0]["payload"].detail).toContain("Otherwise please contact support at naomi-support@imperial.ac.uk");
-            done()
-
-        }, 3100)
+        expect(commit.mock.calls[1][0]["type"]).toBe("ComparisonError");
+        expect(commit.mock.calls[1][0]["payload"].detail).toContain("Otherwise please contact support at naomi-support@imperial.ac.uk");
     })
 })

--- a/src/app/static/src/tests/integration/modelRun.itest.ts
+++ b/src/app/static/src/tests/integration/modelRun.itest.ts
@@ -6,6 +6,7 @@ import {ModelRunState} from "../../app/store/modelRun/modelRun";
 import {api} from "../../app/apiService";
 import {ModelRunMutation} from "../../app/store/modelRun/mutations";
 import {Language} from "../../app/store/translations/locales";
+import { flushPromises } from "@vue/test-utils";
 
 describe("Model run actions", () => {
 
@@ -46,23 +47,16 @@ describe("Model run actions", () => {
         expect(commit.mock.calls[1][0]["payload"]["error"]).toBe("INVALID_INPUT");
     });
 
-    it("can get model run status", (done) => {
+    it("can get model run status", async () => {
         const commit = vi.fn();
         const mockState = {status: {done: true}} as ModelRunState;
 
         actions.poll({commit, state: mockState, dispatch: vi.fn(), rootState} as any, runId);
         expect(commit.mock.calls[0][0]["type"]).toBe("PollingForStatusStarted");
-        const pollingInterval = (commit.mock.calls[0][0]["payload"]);
 
-        const testInterval = setInterval(() => {
-            if (commit.mock.calls.length == 2) {
-                expect(commit.mock.calls[1][0]["type"]).toBe("RunStatusUpdated");
-                clearInterval(pollingInterval);
-                clearInterval(testInterval);
-                done();
-            }
-
-        })
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[1][0]["type"]).toBe("RunStatusUpdated");
     });
 
     it("can get model run result", async () => {

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -379,7 +379,7 @@ describe("Load actions", () => {
         expect(JSON.parse(mockAxios.history.post[0]["data"])).toStrictEqual(sessionFilesPayload)
         expect(commit.mock.calls.length).toBe(4)
         expect(commit.mock.calls[0][0].type).toBe("RehydratePollingStarted")
-        expect(commit.mock.calls[0][0].payload).toBeGreaterThan(1)
+        expect(+commit.mock.calls[0][0].payload).toBeGreaterThan(1)
         expect(commit.mock.calls[1][0].type).toBe("RehydrateStatusUpdated")
         expect(commit.mock.calls[1][0].payload).toStrictEqual(RunningStatusResponse)
         expect(commit.mock.calls[2][0].type).toBe("RehydrateResult")
@@ -468,7 +468,7 @@ describe("Load actions", () => {
         await flushPromises();
         expect(commit.mock.calls.length).toBe(2)
         expect(commit.mock.calls[0][0].type).toBe("RehydratePollingStarted")
-        expect(commit.mock.calls[0][0].payload).toBeGreaterThan(1)
+        expect(+commit.mock.calls[0][0].payload).toBeGreaterThan(1)
         expect(commit.mock.calls[1][0].type).toBe("RehydrateResultError")
         expect(commit.mock.calls[1][0].payload).toStrictEqual(mockError("ERROR"))
         expect(dispatch).not.toHaveBeenCalled()

--- a/src/app/static/src/tests/load/actions.test.ts
+++ b/src/app/static/src/tests/load/actions.test.ts
@@ -14,6 +14,7 @@ import {ProjectRehydrateStatusResponse} from "../../app/generated";
 import {DynamicControlType} from "@reside-ic/vue-next-dynamic-form";
 import {RootState} from "../../app/root";
 import {router} from "../../app/router";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 
@@ -27,8 +28,8 @@ describe("Load actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
-        (console.info as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
+        (console.info as Mock).mockClear();
     });
 
     it("clears loading state", async () => {

--- a/src/app/static/src/tests/metadata/actions.test.ts
+++ b/src/app/static/src/tests/metadata/actions.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../mocks";
 import {actions} from "../../app/store/metadata/actions";
 import {MetadataMutations} from "../../app/store/metadata/mutations";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 describe("Metadata actions", () => {
@@ -16,7 +17,7 @@ describe("Metadata actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("commits metadata after successful fetch", async () => {

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -17,6 +17,7 @@ import {DownloadResultsMutation} from "../../app/store/downloadResults/mutations
 import { ModelOutputTabs } from "../../app/types";
 import { BarchartIndicator } from "../../app/generated";
 import { Mock } from "vitest";
+import { flushPromises } from "@vue/test-utils";
 
 const rootState = mockRootState();
 describe("ModelCalibrate actions", () => {
@@ -29,6 +30,14 @@ describe("ModelCalibrate actions", () => {
     afterEach(() => {
         (console.log as Mock).mockClear();
     });
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
+
+    afterAll(() => {
+        vi.useRealTimers();
+    })
 
     it("fetchModelCalibrateOptions fetches options and commits mutations", async () => {
         const commit = vi.fn();
@@ -98,7 +107,7 @@ describe("ModelCalibrate actions", () => {
         expect(dispatch.mock.calls.length).toBe(0);
     });
 
-    it("poll commits status when successfully fetched", (done) => {
+    it("poll commits status when successfully fetched", async () => {
         mockAxios.onGet(`/calibrate/status/1234`)
             .reply(200, mockSuccess("TEST DATA"));
 
@@ -107,20 +116,17 @@ describe("ModelCalibrate actions", () => {
         const state = mockModelCalibrateState({calibrateId: "1234"});
 
         actions.poll({commit, dispatch, state, rootState} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
-            expect(commit.mock.calls[0][0].payload).toBeGreaterThan(-1);
-            expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
-            expect(commit.mock.calls[1][0].payload).toBe("TEST DATA");
-            expect(dispatch.mock.calls.length).toBe(0);
-
-            done();
-        }, 2100);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+        expect(+commit.mock.calls[0][0].payload).toBeGreaterThan(-1);
+        expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
+        expect(commit.mock.calls[1][0].payload).toBe("TEST DATA");
+        expect(dispatch.mock.calls.length).toBe(0);
     });
 
-    it("poll commits error when unsuccessful fetch", (done) => {
+    it("poll commits error when unsuccessful fetch", async () => {
         mockAxios.onGet(`/calibrate/status/1234`)
             .reply(500, mockFailure("Test Error"));
 
@@ -129,22 +135,19 @@ describe("ModelCalibrate actions", () => {
         const state = mockModelCalibrateState({calibrateId: "1234"});
 
         actions.poll({commit, dispatch, state, rootState} as any);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "SetError",
-                payload: mockError("Test Error")
-            });
-            expect(dispatch.mock.calls.length).toBe(0);
-
-            done();
-        }, 2100);
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "SetError",
+            payload: mockError("Test Error")
+        });
+        expect(dispatch.mock.calls.length).toBe(0);
     });
 
-    it("poll dispatches getResult when status done", (done) => {
+    it("poll dispatches getResult when status done", async () => {
         mockAxios.onGet(`/calibrate/status/1234`)
             .reply(200, mockSuccess("TEST DATA"));
 
@@ -153,17 +156,14 @@ describe("ModelCalibrate actions", () => {
         const state = mockModelCalibrateState({calibrateId: "1234", status: {done: true, success: false} as any});
 
         actions.poll({commit, dispatch, state, rootState} as any);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+        expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
 
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(2);
-            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
-            expect(commit.mock.calls[1][0].type).toBe("CalibrateStatusUpdated");
-
-            expect(dispatch.mock.calls.length).toBe(1);
-            expect(dispatch.mock.calls[0][0]).toBe("getResult");
-
-            done();
-        }, 2100);
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("getResult");
     });
 
     it("getResult commits result and warnings when successfully fetched, sets default plotting selections, and dispatches getCalibratePlot and getComparisonPlot", async () => {

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -16,6 +16,7 @@ import {switches} from "../../app/featureSwitches";
 import {DownloadResultsMutation} from "../../app/store/downloadResults/mutations";
 import { ModelOutputTabs } from "../../app/types";
 import { BarchartIndicator } from "../../app/generated";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 describe("ModelCalibrate actions", () => {
@@ -26,7 +27,7 @@ describe("ModelCalibrate actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("fetchModelCalibrateOptions fetches options and commits mutations", async () => {

--- a/src/app/static/src/tests/modelOptions/actions.test.ts
+++ b/src/app/static/src/tests/modelOptions/actions.test.ts
@@ -1,6 +1,7 @@
 import {actions} from "../../app/store/modelOptions/actions";
 import {ModelOptionsMutation} from "../../app/store/modelOptions/mutations";
 import {mockAxios, mockModelOptionsState, mockRootState, mockSuccess, mockFailure, mockError} from "../mocks";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 describe("model run options actions", () => {
@@ -12,7 +13,7 @@ describe("model run options actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("fetches and commits model run options and version", async () => {

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -13,6 +13,7 @@ import {expectEqualsFrozen} from "../testHelpers";
 import {ModelRunMutation} from "../../app/store/modelRun/mutations";
 import {freezer} from "../../app/utils";
 import { Mock } from "vitest";
+import { flushPromises } from "@vue/test-utils";
 
 const rootState = mockRootState();
 
@@ -29,6 +30,14 @@ describe("Model run actions", () => {
         (console.log as Mock).mockClear();
         (console.info as Mock).mockClear();
     });
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
+
+    afterAll(() => {
+        vi.useRealTimers();
+    })
 
     it("passes model options and version from state", async () => {
 
@@ -94,7 +103,7 @@ describe("Model run actions", () => {
         });
     });
 
-    it("fetches model run result after polling when status is done", (done) => {
+    it("fetches model run result after polling when status is done", async () => {
 
         mockAxios.onGet(`/model/status/1234`)
             .reply(200, mockSuccess({}));
@@ -106,15 +115,13 @@ describe("Model run actions", () => {
         const dispatch = vi.fn();
 
         actions.poll({commit, state, dispatch, rootState} as any, "1234");
-
-        setInterval(() => {
-            expect(dispatch.mock.calls[0][0]).toStrictEqual("getResult");
-            expect(dispatch.mock.calls[0][1]).toStrictEqual("1234");
-            done();
-        }, 2100);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(dispatch.mock.calls[0][0]).toStrictEqual("getResult");
+        expect(dispatch.mock.calls[0][1]).toStrictEqual("1234");
     });
 
-    it("does not fetch model run result after polling if done is not true", (done) => {
+    it("does not fetch model run result after polling if done is not true", async () => {
 
         mockAxios.onGet(`/model/status/1234`)
             .reply(200, mockSuccess({}));
@@ -126,15 +133,12 @@ describe("Model run actions", () => {
         const dispatch = vi.fn();
 
         actions.poll({commit, state, dispatch, rootState} as any, "1234");
-
-        setInterval(() => {
-            expect(dispatch.mock.calls.length).toEqual(0);
-            done();
-        }, 2100);
-
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(dispatch.mock.calls.length).toEqual(0);
     });
 
-    it("poll commits status when successfully fetched",  (done) => {
+    it("poll commits status when successfully fetched", async () => {
         mockAxios.onGet(`/model/status/1234`)
             .reply(200, mockSuccess("TEST DATA"));
         mockAxios.onGet(`/model/result/1234`)
@@ -144,20 +148,16 @@ describe("Model run actions", () => {
         const state = mockModelRunState();
 
         actions.poll({commit, state, rootState} as any, "1234");
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "RunStatusUpdated",
-                payload: "TEST DATA"
-            });
-
-            done();
-        }, 2100);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "RunStatusUpdated",
+            payload: "TEST DATA"
+        });
     });
 
-    it("poll commits error when unsuccessful fetch", (done) => {
+    it("poll commits error when unsuccessful fetch", async () => {
         mockAxios.onGet(`/model/status/1234`)
             .reply(500, mockFailure("Test Error"));
 
@@ -165,17 +165,13 @@ describe("Model run actions", () => {
         const state = mockModelRunState();
 
         actions.poll({commit, state, rootState} as any, "1234");
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
-
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: "RunStatusError",
-                payload: mockError("Test Error")
-            });
-
-            done();
-        }, 2100);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls[0][0].type).toBe("PollingForStatusStarted");
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: "RunStatusError",
+            payload: mockError("Test Error")
+        });
     });
 
     it("getResult commits result and warnings when successfully fetched", async () => {

--- a/src/app/static/src/tests/modelRun/actions.test.ts
+++ b/src/app/static/src/tests/modelRun/actions.test.ts
@@ -12,6 +12,7 @@ import {ModelStatusResponse} from "../../app/generated";
 import {expectEqualsFrozen} from "../testHelpers";
 import {ModelRunMutation} from "../../app/store/modelRun/mutations";
 import {freezer} from "../../app/utils";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 
@@ -25,8 +26,8 @@ describe("Model run actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
-        (console.info as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
+        (console.info as Mock).mockClear();
     });
 
     it("passes model options and version from state", async () => {

--- a/src/app/static/src/tests/password/actions.test.ts
+++ b/src/app/static/src/tests/password/actions.test.ts
@@ -3,6 +3,7 @@ import {actions} from "../../app/store/password/actions";
 import {RootMutation} from "../../app/store/root/mutations";
 import {Language} from "../../app/store/translations/locales";
 import {LanguageMutation} from "../../app/store/language/mutations";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 describe("Password actions", () => {
@@ -14,7 +15,7 @@ describe("Password actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
 

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -6,6 +6,7 @@ import {ErrorsMutation} from "../../app/store/errors/mutations";
 import {Project} from "../../app/types";
 import {serialiseState} from "../../app/localStorageManager";
 import { Mock } from "vitest";
+import { flushPromises } from "@vue/test-utils";
 
 describe("Projects actions", () => {
     beforeEach(() => {
@@ -18,8 +19,15 @@ describe("Projects actions", () => {
     afterEach(() => {
         (console.log as Mock).mockClear();
         (console.info as Mock).mockClear();
-        vi.useRealTimers();
     });
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
+
+    afterAll(() => {
+        vi.useRealTimers();
+    })
 
     const rootState = mockRootState();
 
@@ -77,7 +85,7 @@ describe("Projects actions", () => {
         expect(result).toBe(false);
     });
 
-    it("createProject posts to new project endpoint and sets error on unsuccessful response",  (done) => {
+    it("createProject posts to new project endpoint and sets error on unsuccessful response", async () => {
         mockAxios.onPost(`/project/`)
             .reply(500, mockFailure("TestError"));
 
@@ -86,24 +94,21 @@ describe("Projects actions", () => {
         const state = mockProjectsState({error: "TEST ERROR" as any});
 
         actions.createProject({commit, dispatch, state, rootState} as any, {name: "newProject"});
+        await flushPromises();
+        expect(dispatch).toHaveBeenCalledTimes(1)
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: "modelCalibrate/ResetIds"});
+        expect(commit.mock.calls[2][0]).toStrictEqual({type: "modelRun/ResetIds"});
+        expect(commit.mock.calls[3][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
 
-        setTimeout(() => {
-            expect(dispatch).toHaveBeenCalledTimes(1)
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
-            expect(commit.mock.calls[1][0]).toStrictEqual({type: "modelCalibrate/ResetIds"});
-            expect(commit.mock.calls[2][0]).toStrictEqual({type: "modelRun/ResetIds"});
-            expect(commit.mock.calls[3][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-
-            const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[4][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            done();
+        const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
+        expect(commit.mock.calls[4][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
     });
 
-    it("createProject posts to new project endpoint and resets project with root on successful response",  (done) => {
+    it("createProject posts to new project endpoint and resets project with root on successful response", async () => {
         mockAxios.onPost(`/project/`)
             .reply(200, mockSuccess("TestProject"));
 
@@ -112,23 +117,20 @@ describe("Projects actions", () => {
         const state = mockProjectsState();
 
         actions.createProject({commit, dispatch, state, rootState} as any, {name: "newProject"});
+        await flushPromises();
+        expect(dispatch).toHaveBeenCalledTimes(1)
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: "modelCalibrate/ResetIds"});
+        expect(commit.mock.calls[2][0]).toStrictEqual({type: "modelRun/ResetIds"});
+        expect(commit.mock.calls[3][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
 
-        setTimeout(() => {
-            expect(dispatch).toHaveBeenCalledTimes(1)
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
-            expect(commit.mock.calls[1][0]).toStrictEqual({type: "modelCalibrate/ResetIds"});
-            expect(commit.mock.calls[2][0]).toStrictEqual({type: "modelRun/ResetIds"});
-            expect(commit.mock.calls[3][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-
-            const posted = mockAxios.history.post[0].data;
-            expect(posted).toEqual("name=newProject");
-            expect(commit.mock.calls[4][0]).toStrictEqual({type: RootMutation.SetProject, payload: "TestProject"});
-            expect(commit.mock.calls[4][1]).toStrictEqual({root: true});
-            done();
-        });
+        const posted = mockAxios.history.post[0].data;
+        expect(posted).toEqual("name=newProject");
+        expect(commit.mock.calls[4][0]).toStrictEqual({type: RootMutation.SetProject, payload: "TestProject"});
+        expect(commit.mock.calls[4][1]).toStrictEqual({root: true});
     });
 
-    it("gets projects and commits mutation on successful response",  (done) => {
+    it("gets projects and commits mutation on successful response", async () => {
         const testProjects = [{id: 1, name: "v1", versions: []}];
         mockAxios.onGet("/projects/")
             .reply(200, mockSuccess(testProjects));
@@ -137,18 +139,15 @@ describe("Projects actions", () => {
         const state = mockProjectsState();
 
         actions.getProjects({commit, state, rootState} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: ProjectsMutations.SetPreviousProjects,
-                payload: testProjects
-            });
-            done();
+        await flushPromises();
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.SetPreviousProjects,
+            payload: testProjects
         });
     });
 
-    it("gets current project and commits mutation on successful response",  (done) => {
+    it("gets current project and commits mutation on successful response", async () => {
         const testProjects = [{id: 1, name: "v1", versions: []}];
         mockAxios.onGet("/project/current")
             .reply(200, mockSuccess(testProjects));
@@ -158,19 +157,16 @@ describe("Projects actions", () => {
         const rootGetters = {isGuest: false}
 
         actions.getCurrentProject({commit, state, rootState, rootGetters} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: ProjectsMutations.SetCurrentProject,
-                payload: testProjects
-            });
-            expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
-            done();
+        await flushPromises();
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.SetCurrentProject,
+            payload: testProjects
         });
+        expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
     });
 
-    it("if current version, createProject uploads current version before post to new project endpoint",  (done) => {
+    it("if current version, createProject uploads current version before post to new project endpoint", async () => {
         mockAxios.onPost(`/project/`)
             .reply(200, mockSuccess("TestProject"));
         mockAxios.onPost("/project/1/version/version-id/state/")
@@ -189,17 +185,14 @@ describe("Projects actions", () => {
         });
 
         actions.createProject({commit, dispatch, state, rootState} as any, {name: "newProject"});
-
-        setTimeout(() => {
-            expect(dispatch).toHaveBeenCalledTimes(1)
-            expect(mockAxios.history.post.length).toBe(2);
-            expect(mockAxios.history.post[0].url).toBe("/project/1/version/version-id/state/");
-            expect(mockAxios.history.post[1].url).toBe("/project/");
-            done();
-        });
+        await flushPromises();
+        expect(dispatch).toHaveBeenCalledTimes(1)
+        expect(mockAxios.history.post.length).toBe(2);
+        expect(mockAxios.history.post[0].url).toBe("/project/1/version/version-id/state/");
+        expect(mockAxios.history.post[1].url).toBe("/project/");
     });
 
-    it("gets projects and sets error on unsuccessful response",  (done) => {
+    it("gets projects and sets error on unsuccessful response", async () => {
         mockAxios.onGet("/projects/")
             .reply(500, mockFailure("TestError"));
 
@@ -207,19 +200,16 @@ describe("Projects actions", () => {
         const state = mockProjectsState();
 
         actions.getProjects({commit, state, rootState} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
     });
 
-    it("gets current project and sets error on unsuccessful response",  (done) => {
+    it("gets current project and sets error on unsuccessful response", async () => {
         mockAxios.onGet("/project/current")
             .reply(500, mockFailure("TestError"));
 
@@ -228,30 +218,25 @@ describe("Projects actions", () => {
         const rootGetters = {isGuest: false}
 
         actions.getCurrentProject({commit, state, rootState, rootGetters} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[1][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
-            done();
+        await flushPromises();
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
+        expect(commit.mock.calls[1][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
+        expect(commit.mock.calls[2][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: false});
     });
 
-    it("queueVersionStateUpload does nothing if no current version",  (done) => {
+    it("queueVersionStateUpload does nothing if no current version", async () => {
         const commit = vi.fn();
         const state = mockProjectsState();
 
         actions.queueVersionStateUpload({commit, state, rootState} as any);
-
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(0);
-            expect(mockAxios.history.post.length).toBe(0);
-            done();
-        }, 2500);
+        vi.advanceTimersByTime(2000);
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(0);
+        expect(mockAxios.history.post.length).toBe(0);
     });
 
     it("queued upload will not run while version upload is already in progress",  () => {
@@ -279,7 +264,7 @@ describe("Projects actions", () => {
         expect(mockAxios.history.post.length).toBe(0);
     });
 
-    it("queued upload will run if no version upload is in progress", (done) => {
+    it("queued upload will run if no version upload is in progress", async () => {
         const commit = vi.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
@@ -295,11 +280,8 @@ describe("Projects actions", () => {
         mockAxios.onPost(url)
             .reply(200, mockSuccess("OK"));
 
-        vi.useFakeTimers();
         vi.spyOn(window, "setInterval");
-
         actions.queueVersionStateUpload({commit, state, rootState} as any);
-
         expect(setInterval).toHaveBeenCalledTimes(1);
 
         expect(commit.mock.calls.length).toBe(2);
@@ -322,27 +304,23 @@ describe("Projects actions", () => {
             payload: true
         });
 
-        vi.useRealTimers();
-
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(6);
-            expect(commit.mock.calls[4][0]).toStrictEqual({
-                type: ProjectsMutations.VersionUploadSuccess,
-                payload: "OK"
-            });
-            expect(commit.mock.calls[5][0]).toStrictEqual({
-                type: ProjectsMutations.SetVersionUploadInProgress,
-                payload: false
-            });
-            expect(mockAxios.history.post.length).toBe(1);
-            expect(mockAxios.history.post[0].url).toBe(url);
-            const posted = mockAxios.history.post[0].data;
-            expect(JSON.parse(posted)).toStrictEqual(serialiseState(rootState));
-            done();
-        })
+        await flushPromises()
+        expect(commit.mock.calls.length).toBe(6);
+        expect(commit.mock.calls[4][0]).toStrictEqual({
+            type: ProjectsMutations.VersionUploadSuccess,
+            payload: "OK"
+        });
+        expect(commit.mock.calls[5][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: false
+        });
+        expect(mockAxios.history.post.length).toBe(1);
+        expect(mockAxios.history.post[0].url).toBe(url);
+        const posted = mockAxios.history.post[0].data;
+        expect(JSON.parse(posted)).toStrictEqual(serialiseState(rootState));
     });
 
-    it("uploadVersionState commits ErrorAdded on error response and unsets in progress upload",  (done) => {
+    it("uploadVersionState commits ErrorAdded on error response and unsets in progress upload", async () => {
         const commit = vi.fn();
         const state = mockProjectsState({
             currentProject: mockProject,
@@ -358,22 +336,16 @@ describe("Projects actions", () => {
         mockAxios.onPost(url)
             .reply(500, mockFailure("ERR"));
 
-        vi.useFakeTimers();
-
         actions.queueVersionStateUpload({commit, state, rootState} as any);
 
         vi.advanceTimersByTime(2001);
-        vi.useRealTimers();
-
-        setTimeout(() => {
-            expect(commit.mock.calls.length).toBe(6);
-            expect(commit.mock.calls[4][0]["type"]).toBe("errors/ErrorAdded");
-            expect(commit.mock.calls[5][0]).toStrictEqual({
-                type: ProjectsMutations.SetVersionUploadInProgress,
-                payload: false
-            });
-            done();
-        })
+        await flushPromises();
+        expect(commit.mock.calls.length).toBe(6);
+        expect(commit.mock.calls[4][0]["type"]).toBe("errors/ErrorAdded");
+        expect(commit.mock.calls[5][0]).toStrictEqual({
+            type: ProjectsMutations.SetVersionUploadInProgress,
+            payload: false
+        });
     });
 
     it("newVersion uploads current version state then requests new version, commits VersionCreated", async () => {
@@ -464,7 +436,7 @@ describe("Projects actions", () => {
         expect(commit.mock.calls[3][1]).toStrictEqual({root: true});
     });
 
-    it("loadVersion fetches version details and invokes load state action",  (done) => {
+    it("loadVersion fetches version details and invokes load state action", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {error: null};
@@ -473,17 +445,15 @@ describe("Projects actions", () => {
             .reply(200, mockSuccess(mockVersionDetails));
 
         actions.loadVersion({commit, dispatch, state, rootState} as any, {projectId: 1, versionId: "testVersion"});
-        setTimeout(() => {
-            expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
-            expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            expect(dispatch.mock.calls[0][0]).toBe("load/loadFromVersion");
-            expect(dispatch.mock.calls[0][1]).toStrictEqual(mockVersionDetails);
-            expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
-            done();
-        });
+        await flushPromises();
+        expect(commit.mock.calls[0][0]).toStrictEqual({type: "downloadResults/ResetIds"});
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        expect(dispatch.mock.calls[0][0]).toBe("load/loadFromVersion");
+        expect(dispatch.mock.calls[0][1]).toStrictEqual(mockVersionDetails);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
     });
 
-    it("loadVersion commits error if cannot fetch version details",  (done) => {
+    it("loadVersion commits error if cannot fetch version details", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {error: "test error"};
@@ -491,18 +461,16 @@ describe("Projects actions", () => {
             .reply(500, mockFailure("test error"));
 
         actions.loadVersion({commit, dispatch, state, rootState} as any, {projectId: 1, versionId: "testVersion"});
-        setTimeout(() => {
-            expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
-            const expectedError = {detail: "test error", error: "OTHER_ERROR"};
-            expect(commit.mock.calls[2][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        expect(commit.mock.calls[1][0]).toStrictEqual({type: ProjectsMutations.SetLoading, payload: true});
+        const expectedError = {detail: "test error", error: "OTHER_ERROR"};
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
     });
 
-    it("deleteProject dispatches getProjects action",  (done) => {
+    it("deleteProject dispatches getProjects action", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
@@ -510,27 +478,23 @@ describe("Projects actions", () => {
             .reply(200, mockSuccess("OK"));
 
         actions.deleteProject({commit, dispatch, state, rootState} as any, 1);
-        setTimeout(() => {
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            expect(commit.mock.calls.length).toBe(0);
-            done();
-        });
+        await flushPromises();
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
+        expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("deleteProject commits ProjectError on failure",  (done) => {
+    it("deleteProject commits ProjectError on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
         mockAxios.onDelete("project/1")
             .reply(500, mockFailure("TEST ERROR"));
         actions.deleteProject({commit, dispatch, state, rootState} as any, 1);
-        setTimeout(() => {
-            const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
     });
 
@@ -545,7 +509,7 @@ describe("Projects actions", () => {
         expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.ClearCurrentVersion});
     });
 
-    it("deleteVersion dispatches getProjects action",  (done) => {
+    it("deleteVersion dispatches getProjects action", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
@@ -553,27 +517,23 @@ describe("Projects actions", () => {
             .reply(200, mockSuccess("OK"));
 
         actions.deleteVersion({commit, dispatch, state, rootState} as any, {projectId: 1, versionId: "testVersion"});
-        setTimeout(() => {
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            expect(commit.mock.calls.length).toBe(0);
-            done();
-        });
+        await flushPromises();
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
+        expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("deleteVersion commits ProjectError on failure",  (done) => {
+    it("deleteVersion commits ProjectError on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
         mockAxios.onDelete("project/1/version/testVersion")
             .reply(500, mockFailure("TEST ERROR"));
         actions.deleteVersion({commit, dispatch, state, rootState} as any, {projectId: 1, versionId: "testVersion"});
-        setTimeout(() => {
-            const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: ProjectsMutations.ProjectError,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: ProjectsMutations.ProjectError,
+            payload: expectedError
         });
     });
 
@@ -588,7 +548,7 @@ describe("Projects actions", () => {
         expect(commit.mock.calls[0][0]).toStrictEqual({type: ProjectsMutations.ClearCurrentVersion});
     });
 
-    it("promoteVersion creates new project containing replicated version",  (done) => {
+    it("promoteVersion creates new project containing replicated version", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = mockProjectsState({
@@ -606,18 +566,15 @@ describe("Projects actions", () => {
             note: "test"
         }
         actions.promoteVersion({commit, state, rootState, dispatch} as any, versionPayload);
+        await flushPromises();
+        const posted = mockAxios.history.post[0].data;
+        expect(posted).toEqual("name=newProject&note=test");
 
-        setTimeout(() => {
-            const posted = mockAxios.history.post[0].data;
-            expect(posted).toEqual("name=newProject&note=test");
-
-            expect(commit.mock.calls.length).toBe(1);
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            done();
-        });
+        expect(commit.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
     });
 
-    it("promoteVersion commits ErrorAdded on failure",  (done) => {
+    it("promoteVersion commits ErrorAdded on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
@@ -630,17 +587,15 @@ describe("Projects actions", () => {
             note: "new editable note"
         }
         actions.promoteVersion({commit, dispatch, state, rootState} as any, versionPayload);
-        setTimeout(() => {
-            const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: `errors/${ErrorsMutation.ErrorAdded}`,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: `errors/${ErrorsMutation.ErrorAdded}`,
+            payload: expectedError
         });
     });
 
-    it("updateVersionNote action adds/edits a project's note",  (done) => {
+    it("updateVersionNote action adds/edits a project's note", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const testProjects = [{id: 1, name: "v1", versions: []}];
@@ -656,17 +611,14 @@ describe("Projects actions", () => {
         };
 
         actions.updateVersionNote({commit, dispatch, state, rootState} as any, versionPayload);
-
-        setTimeout(() => {
-            const posted = mockAxios.history.post[0].data;
-            expect(posted).toEqual("note=edit%20version%20note");
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            expect(dispatch.mock.calls.length).toBe(1);
-            done();
-        });
+        await flushPromises();
+        const posted = mockAxios.history.post[0].data;
+        expect(posted).toEqual("note=edit%20version%20note");
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
+        expect(dispatch.mock.calls.length).toBe(1);
     });
 
-    it("can update project notes",  (done) => {
+    it("can update project notes", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const testProjects = [{id: 1, name: "v1", versions: []}];
@@ -681,16 +633,14 @@ describe("Projects actions", () => {
             note: "test project note"
         }
         actions.updateProjectNote({commit, dispatch, state, rootState} as any, projectPayload);
-        setTimeout(() => {
-            const posted = mockAxios.history.post[0].data;
-            expect(posted).toEqual("note=test%20project%20note");
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            expect(dispatch.mock.calls.length).toBe(1);
-            done();
-        });
+        await flushPromises();
+        const posted = mockAxios.history.post[0].data;
+        expect(posted).toEqual("note=test%20project%20note");
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
+        expect(dispatch.mock.calls.length).toBe(1);
     });
 
-    it("update project notes commits Project Error on failure",  (done) => {
+    it("update project notes commits Project Error on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = mockProjectsState({error: "TEST ERROR" as any});
@@ -704,17 +654,15 @@ describe("Projects actions", () => {
             note: "test project note"
         }
         actions.updateProjectNote({commit, dispatch, state, rootState} as any, projectPayload);
-        setTimeout(() => {
-            const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: `errors/${ErrorsMutation.ErrorAdded}`,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: `errors/${ErrorsMutation.ErrorAdded}`,
+            payload: expectedError
         });
     });
 
-    it("update version notes commits Project Error on failure",  (done) => {
+    it("update version notes commits Project Error on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = mockProjectsState({error: "TEST ERROR" as any});
@@ -729,14 +677,11 @@ describe("Projects actions", () => {
         };
 
         actions.updateVersionNote({commit, dispatch, state, rootState} as any, versionPayload);
-
-        setTimeout(() => {
-            const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: `errors/${ErrorsMutation.ErrorAdded}`,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {error: "OTHER_ERROR", detail: "TestError"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: `errors/${ErrorsMutation.ErrorAdded}`,
+            payload: expectedError
         });
     });
 
@@ -767,7 +712,7 @@ describe("Projects actions", () => {
         expect(dispatch.mock.calls.length).toBe(2);
     });
 
-    it("renameProject does not dispatch getCurrentProject if currentProject is not being renamed",  (done) => {
+    it("renameProject does not dispatch getCurrentProject if currentProject is not being renamed", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = mockProjectsState({
@@ -784,17 +729,14 @@ describe("Projects actions", () => {
             name: "renamedProject"
         }
         actions.renameProject({commit, state, rootState, dispatch} as any, projectPayload);
-
-        setTimeout(() => {
-            const posted = mockAxios.history.post[0].data;
-            expect(posted).toEqual("name=renamedProject");
-            expect(dispatch.mock.calls[0][0]).toBe("getProjects");
-            expect(dispatch.mock.calls.length).toBe(1);
-            done();
-        });
+        await flushPromises();
+        const posted = mockAxios.history.post[0].data;
+        expect(posted).toEqual("name=renamedProject");
+        expect(dispatch.mock.calls[0][0]).toBe("getProjects");
+        expect(dispatch.mock.calls.length).toBe(1);
     });
 
-    it("renameProject commits ErrorAdded on failure",  (done) => {
+    it("renameProject commits ErrorAdded on failure", async () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         const state = {};
@@ -806,14 +748,11 @@ describe("Projects actions", () => {
             name: "renamedProject"
         }
         actions.renameProject({commit, dispatch, state, rootState} as any, projectPayload);
-        setTimeout(() => {
-            const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
-            expect(commit.mock.calls[0][0]).toStrictEqual({
-                type: `errors/${ErrorsMutation.ErrorAdded}`,
-                payload: expectedError
-            });
-            done();
+        await flushPromises();
+        const expectedError = {detail: "TEST ERROR", error: "OTHER_ERROR"};
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: `errors/${ErrorsMutation.ErrorAdded}`,
+            payload: expectedError
         });
     });
-
 });

--- a/src/app/static/src/tests/projects/actions.test.ts
+++ b/src/app/static/src/tests/projects/actions.test.ts
@@ -5,6 +5,7 @@ import {RootMutation} from "../../app/store/root/mutations";
 import {ErrorsMutation} from "../../app/store/errors/mutations";
 import {Project} from "../../app/types";
 import {serialiseState} from "../../app/localStorageManager";
+import { Mock } from "vitest";
 
 describe("Projects actions", () => {
     beforeEach(() => {
@@ -15,8 +16,8 @@ describe("Projects actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
-        (console.info as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
+        (console.info as Mock).mockClear();
         vi.useRealTimers();
     });
 

--- a/src/app/static/src/tests/projects/mutations.test.ts
+++ b/src/app/static/src/tests/projects/mutations.test.ts
@@ -1,6 +1,7 @@
 import {mockProjectsState} from "../mocks";
 import {mutations, ProjectsMutations} from "../../app/store/projects/mutations";
 import {router} from "../../app/router";
+import { Mock } from "vitest";
 
 describe("Projects mutations", () => {
     const testNow = Date.now();
@@ -27,7 +28,7 @@ describe("Projects mutations", () => {
     });
 
     afterEach(() => {
-        (console.error as vi.Mock).mockClear();
+        (console.error as Mock).mockClear();
     });
 
     it("sets cloningProject and resets error", () => {

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -5,6 +5,7 @@ import Vuex from "vuex";
 import {mockRootState} from "./mocks";
 import {store} from "../app/main";
 import Hint from "../app/components/Hint.vue";
+import { Mock } from "vitest";
 
 // Mock the actions before import the router as the app will call
 // these actions on import
@@ -53,7 +54,7 @@ import {router, beforeEnter} from '../app/router';
 describe("Router", () => {
 
     afterAll(() => {
-        (console.error as vi.Mock).mockClear();
+        (console.error as Mock).mockClear();
     });
 
     it("has expected properties", async () => {

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -14,8 +14,8 @@ import {
 import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
 import {expectEqualsFrozen} from "../testHelpers";
 import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
-import Mock = vi.Mock;
 import {expectValidAdrImportPayload} from "../baseline/actions.test";
+import { Mock } from "vitest";
 
 const rootState = mockRootState();
 const mockFormData = {
@@ -37,7 +37,7 @@ describe("Survey and programme actions", () => {
     });
 
     afterEach(() => {
-        (console.log as vi.Mock).mockClear();
+        (console.log as Mock).mockClear();
     });
 
     it("sets data after surveys file upload", async () => {

--- a/src/app/static/src/tests/testHelpers.ts
+++ b/src/app/static/src/tests/testHelpers.ts
@@ -9,8 +9,8 @@ import ErrorReport from "../app/components/ErrorReport.vue";
 import { VueWrapper, mount, shallowMount } from "@vue/test-utils";
 import translate from "../app/directives/translate";
 import { nextTick } from "vue";
-import Mock = vi.Mock;
 import {RootState} from "../app/root";
+import { Mock } from "vitest";
 
 export function expectEqualsFrozen(args: PayloadWithType<any>, expected: PayloadWithType<any>) {
     expect(Object.isFrozen(args["payload"])).toBe(true);


### PR DESCRIPTION
## Description

The diff is big but the changes are largely programmatic. Changes of interest:
* vi does not contain types `Mock` and `Mocked` (which jest did) so we have to replace `vi.Mock` to `Mock` and imoprt `Mock` from vitest
* done is deprecated and it is slow, this also removes all dones (these were used in timeouts so instead we are awaiting and advancing fake timers)
* mock plotly in plotly.test.ts (vi.mock is different from jest.mock)