### PR TITLE
mrc-5305: Fix issue with projects not reloading properly because of setTimeout interval issue

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.7.2";
+export const currentHintVersion = "3.7.3";

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -91,7 +91,7 @@ const persistState = (store: Store<RootState>): void => {
         const {dispatch} = store;
         const type = stripNamespace(mutation.type);
         if (type[0] !== "projects" && type[0] !== "errors") {
-            dispatch("projects/queueVersionStateUpload", {root: true});
+            dispatch("projects/queueVersionStateUpload", null, {root: true});
         }
     })
 };


### PR DESCRIPTION
## Description

We updated this for testing but that highlighted a problem where we were passing some options as a payload :see_no_evil: this was causing issues with project reloading as state was being overwritten because the setTimeout poll interval was being set very low. This fixes that.

I had a look elsewhere for other instances of the new `interval = null` but I can't see any which are setting any options in the `dispatch` call.

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
