### PR TITLE
mrc-4841 Fix tests part 2

### DIFF
--- a/buildkite/shared-build-env.dockerfile
+++ b/buildkite/shared-build-env.dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/node-docker:master
+FROM mrcide/node-20-docker:master
 
 RUN apt-get install wget
 

--- a/buildkite/shared-build-env.dockerfile
+++ b/buildkite/shared-build-env.dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/node-20-docker:master
+FROM mrcide/node-20-docker:main
 
 RUN apt-get install wget
 

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -9,7 +9,7 @@
     "build": "rm -rf public && vue-cli-service build ./src/app/index.ts",
     "serve": "rm -rf public && VUE_CLI_SERVICE_CONFIG_PATH=$PWD/vue.config.js vue-cli-service serve ./src/app/index.ts",
     "copy": "cp -r ./templates/*.ftl ./public && cp -r ./assets/* ./public",
-    "test": "vitest",
+    "test": "vitest --run",
     "browser-test": "npx playwright test",
     "integration-test": "jest --testPathIgnorePatterns adr-dataset -c jest.integration.config.js",
     "adr-integration-test": "jest --testPathPattern adr-dataset -c jest.integration.adr.config.js",

--- a/src/app/static/src/app/components/HintTreeSelect.vue
+++ b/src/app/static/src/app/components/HintTreeSelect.vue
@@ -4,6 +4,10 @@
     :options="options"
     :model-value="modelValue"
     :multiple="multiple"
+    :disabled="!!disabled"
+    :clearable="!!clearable"
+    :placeholder="placeholder"
+    :searchable="searchable"
     @update:model-value="input">
     <!-- way to pass down all slots -->
     <template v-for="(_, slot) in $slots" v-slot:[slot]="scope">
@@ -38,6 +42,18 @@
                 type: [Array, String] as PropType<string | string[] | null>,
             },
             multiple: {
+                type: Boolean
+            },
+            disabled: {
+                type: Boolean
+            },
+            clearable: {
+                type: Boolean
+            },
+            placeholder: {
+                type: String
+            },
+            searchable: {
                 type: Boolean
             }
         },

--- a/src/app/static/src/tests/components/adr/selectDataset.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDataset.test.ts
@@ -642,9 +642,8 @@ describe("select dataset", () => {
             }, 
         });
         await rendered.find("button").trigger("click");
-        const select = rendered.findComponent(TreeSelect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("multiple")).toBe(false);
-        expect(select.props("searchable")).toBe(true);
 
         const expectedOptions = [
             {

--- a/src/app/static/src/tests/components/adr/selectRelease.test.ts
+++ b/src/app/static/src/tests/components/adr/selectRelease.test.ts
@@ -4,7 +4,6 @@ import {ADRMutation} from "../../../app/store/adr/mutations";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
 import {mockRootState} from "../../mocks";
 import {expectTranslated, mountWithTranslate, shallowMountWithTranslate} from "../../testHelpers";
-import Treeselect from "vue3-treeselect";
 import {Language} from "../../../app/store/translations/locales";
 import {Dataset} from "../../../app/types";
 import VueFeather from "vue-feather";
@@ -37,10 +36,9 @@ describe("select release", () => {
             pop: null,
             survey: null,
             shape: null,
-            anc: null,
-            vmmc: null
+            anc: null
         }
-    }
+    } as any
     const getReleasesMock = vi.fn();
     const clearReleasesMock = vi.fn();
     
@@ -98,9 +96,8 @@ describe("select release", () => {
         expectTranslated(labels[2], "Releases", "Versions",
             "Lançamentos", store);
         expect(rendered.findAllComponents(VueFeather).length).toBe(2);
-        const select = rendered.findComponent(Treeselect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("multiple")).toBe(false);
-        expect(select.props("searchable")).toBe(true);
         expect((rendered.vm.$data as any).releaseId).toBeUndefined();
 
         const expectedOptions = [
@@ -222,7 +219,7 @@ describe("select release", () => {
             }, 
         });
         await rendered.setProps({datasetId: "datasetId"})
-        const select = rendered.findComponent(Treeselect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
         const selectRelease = rendered.findAll("input")[1]
         await selectRelease.trigger("change")
@@ -236,7 +233,7 @@ describe("select release", () => {
                 plugins: [store]
             }, props: {datasetId: "datasetId"}
         });
-        const select = rendered.findComponent(Treeselect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
         expect((rendered.vm.$data as any).releaseId).toBe("releaseId");
     });
@@ -268,7 +265,7 @@ describe("select release", () => {
                 plugins: [store]
             }, props: {datasetId: "datasetId", choiceADR: "useRelease"}
         });
-        const select = rendered.findComponent(Treeselect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
         expect((rendered.vm.$data as any).releaseId).toBeUndefined();
     });
@@ -335,7 +332,7 @@ describe("select release", () => {
 
         await rendered.setProps({datasetId: "datasetId2"})
         expect(clearReleasesMock.mock.calls.length).toBe(2);
-        const select = rendered.findComponent(Treeselect);
+        const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
         expect((rendered.vm.$data as any).releaseId).toBe(undefined);
         expect((rendered.vm.$data as any).choiceADR).toBe("useLatest");

--- a/src/app/static/src/tests/components/genericChart/plotly.test.ts
+++ b/src/app/static/src/tests/components/genericChart/plotly.test.ts
@@ -254,7 +254,7 @@ describe("Plotly", () => {
 
         // Rendering flag should be set while rendering proceeds
         expect((wrapper.vm as any).rendering).toBe(true);
-        await nextTick();
+        await flushPromises();
         expect(mockPlotlyReact.mock.calls.length).toBe(1);
         expectPlotlyParams(mockPlotlyReact.mock.calls[0]);
         expect((wrapper.vm as any).rendering).toBe(false);

--- a/src/app/static/src/tests/components/hintTreeSelect.test.ts
+++ b/src/app/static/src/tests/components/hintTreeSelect.test.ts
@@ -1,6 +1,6 @@
 import { VueWrapper, mount } from "@vue/test-utils";
 import HintTreeSelect from "../../app/components/HintTreeSelect.vue";
-import Treeselect from "vue3-treeselect";
+import Treeselect from "@reside-ic/vue3-treeselect";
 
 describe("Treeselect component", () => {
 
@@ -22,10 +22,18 @@ describe("Treeselect component", () => {
         return wrapper.vm.$data.reRender
     }
 
+    beforeAll(() => {
+        vi.useFakeTimers();
+    });
+    afterAll(() => {
+        vi.useRealTimers();
+    });
+
     it("updates key when model value changes with user input (array)", async () => {
         const wrapper = getWrapper();
         expect(getKey(wrapper)).toBe(0);
         await callWatcher(wrapper, "modelValue", ["2"]);
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(1);
     });
 
@@ -33,6 +41,7 @@ describe("Treeselect component", () => {
         const wrapper = getWrapper();
         expect(getKey(wrapper)).toBe(0);
         await callWatcher(wrapper, "modelValue", "2");
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(1);
     });
 
@@ -40,6 +49,7 @@ describe("Treeselect component", () => {
         const wrapper = getWrapper();
         expect(getKey(wrapper)).toBe(0);
         await callWatcher(wrapper, "modelValue", null);
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(1);
     });
 
@@ -49,6 +59,7 @@ describe("Treeselect component", () => {
         expect(getKey(wrapper)).toBe(0);
         await treeSelect.vm.$emit("update:model-value", "2")
         await callWatcher(wrapper, "modelValue", ["2"]);
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(0);
     });
 
@@ -58,6 +69,7 @@ describe("Treeselect component", () => {
         expect(getKey(wrapper)).toBe(0);
         await treeSelect.vm.$emit("update:model-value", "2")
         await callWatcher(wrapper, "modelValue", "2");
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(0);
     });
 
@@ -65,6 +77,7 @@ describe("Treeselect component", () => {
         const wrapper = getWrapper(true);
         expect(getKey(wrapper)).toBe(0);
         await callWatcher(wrapper, "modelValue", ["1", "2"]);
+        vi.advanceTimersByTime(1);
         expect(getKey(wrapper)).toBe(0);
     });
 });

--- a/src/app/static/src/tests/components/outputTable/newFilterSelect.test.ts
+++ b/src/app/static/src/tests/components/outputTable/newFilterSelect.test.ts
@@ -1,5 +1,5 @@
 import FilterSelect from "../../../app/components/plots/FilterSelect.vue";
-import TreeSelect from "vue3-treeselect";
+import HintTreeSelect from "../../../app/components/HintTreeSelect.vue";
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
@@ -55,7 +55,7 @@ describe("FilterSelect component", () => {
         expect(wrapper.find("span.filter-select").exists()).toBe(false);
     });
 
-    it("renders TreeSelect", () => {
+    it("renders HintTreeSelect", () => {
         const wrapper = mountWithTranslate(FilterSelect, store, {
             global: {
                 plugins: [store]
@@ -69,7 +69,7 @@ describe("FilterSelect component", () => {
                 }
         });
 
-        const treeSelect = wrapper.findComponent(TreeSelect);
+        const treeSelect = wrapper.findComponent(HintTreeSelect);
         expect(treeSelect.props("modelValue")).toBe("2");
         expect(treeSelect.props("disabled")).toBe(false);
         expect(treeSelect.props("options")).toStrictEqual(testOptions);
@@ -81,7 +81,7 @@ describe("FilterSelect component", () => {
         expect(label.classes().indexOf("disabled-label")).toBe(-1);
     });
 
-    it("renders TreeSelect with null value and placeholder if disabled", () => {
+    it("renders HintTreeSelect with null value and placeholder if disabled", () => {
         const wrapper = mountWithTranslate(FilterSelect, store, {
             global: {
                 plugins: [store]
@@ -95,7 +95,7 @@ describe("FilterSelect component", () => {
                 }
         });
 
-        const treeSelect = wrapper.findComponent(TreeSelect);
+        const treeSelect = wrapper.findComponent(HintTreeSelect);
         expect(treeSelect.props("modelValue")).toBeNull();
         expect(treeSelect.props("disabled")).toBe(true);
         expect(treeSelect.props("options")).toStrictEqual(testOptions);
@@ -114,7 +114,7 @@ describe("FilterSelect component", () => {
                 plugins: [store]
             }, props: {label: "label", options: testOptions}
         });
-        await wrapper.findAllComponents(TreeSelect)[0].vm.$emit("update:modelValue", "2");
+        await wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("update:modelValue", "2");
         expect(wrapper.emitted("input")![0][0]).toBe("2");
     });
 
@@ -125,7 +125,7 @@ describe("FilterSelect component", () => {
             },
             props: {label: "label", options: testOptions, disabled: true}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("update:modelValue", "2");
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("update:modelValue", "2");
         expect(wrapper.emitted("input")!).toBeUndefined();
     });
 
@@ -136,10 +136,10 @@ describe("FilterSelect component", () => {
             },
             props: {label: "Label", options: testOptions, multiple: true, value: []}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "1", label: "one"}]);
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
         expect(wrapper.emitted("update:filter-select")![1][0]).toStrictEqual([{id: "1", label: "one"}, {id: "2", label: "two"}]);
     });
 
@@ -150,10 +150,10 @@ describe("FilterSelect component", () => {
             },
             props: {label: "Label", options: testOptions, multiple: false}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "1", label: "one"}]);
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
         expect(wrapper.emitted("update:filter-select")![1][0]).toStrictEqual([{id: "2", label: "two"}]);
     });
 
@@ -165,7 +165,7 @@ describe("FilterSelect component", () => {
             props: {label: "Label", options: testOptions, multiple: true, value: ["1", "2"]}
         });
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("deselect", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("deselect", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "2", label: "two"}]);
     });
 });

--- a/src/app/static/src/tests/components/outputTable/tableData.test.ts
+++ b/src/app/static/src/tests/components/outputTable/tableData.test.ts
@@ -1,9 +1,16 @@
-const mockAddFilteredData = vi.fn();
-const mockDownload = vi.fn();
-const mockExportService = vi.fn().mockReturnValue({
-    addFilteredData: mockAddFilteredData.mockReturnValue({
+const mocks = vi.hoisted(() => {
+    const mockAddFilteredData = vi.fn();
+    const mockDownload = vi.fn();
+    const mockExportService = vi.fn().mockReturnValue({
+        addFilteredData: mockAddFilteredData.mockReturnValue({
+            download: mockDownload
+        })
+    });
+    return {
+        exportService: mockExportService,
+        addFilteredData: mockAddFilteredData,
         download: mockDownload
-    })
+    }
 });
 
 import { shallowMount } from "@vue/test-utils";
@@ -14,7 +21,7 @@ import TableReshapeData from "../../../app/components/outputTable/TableReshapeDa
 import DownloadButton from "../../../app/components/downloadIndicator/DownloadButton.vue";
 
 vi.mock("../../../app/dataExportService", () => {
-    return { exportService: mockExportService };
+    return { exportService: mocks.exportService };
 });
 
 const mockFilters = [
@@ -149,7 +156,7 @@ describe("Output Table display table tests", () => {
         const wrapper = getWrapper("pop", "op1", 2);
         const downloadButton = wrapper.findComponent(DownloadButton);
         downloadButton.vm.$emit("click");
-        expect(mockExportService.mock.calls[0][0].data.filteredData).toStrictEqual([
+        expect(mocks.exportService.mock.calls[0][0].data.filteredData).toStrictEqual([
             {
                 area_level: 2, area_name: "", col_id_filter_1: "op1", id: 3,
                 indicator: "pop", parent_area_id: "", mode: 1, mean: 2, upper: 3,
@@ -157,14 +164,14 @@ describe("Output Table display table tests", () => {
                 formatted_lower: 40
             }
         ]);
-        expect(mockExportService.mock.calls[0][0].filename).toContain("ABC_naomi_table-data_");
-        expect(mockExportService.mock.calls[0][0].options).toStrictEqual({
+        expect(mocks.exportService.mock.calls[0][0].filename).toContain("ABC_naomi_table-data_");
+        expect(mocks.exportService.mock.calls[0][0].options).toStrictEqual({
             header: ["area_id", "area_name", "area_level", "parent_area_id",
                     "indicator", "calendar_quarter", "age_group", "sex",
                     "formatted_mode", "formatted_mean", "formatted_upper",
                     "formatted_lower", "mode", "mean", "upper", "lower"]
         });
-        expect(mockAddFilteredData.mock.calls.length).toBe(1);
-        expect(mockDownload.mock.calls.length).toBe(1);
+        expect(mocks.addFilteredData.mock.calls.length).toBe(1);
+        expect(mocks.download.mock.calls.length).toBe(1);
     });
 });

--- a/src/app/static/src/tests/components/password/resetPassword.test.ts
+++ b/src/app/static/src/tests/components/password/resetPassword.test.ts
@@ -93,7 +93,7 @@ describe("Reset password component", () => {
             "Por favor, solicite outra ligação aqui.",
             store);
         expect((wrapper.find("#request-new-link a").element as HTMLLinkElement).href)
-            .toEqual("http://localhost:3000/password/forgot-password");
+            .toEqual("http://localhost/password/forgot-password");
         expect(wrapper.findAll("#password-was-reset").length).toEqual(0);
     });
 

--- a/src/app/static/src/tests/components/password/resetPassword.test.ts
+++ b/src/app/static/src/tests/components/password/resetPassword.test.ts
@@ -93,7 +93,7 @@ describe("Reset password component", () => {
             "Por favor, solicite outra ligação aqui.",
             store);
         expect((wrapper.find("#request-new-link a").element as HTMLLinkElement).href)
-            .toEqual("http://localhost/password/forgot-password");
+            .toEqual("http://localhost:3000/password/forgot-password");
         expect(wrapper.findAll("#password-was-reset").length).toEqual(0);
     });
 

--- a/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/bubblePlot.test.ts
@@ -17,6 +17,7 @@ import MapEmptyFeature from "../../../../app/components/plots/MapEmptyFeature.vu
 import ResetMap from "../../../../app/components/plots/ResetMap.vue";
 import { mountWithTranslate } from "../../../testHelpers";
 import { nextTick } from "vue";
+import HintTreeSelect from "../../../../app/components/HintTreeSelect.vue";
 
 vi.mock("@vue-leaflet/vue-leaflet", () => {
     const LMap = {
@@ -82,7 +83,7 @@ const getWrapper = (customPropsData: any = {}) => {
 export const expectIndicatorSelect = (wrapper: VueWrapper<any>, divId: string, value: string) => {
     const indDiv = wrapper.find("#" + divId);
     expect(indDiv.classes()[0]).toBe("form-group");
-    const indSelect = indDiv.findComponent(Treeselect);
+    const indSelect = indDiv.findComponent(HintTreeSelect);
     expect(indSelect.props().multiple).toBe(false);
     expect(indSelect.props().clearable).toBe(false);
     expect(indSelect.props().options).toStrictEqual(props.indicators);

--- a/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/bubble/sizeLegend.test.ts
@@ -7,11 +7,15 @@ import MapAdjustScale from "../../../../app/components/plots/MapAdjustScale.vue"
 import {ScaleType} from "../../../../app/store/plottingSelections/plottingSelections";
 import { mountWithTranslate, shallowMountWithTranslate } from "../../../testHelpers";
 
-vi.mock("@vue-leaflet/vue-leaflet", () => {
+vi.mock("@vue-leaflet/vue-leaflet", async () => {
+    const actual = await vi.importActual("@vue-leaflet/vue-leaflet")
     const LControl = {
         template: "<div id='l-control-mock'><slot></slot></div>"
     }
-    return { LControl }
+    return {
+        ...actual,
+        LControl
+    }
 });
 
 const store = new Vuex.Store({

--- a/src/app/static/src/tests/components/plots/filterSelect.test.ts
+++ b/src/app/static/src/tests/components/plots/filterSelect.test.ts
@@ -1,5 +1,5 @@
 import FilterSelect from "../../../app/components/plots/FilterSelect.vue";
-import TreeSelect from "vue3-treeselect";
+import HintTreeSelect from "../../../app/components/HintTreeSelect.vue";
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
@@ -55,7 +55,7 @@ describe("FilterSelect component", () => {
         expect(wrapper.find("span.filter-select").exists()).toBe(false);
     });
 
-    it("renders TreeSelect", () => {
+    it("renders HintTreeSelect", () => {
         const wrapper = mountWithTranslate(FilterSelect, store, {
             global: {
                 plugins: [store]
@@ -69,7 +69,7 @@ describe("FilterSelect component", () => {
                 }
         });
 
-        const treeSelect = wrapper.findComponent(TreeSelect);
+        const treeSelect = wrapper.findComponent(HintTreeSelect);
         expect(treeSelect.props("modelValue")).toBe("2");
         expect(treeSelect.props("disabled")).toBe(false);
         expect(treeSelect.props("options")).toStrictEqual(testOptions);
@@ -81,7 +81,7 @@ describe("FilterSelect component", () => {
         expect(label.classes().indexOf("disabled-label")).toBe(-1);
     });
 
-    it("renders TreeSelect with null value and placeholder if disabled", () => {
+    it("renders HintTreeSelect with null value and placeholder if disabled", () => {
         const wrapper = mountWithTranslate(FilterSelect, store, {
             global: {
                 plugins: [store]
@@ -95,7 +95,7 @@ describe("FilterSelect component", () => {
                 }
         });
 
-        const treeSelect = wrapper.findComponent(TreeSelect);
+        const treeSelect = wrapper.findComponent(HintTreeSelect);
         expect(treeSelect.props("modelValue")).toBeNull();
         expect(treeSelect.props("disabled")).toBe(true);
         expect(treeSelect.props("options")).toStrictEqual(testOptions);
@@ -114,7 +114,7 @@ describe("FilterSelect component", () => {
                 plugins: [store]
             }, props: {label: "label", options: testOptions}
         });
-        await wrapper.findAllComponents(TreeSelect)[0].vm.$emit("update:modelValue", "2");
+        await wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("update:modelValue", "2");
         expect(wrapper.emitted("input")![0][0]).toBe("2");
     });
 
@@ -125,7 +125,7 @@ describe("FilterSelect component", () => {
             },
             props: {label: "label", options: testOptions, disabled: true}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("update:modelValue", "2");
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("update:modelValue", "2");
         expect(wrapper.emitted("input")!).toBeUndefined();
     });
 
@@ -136,10 +136,10 @@ describe("FilterSelect component", () => {
             },
             props: {label: "Label", options: testOptions, multiple: true, value: []}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "1", label: "one"}]);
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
         expect(wrapper.emitted("update:filter-select")![1][0]).toStrictEqual([{id: "1", label: "one"}, {id: "2", label: "two"}]);
     });
 
@@ -150,10 +150,10 @@ describe("FilterSelect component", () => {
             },
             props: {label: "Label", options: testOptions, multiple: false}
         });
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "1", label: "one"}]);
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("select", {id: "2", label: "two"});
         expect(wrapper.emitted("update:filter-select")![1][0]).toStrictEqual([{id: "2", label: "two"}]);
     });
 
@@ -165,7 +165,7 @@ describe("FilterSelect component", () => {
             props: {label: "Label", options: testOptions, multiple: true, value: ["1", "2"]}
         });
 
-        wrapper.findAllComponents(TreeSelect)[0].vm.$emit("deselect", {id: "1", label: "one"});
+        wrapper.findAllComponents(HintTreeSelect)[0].vm.$emit("deselect", {id: "1", label: "one"});
         expect(wrapper.emitted("update:filter-select")![0][0]).toStrictEqual([{id: "2", label: "two"}]);
     });
 });

--- a/src/app/static/src/tests/components/plots/mapControl.test.ts
+++ b/src/app/static/src/tests/components/plots/mapControl.test.ts
@@ -1,6 +1,5 @@
-import {mount, shallowMount} from '@vue/test-utils';
+import {flushPromises, mount, shallowMount} from '@vue/test-utils';
 import MapControl from "../../../app/components/plots/MapControl.vue";
-import Treeselect from "vue3-treeselect";
 import HintTreeSelect from '../../../app/components/HintTreeSelect.vue';
 import Vuex from "vuex";
 import {emptyState} from "../../../app/root";
@@ -12,11 +11,15 @@ const store = new Vuex.Store({
 });
 registerTranslations(store);
 
-vi.mock("@vue-leaflet/vue-leaflet", () => {
+vi.mock("@vue-leaflet/vue-leaflet", async () => {
+    const actual = await vi.importActual("@vue-leaflet/vue-leaflet")
     const LControl = {
         template: "<div id='l-control-mock'><slot></slot></div>"
     }
-    return { LControl }
+    return {
+        ...actual,
+        LControl
+    }
 });
 
 describe("Map control component", () => {
@@ -42,19 +45,19 @@ describe("Map control component", () => {
     it("renders tree selects with expected properties", () => {
         const wrapper = mount(MapControl, {props, global: {plugins: [store]}});
 
-        expect(wrapper.findAllComponents(Treeselect)[0].props("searchable")).toBe(false);
-        expect(wrapper.findAllComponents(Treeselect)[0].props("multiple")).toBe(false);
-        expect(wrapper.findAllComponents(Treeselect)[0].props("clearable")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[0].props("searchable")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[0].props("multiple")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[0].props("clearable")).toBe(false);
 
-        expect(wrapper.findAllComponents(Treeselect)[1].props("searchable")).toBe(false);
-        expect(wrapper.findAllComponents(Treeselect)[1].props("multiple")).toBe(false);
-        expect(wrapper.findAllComponents(Treeselect)[1].props("clearable")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[1].props("searchable")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[1].props("multiple")).toBe(false);
+        expect(wrapper.findAllComponents(HintTreeSelect)[1].props("clearable")).toBe(false);
     });
 
     it("renders indicator options", () => {
         const wrapper = mount(MapControl, {props, global: {plugins: [store]}});
 
-        expect(wrapper.findAllComponents(Treeselect)[0].props("options"))
+        expect(wrapper.findAllComponents(HintTreeSelect)[0].props("options"))
             .toStrictEqual([{id: "art_coverage", label: "ART coverage"},
                 {id: "prevalence", label: "Prevalence"}]);
     });
@@ -62,7 +65,7 @@ describe("Map control component", () => {
     it("renders detail options", () => {
         const wrapper = mount(MapControl, {props, global: {plugins: [store]}});
 
-        expect(wrapper.findAllComponents(Treeselect)[1].props("options"))
+        expect(wrapper.findAllComponents(HintTreeSelect)[1].props("options"))
             .toStrictEqual([{id: 4, label: "Admin Level 4"},
                 {id: 5, label: "Admin Level 5"}]);
     });

--- a/src/app/static/src/tests/components/plots/mapEmptyFeature.test.ts
+++ b/src/app/static/src/tests/components/plots/mapEmptyFeature.test.ts
@@ -4,11 +4,15 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {expectTranslated, mountWithTranslate, shallowMountWithTranslate} from "../../testHelpers";
 import Vuex from "vuex";
 
-vi.mock("@vue-leaflet/vue-leaflet", () => {
+vi.mock("@vue-leaflet/vue-leaflet", async () => {
+    const actual = await vi.importActual("@vue-leaflet/vue-leaflet")
     const LControl = {
         template: "<div id='l-control-mock'><slot></slot></div>"
     }
-    return { LControl }
+    return {
+        ...actual,
+        LControl
+    }
 });
 
 const store = new Vuex.Store({

--- a/src/app/static/src/tests/components/plots/mapLegend.test.ts
+++ b/src/app/static/src/tests/components/plots/mapLegend.test.ts
@@ -1,8 +1,12 @@
-vi.mock("@vue-leaflet/vue-leaflet", () => {
+vi.mock("@vue-leaflet/vue-leaflet", async () => {
+    const actual = await vi.importActual("@vue-leaflet/vue-leaflet")
     const LControl = {
         template: "<div id='l-control-mock'><slot></slot></div>"
     }
-    return { LControl }
+    return {
+        ...actual,
+        LControl
+    }
 });
 
 import {DOMWrapper} from '@vue/test-utils';

--- a/src/app/static/src/tests/components/plots/resetMap.test.ts
+++ b/src/app/static/src/tests/components/plots/resetMap.test.ts
@@ -4,11 +4,15 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {expectTranslated, mountWithTranslate} from "../../testHelpers";
 import Vuex from "vuex";
 
-vi.mock("@vue-leaflet/vue-leaflet", () => {
+vi.mock("@vue-leaflet/vue-leaflet", async () => {
+    const actual = await vi.importActual("@vue-leaflet/vue-leaflet")
     const LControl = {
         template: "<div id='l-control-mock'><slot></slot></div>"
     }
-    return { LControl }
+    return {
+        ...actual,
+        LControl
+    }
 });
 
 const store = new Vuex.Store({

--- a/src/app/static/src/tests/components/projects/projectHistory.test.ts
+++ b/src/app/static/src/tests/components/projects/projectHistory.test.ts
@@ -325,8 +325,7 @@ describe("Project history component", () => {
         expect(chevRight.isVisible()).toBe(true);
         expect(chevDown.isVisible()).toBe(false);
         await button.trigger("click");
-        await flushPromises();
-        expect(versionMenu.classes()).toStrictEqual(["collapse", "show"])
+        expect(versionMenu.classes()).toStrictEqual(["collapse", "show", "collapsing"])
         expect(chevRight.isVisible()).toBe(false);
         expect(chevDown.isVisible()).toBe(true);
     });
@@ -344,7 +343,7 @@ describe("Project history component", () => {
         await flushPromises();
         expect(chevRight.isVisible()).toBe(false);
         expect(chevDown.isVisible()).toBe(true);
-        expect(versionMenu.classes()).toStrictEqual(["collapse", "show"])
+        expect(versionMenu.classes()).toStrictEqual(["collapse", "show", "collapsing"])
         await button.trigger("click");
         await new Promise((r) => setTimeout(r, 200))
         expect(chevRight.isVisible()).toBe(true);

--- a/src/app/static/src/tests/components/projects/shareProject.test.ts
+++ b/src/app/static/src/tests/components/projects/shareProject.test.ts
@@ -1,4 +1,4 @@
-import {mount, shallowMount} from "@vue/test-utils";
+import {flushPromises, mount, shallowMount} from "@vue/test-utils";
 import ShareProject from "../../../app/components/projects/ShareProject.vue";
 import Modal from "../../../app/components/Modal.vue";
 import Vuex from "vuex";
@@ -286,6 +286,8 @@ describe("ShareProject", () => {
         await input.setValue("goodemail");
         await input.trigger("blur");
 
+        await flushPromises();
+
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("input").classes()).not.toContain("is-invalid");
         expect(modal.find(".text-danger").exists()).toBe(false);
@@ -309,6 +311,8 @@ describe("ShareProject", () => {
         const input = wrapper.findComponent(Modal).find("input");
         await input.setValue("GOODEMAIL");
         await input.trigger("blur");
+
+        await flushPromises();
 
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("input").classes()).not.toContain("is-invalid");
@@ -442,7 +446,7 @@ describe("ShareProject", () => {
             expect(inputs.length).toBe(1);
             await inputs[0].setValue("testing");
             await inputs[0].trigger("blur");
-
+            await flushPromises();
             expect(wrapper.findComponent(Modal).findAll("input").length).toBe(2);
             expect(wrapper.findComponent(Modal).find(".help-text").isVisible()).toBe(true);
 
@@ -528,7 +532,7 @@ describe("ShareProject", () => {
         const input = wrapper.findComponent(Modal).find("input");
         await input.setValue("testing");
         await input.trigger("blur");
-
+        await flushPromises();
         await wrapper.findComponent(Modal).find("button").trigger("click");
         expect(cloneProject.mock.calls[0][1]).toEqual({projectId: 1, emails: ["testing"]});
     });

--- a/src/app/static/src/tests/components/reviewInputs/reviewInputs.test.ts
+++ b/src/app/static/src/tests/components/reviewInputs/reviewInputs.test.ts
@@ -24,7 +24,6 @@ import Choropleth from "../../../app/components/plots/choropleth/Choropleth.vue"
 import AreaIndicatorsTable from "../../../app/components/plots/table/AreaIndicatorsTable.vue";
 import { nextTick } from 'vue';
 import Filters from '../../../app/components/plots/Filters.vue';
-import Treeselect from "vue3-treeselect";
 import HintTreeSelect from '../../../app/components/HintTreeSelect.vue';
 
 describe("Survey and programme component", () => {
@@ -326,17 +325,17 @@ describe("Survey and programme component", () => {
                 stubs: ["filters", "l-map", "area-indicators-table", "generic-chart"]
             }, data
         });
-        let options = wrapper.findComponent(Treeselect).props("options");
+        let options = wrapper.findComponent(HintTreeSelect).props("options");
         expect(options).toStrictEqual([{id, label: englishName}]);
 
         store.state.language = Language.fr;
         await nextTick();
-        options = wrapper.findComponent(Treeselect).props("options");
+        options = wrapper.findComponent(HintTreeSelect).props("options");
         expect(options).toStrictEqual([{id, label:frenchName}]);
 
         store.state.language = Language.pt;
         await nextTick();
-        options = wrapper.findComponent(Treeselect).props("options");
+        options = wrapper.findComponent(HintTreeSelect).props("options");
         expect(options).toStrictEqual([{id, label:portugueseName}]);
     }
 

--- a/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
+++ b/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
@@ -21,7 +21,7 @@ import {expectTranslatedWithStoreType, mountWithTranslate, shallowMountWithTrans
 import {SurveyAndProgramActions} from "../../../app/store/surveyAndProgram/actions";
 import {getters} from "../../../app/store/surveyAndProgram/getters";
 import {DataType, SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
-import {testUploadComponent} from "./fileUploads.";
+import {testUploadComponent} from "./fileUploads";
 import {RootState} from "../../../app/root";
 import { MockInstance, Mocked } from 'vitest';
 import { flushPromises } from '@vue/test-utils';

--- a/src/app/static/src/tests/projects/mutations.test.ts
+++ b/src/app/static/src/tests/projects/mutations.test.ts
@@ -7,7 +7,7 @@ describe("Projects mutations", () => {
     const testNow = Date.now();
 
     beforeAll(() => {
-        vi.useFakeTimers('modern');
+        vi.useFakeTimers();
         vi.setSystemTime(testNow);
     });
 

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -40,13 +40,17 @@ console.error = vi.fn();
 // Mock the components before we import the rooter as the app will call these components
 // on import of the router
 vi.mock("../app/components/Stepper.vue", () => ({
-    name: "Stepper",
-    template: "<div id='stepper-stub'/>"
+    default: {
+        name: "Stepper",
+        template: "<div id='stepper-stub'/>"
+    }
 }))
 
 vi.mock("../app/components/projects/Projects.vue", () => ({
-    name: "Projects",
-    template: "<div id='projects-stub'/>"
+    default: {
+        name: "Projects",
+        template: "<div id='projects-stub'/>"
+    }
 }))
 
 import {router, beforeEnter} from '../app/router';

--- a/src/app/static/vitest.config.ts
+++ b/src/app/static/vitest.config.ts
@@ -10,9 +10,6 @@ export default defineConfig({
     setupFiles: [
       './src/tests/setup.ts'
     ],
-    environmentOptions: {
-      url: 'http://localhost'
-    },
     coverage: {
       provider: "v8",
       reportsDirectory: "coverage",

--- a/src/app/static/vitest.config.ts
+++ b/src/app/static/vitest.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
         './tests/.*/helpers.ts',
       ],
     },
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost"
+      }
+    }
   },
-  plugins: [vue()]
+  plugins: [vue()],
 });


### PR DESCRIPTION
## Description

This PR is a little messy, random misc changes:
* more vi.mocks because it is different from jest.mock (mainly mocking leaflet)
* add disabled, clearable, placeholder and searchable props to hint tree select because before we were testing the base treeselect as the properties were being passed on automatically in the component, but vitest doesnt seem to detect the base treeselect hence added those props to hint tree select to make it testable
* bootstrap expanding and collapsing rows in projects page was being slow, taking 1s in tests so just testing that the bootstrap animation has begun
* I have no idea what is going on with reset password localhost url, there is a comment i left about it

We are almost there actually, all front end tests work, just need to add in all the other configs like integration tests, etc
