### PR TITLE
change from default plot setting to default effect

### DIFF
--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -148,11 +148,17 @@ export interface CalibrateMetadataResponse {
   }[];
   plotSettingsControl: {
     choropleth: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;
@@ -174,11 +180,17 @@ export interface CalibrateMetadataResponse {
       }[];
     };
     barchart: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;
@@ -200,11 +212,17 @@ export interface CalibrateMetadataResponse {
       }[];
     };
     table: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;
@@ -226,11 +244,17 @@ export interface CalibrateMetadataResponse {
       }[];
     };
     bubble: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;
@@ -1276,11 +1300,17 @@ export interface PlotSettingOption {
   };
 }
 export interface PlotSettingsControl {
-  defaultFilterTypes?: {
-    filterId: string;
-    label: string;
-    stateFilterId: string;
-  }[];
+  defaultEffect?: {
+    setFilters?: {
+      filterId: string;
+      label: string;
+      stateFilterId: string;
+    }[];
+    setMultiple?: string[];
+    setFilterValues?: {
+      [k: string]: string[];
+    };
+  };
   plotSettings: {
     id: string;
     label: string;
@@ -1616,11 +1646,17 @@ export interface ReviewInputFilterMetadataResponse {
   }[];
   plotSettingsControl: {
     timeSeries: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;
@@ -1642,11 +1678,17 @@ export interface ReviewInputFilterMetadataResponse {
       }[];
     };
     inputChoropleth: {
-      defaultFilterTypes?: {
-        filterId: string;
-        label: string;
-        stateFilterId: string;
-      }[];
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
       plotSettings: {
         id: string;
         label: string;

--- a/src/app/static/src/app/store/plotSelections/actions.ts
+++ b/src/app/static/src/app/store/plotSelections/actions.ts
@@ -2,9 +2,9 @@ import { ActionContext, ActionTree, Commit } from "vuex"
 import { OutputPlotName, PlotDataType, PlotName, PlotSelectionsState, plotNameToDataType } from "./plotSelections"
 import { RootState } from "../../root"
 import { GenericChartDataset, PayloadWithType } from "../../types"
-import { CalibrateDataResponse, FilterOption, InputTimeSeriesData, InputTimeSeriesRow, PlotSettingOption } from "../../generated"
+import { CalibrateDataResponse, FilterOption, InputTimeSeriesData, InputTimeSeriesRow, PlotSettingEffect, PlotSettingOption } from "../../generated"
 import { PlotSelectionUpdate, PlotSelectionsMutations } from "./mutations"
-import { filtersInfoFromPlotSettings, getPlotData } from "./utils"
+import { filtersInfoFromEffects, getPlotData } from "./utils"
 import { api } from "../../apiService"
 import { PlotDataMutations, PlotDataUpdate } from "../plotData/mutations"
 import { PlotMetadataFrame } from "../metadata/metadata"
@@ -46,13 +46,16 @@ export const actions: ActionTree<PlotSelectionsState, RootState> & PlotSelection
             const fIndex = updatedSelections.filters.findIndex(f => f.stateFilterId === selection.filter.id);
             updatedSelections.filters[fIndex].selection = selection.filter.options;
         } else {
+            const plotMetadata = metadata.plotSettingsControl[plot];
             const pIndex = updatedSelections.controls.findIndex(p => p.id === selection.plotSetting.id);
             updatedSelections.controls[pIndex].selection = selection.plotSetting.options;
             const plotSettingOptions: PlotSettingOption[] = updatedSelections.controls.map(c => {
-                const plotSetting = metadata.plotSettingsControl[plot].plotSettings.find(ps => ps.id === c.id);
+                const plotSetting = plotMetadata.plotSettings.find(ps => ps.id === c.id);
                 return plotSetting!.options.find(op => op.id === c.selection[0].id)!;
             });
-            const filtersInfo = filtersInfoFromPlotSettings(plotSettingOptions, plot, rootState, metadata);
+            const effects: PlotSettingEffect[] = plotMetadata.defaultEffect ? [plotMetadata.defaultEffect] : [];
+            plotSettingOptions.forEach(pso => effects.push(pso.effect));
+            const filtersInfo = filtersInfoFromEffects(effects, rootState, metadata);
             updatedSelections.filters = filtersInfo;
         }
 


### PR DESCRIPTION
## Description

Instead of relying on the default plot control and `defaultFilterTypes` props, we now have a new property called `defaultEffect` and this will contain any effect you want to occur for all plot settings in a given plot

Note: If you would like to see how the metadata changes, see the description here: https://github.com/mrc-ide/hintr/pull/493, I am keeping the description up to date