### PR TITLE
mrc-5284: Add comparison plot back in

### DIFF
--- a/src/app/static/src/app/components/modelOutput/ModelOutput.vue
+++ b/src/app/static/src/app/components/modelOutput/ModelOutput.vue
@@ -19,6 +19,9 @@
             <barchart class="col-md-9" v-if="selectedPlot === 'barchart'"
                       :plot="selectedPlot"
                       :show-error-bars="true"/>
+            <barchart class="col-md-9" v-if="selectedPlot === 'comparison'"
+                      :plot="selectedPlot"
+                      :show-error-bars="true"/>
         </div>
     </div>
 </template>
@@ -27,7 +30,7 @@
 import {computed, defineComponent} from "vue";
 import FilterSet from "../plots/FilterSet.vue";
 import PlotControlSet from "../plots/PlotControlSet.vue";
-import {OutputPlotName, outputPlotNames, PlotName} from "../../store/plotSelections/plotSelections";
+import {OutputPlotName, outputPlotNames} from "../../store/plotSelections/plotSelections";
 import {useStore} from "vuex";
 import {RootState} from "../../root";
 import { ModelOutputMutation } from "../../store/modelOutput/mutations";

--- a/src/app/static/src/app/components/plots/Filter.vue
+++ b/src/app/static/src/app/components/plots/Filter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :key="filter.filterId">
+    <div :key="`${plot}.${filter.filterId}`">
         <multi-select v-if="filter.multiple"
                       :options="options"
                       :model-value="selected"

--- a/src/app/static/src/app/components/plots/PlotControl.vue
+++ b/src/app/static/src/app/components/plots/PlotControl.vue
@@ -1,13 +1,15 @@
 <template>
-    <single-select :options="controlOptions"
+    <div :key="`${plot}.${plotControlId}`">
+        <single-select :options="controlOptions"
                    :model-value="selected"
                    :placeholder="placeholder"
                    @update:model-value="updateControlSelection"/>
+    </div>
 </template>
 
 <script lang="ts">
 import { SingleSelect } from "@reside-ic/vue-nested-multiselect";
-import {computed, defineComponent, PropType, ref} from 'vue';
+import {computed, defineComponent, PropType} from 'vue';
 import i18next from "i18next";
 import {useStore} from "vuex";
 import {RootState} from "../../root";
@@ -32,11 +34,11 @@ export default defineComponent({
         const controlOptions = computed(() => {
             const metadata = getMetadataFromPlotName(store.state, props.plot);
             return metadata.plotSettingsControl[props.plot].plotSettings
-                .find(f => f.id === props.plotControlId)!.options;
+                .find(f => f.id === props.plotControlId)!.options
         });
 
         const selected = computed(() => {
-            const controls =  store.state.plotSelections[props.plot].controls
+            const controls = store.state.plotSelections[props.plot].controls
             return controls.find(control => control.id == props.plotControlId)!.selection[0]?.id;
         });
 

--- a/src/app/static/src/app/components/plots/PlotControlSet.vue
+++ b/src/app/static/src/app/components/plots/PlotControlSet.vue
@@ -1,8 +1,9 @@
 <template>
-
     <div class="form-group" v-for="control of plotControls" :key="control.id">
-        <label class="font-weight-bold">{{control.label}}</label>
-        <plot-control :plot-control-id="control.id" :plot="plot"/>
+        <div v-if="!isHidden(control.id)">
+            <label class="font-weight-bold">{{control.label}}</label>
+            <plot-control :plot-control-id="control.id" :plot="plot"/>
+        </div>
     </div>
     <hr v-if="plotControls.length > 0" class="mt-1 mb-2"/>
 
@@ -14,6 +15,7 @@ import {useStore} from "vuex";
 import {RootState} from "../../root";
 import PlotControl from "./PlotControl.vue";
 import {PlotName} from "../../store/plotSelections/plotSelections";
+import {getMetadataFromPlotName} from "../../store/plotSelections/actions";
 
 export default defineComponent({
     components: {
@@ -31,8 +33,14 @@ export default defineComponent({
             return store.state.plotSelections[props.plot].controls;
         });
 
+        const isHidden = computed(() => (controlId: string) => {
+            const metadata = getMetadataFromPlotName(store.state, props.plot);
+            return metadata.plotSettingsControl[props.plot].plotSettings.find(c => c.id === controlId)!.hidden;
+        });
+
         return {
-            plotControls
+            plotControls,
+            isHidden
         }
     }
 })

--- a/src/app/static/src/app/components/plots/PlotControlSet.vue
+++ b/src/app/static/src/app/components/plots/PlotControlSet.vue
@@ -33,10 +33,11 @@ export default defineComponent({
             return store.state.plotSelections[props.plot].controls;
         });
 
-        const isHidden = computed(() => (controlId: string) => {
-            const metadata = getMetadataFromPlotName(store.state, props.plot);
-            return metadata.plotSettingsControl[props.plot].plotSettings.find(c => c.id === controlId)!.hidden;
-        });
+        const plotMetadata = computed(() => getMetadataFromPlotName(store.state, props.plot));
+
+        const isHidden = (controlId: string) => {
+            return plotMetadata.value.plotSettingsControl[props.plot].plotSettings.find(c => c.id === controlId)!.hidden;
+        };
 
         return {
             plotControls,

--- a/src/app/static/src/app/components/plots/bar/Barchart.vue
+++ b/src/app/static/src/app/components/plots/bar/Barchart.vue
@@ -54,7 +54,6 @@ export default defineComponent({
             return store.state.plotData[props.plot]
         });
 
-
         const chartDataGetter = store.getters["plotSelections/barchartData"];
         const chartData = ref<BarChartData>({datasets:[], labels: [], maxValuePlusError: 0});
         const chartOptions = ref({});

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -650,6 +650,7 @@ export interface ComparisonBarchartMetadata {
 export type ComparisonPlotData = {
   area_id: string;
   area_name: string;
+  area_level?: number;
   sex: string;
   age_group: string;
   calendar_quarter: string;
@@ -660,10 +661,77 @@ export type ComparisonPlotData = {
   upper: number | null;
   [k: string]: any;
 }[];
+export interface ComparisonPlotMetadata {
+  filterTypes: {
+    id: string;
+    column_id: string;
+    options: {
+      label: string;
+      id: string;
+      description?: string;
+    }[];
+    use_shape_regions?: boolean;
+    visible?: boolean;
+  }[];
+  indicators: {
+    indicator: string;
+    value_column: string;
+    error_low_column?: string;
+    error_high_column?: string;
+    indicator_column?: string;
+    indicator_value?: string;
+    indicator_sort_order?: number;
+    name: string;
+    min: number;
+    max: number;
+    colour: string;
+    invert_scale: boolean;
+    scale: number;
+    accuracy: number | null;
+    format: string;
+  }[];
+  plotSettingsControl: {
+    comparison: {
+      defaultEffect?: {
+        setFilters?: {
+          filterId: string;
+          label: string;
+          stateFilterId: string;
+        }[];
+        setMultiple?: string[];
+        setFilterValues?: {
+          [k: string]: string[];
+        };
+      };
+      plotSettings: {
+        id: string;
+        label: string;
+        options: {
+          id: string;
+          label: string;
+          effect: {
+            setFilters?: {
+              filterId: string;
+              label: string;
+              stateFilterId: string;
+            }[];
+            setMultiple?: string[];
+            setFilterValues?: {
+              [k: string]: string[];
+            };
+          };
+        }[];
+        visible?: boolean;
+      }[];
+    };
+  };
+  [k: string]: any;
+}
 export interface ComparisonPlotResponse {
   data: {
     area_id: string;
     area_name: string;
+    area_level?: number;
     sex: string;
     age_group: string;
     calendar_quarter: string;
@@ -674,54 +742,77 @@ export interface ComparisonPlotResponse {
     upper: number | null;
     [k: string]: any;
   }[];
-  plottingMetadata: {
-    barchart: {
-      indicators: {
-        indicator: string;
-        value_column: string;
-        indicator_column: string;
-        indicator_value: string;
-        indicator_sort_order?: number;
-        name: string;
-        error_low_column: string;
-        error_high_column: string;
-        scale: number;
-        accuracy: number | null;
-        format: string;
-      }[];
-      filters: {
-        id: string;
-        column_id: string;
+  metadata: {
+    filterTypes: {
+      id: string;
+      column_id: string;
+      options: {
         label: string;
-        options: {
-          label: string;
+        id: string;
+        description?: string;
+      }[];
+      use_shape_regions?: boolean;
+      visible?: boolean;
+    }[];
+    indicators: {
+      indicator: string;
+      value_column: string;
+      error_low_column?: string;
+      error_high_column?: string;
+      indicator_column?: string;
+      indicator_value?: string;
+      indicator_sort_order?: number;
+      name: string;
+      min: number;
+      max: number;
+      colour: string;
+      invert_scale: boolean;
+      scale: number;
+      accuracy: number | null;
+      format: string;
+    }[];
+    plotSettingsControl: {
+      comparison: {
+        defaultEffect?: {
+          setFilters?: {
+            filterId: string;
+            label: string;
+            stateFilterId: string;
+          }[];
+          setMultiple?: string[];
+          setFilterValues?: {
+            [k: string]: string[];
+          };
+        };
+        plotSettings: {
           id: string;
-          description?: string;
+          label: string;
+          options: {
+            id: string;
+            label: string;
+            effect: {
+              setFilters?: {
+                filterId: string;
+                label: string;
+                stateFilterId: string;
+              }[];
+              setMultiple?: string[];
+              setFilterValues?: {
+                [k: string]: string[];
+              };
+            };
+          }[];
+          visible?: boolean;
         }[];
-        use_shape_regions?: boolean | null;
-      }[];
-      defaults: {
-        indicator_id: string;
-        x_axis_id: string;
-        disaggregate_by_id: string;
-        selected_filter_options: {
-          [k: string]: any;
-        };
       };
-      selections: {
-        indicator_id: string;
-        x_axis_id: string;
-        disaggregate_by_id: string;
-        selected_filter_options: {
-          [k: string]: any;
-        };
-      }[];
     };
+    [k: string]: any;
   };
 }
 export interface ComparisonPlotRow {
   area_id: string;
   area_name: string;
+  area_level?: number;
   sex: string;
   age_group: string;
   calendar_quarter: string;

--- a/src/app/static/src/app/store/modelOutput/modelOutput.ts
+++ b/src/app/static/src/app/store/modelOutput/modelOutput.ts
@@ -1,11 +1,8 @@
 import {Module} from "vuex";
 import {RootState} from "../../root";
-import {BarchartIndicator, DisplayFilter, Filter, ModelOutputTabs} from "../../types";
-import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
+import {ModelOutputTabs} from "../../types";
 import {mutations} from "./mutations";
 import {actions} from "./actions";
-import {rootOptionChildren} from "../../utils";
-import {UnadjustedBarchartSelections} from "../plottingSelections/plottingSelections";
 import {OutputPlotName, outputPlotNames} from "../plotSelections/plotSelections";
 
 const namespaced = true;
@@ -16,101 +13,6 @@ export interface ModelOutputState {
         [k in ModelOutputTabs]: boolean
     }
 }
-
-export const modelOutputGetters = {
-    barchartIndicators: (state: ModelOutputState, getters: any, rootState: RootState): BarchartIndicator[] => {
-        return rootState.modelCalibrate.metadata!.plottingMetadata.barchart.indicators;
-    },
-    comparisonPlotIndicators: (state: ModelOutputState, getters: any, rootState: RootState): BarchartIndicator[] => {
-        return rootState.modelCalibrate.comparisonPlotResult?.plottingMetadata.barchart.indicators || [];
-    },
-    comparisonPlotDefaultSelections: (state: ModelOutputState, getters: any, rootState: RootState): UnadjustedBarchartSelections[] => {
-        return rootState.modelCalibrate.comparisonPlotResult?.plottingMetadata.barchart.selections || [];
-    },
-    barchartFilters: (state: ModelOutputState, getters: any, rootState: RootState): Filter[] => {
-        return outputPlotFilters(rootState);
-    },
-    comparisonPlotFilters: (state: ModelOutputState, getters: any, rootState: RootState): Filter[] => {
-        return outputPlotFilters(rootState, "comparisonPlotResult");
-    },
-    bubblePlotIndicators: (state: ModelOutputState, getters: any, rootState: RootState): ChoroplethIndicatorMetadata[] => {
-        return rootState.modelCalibrate.metadata!.plottingMetadata.choropleth.indicators;
-    },
-    bubblePlotFilters: (state: ModelOutputState, getters: any, rootState: RootState): Filter[] => {
-        return outputPlotFilters(rootState);
-    },
-    choroplethIndicators: (state: ModelOutputState, getters: any, rootState: RootState): ChoroplethIndicatorMetadata[] => {
-        return rootState.modelCalibrate.metadata!.plottingMetadata.choropleth.indicators;
-    },
-    choroplethFilters: (state: ModelOutputState, getters: any, rootState: RootState, rootGetters: any): DisplayFilter[] => {
-        const outputFilters = outputPlotFilters(rootState) as Filter[];
-        const areaId = "area";
-        return outputFilters.map(f => {
-            return {
-                ...f,
-                allowMultiple: f.id == areaId,
-                options: f.id == areaId ? rootOptionChildren(f.options) : f.options
-            }
-        });
-    },
-    tableFilters: (state: ModelOutputState, getters: any, rootState: RootState, rootGetters: any): DisplayFilter[] => {
-        const outputFilters = outputPlotFilters(rootState, "table") as DisplayFilter[];
-        const currentPresetMetadata = getPresetMetadata(rootState);
-        if (currentPresetMetadata) {
-            return outputFilters.map(f => {
-                return {
-                    ...f,
-                    allowMultiple: f.column_id === currentPresetMetadata.defaults.row.id || f.column_id === currentPresetMetadata.defaults.column.id
-                }
-            });
-        } else {
-            return []
-        }
-    },
-    countryAreaFilterOption: (state: ModelOutputState, getters: any, rootState: RootState, rootGetters: any): FilterOption => {
-        const outputFilters = outputPlotFilters(rootState) as Filter[];
-        return outputFilters[0].options[0]
-    }
-};
-
-const getPresetMetadata = (rootState: RootState) => {
-    const currentPreset = rootState.plottingSelections.table.preset;
-    const presetMetadata = rootState.modelCalibrate.metadata?.tableMetadata.presets;
-    const currentPresetMetadata = presetMetadata?.find((p: any) => p.defaults.id === currentPreset);
-    if (currentPreset && presetMetadata && currentPresetMetadata) {
-        return currentPresetMetadata;
-    }
-    return null;
-};
-
-const outputPlotFilters = (rootState: RootState, resultName: "metadata" | "comparisonPlotResult" | "table" = "metadata") => {
-    let filters: any[];
-    if (resultName === "table") {
-        const currentPresetMetadata = getPresetMetadata(rootState);
-        if (currentPresetMetadata) {
-            filters = [...(currentPresetMetadata?.filters || [])];
-        } else {
-            filters = [];
-        }
-    } else {
-        filters = [...(rootState.modelCalibrate[resultName]?.plottingMetadata?.barchart.filters || [])];
-    }
-    const area = filters.find((f: any) => f.id == "area");
-    if (area && area.use_shape_regions) {
-        const regions: FilterOption[] = rootState.baseline.shape!.filters!.regions ?
-            [rootState.baseline.shape!.filters!.regions] : [];
-
-        //remove old, frozen area filter, add new one with regions from shape
-        filters = [
-            {...area, options: regions},
-            ...filters.filter((f: any) => f.id != "area")
-        ];
-    }
-
-    return [
-        ...filters
-    ];
-};
 
 export const initialModelOutputState = (): ModelOutputState => {
     return {
@@ -129,7 +31,6 @@ export const modelOutput = (existingState: Partial<RootState> | null): Module<Mo
     return {
         namespaced,
         state: {...initialModelOutputState(), ...existingState && existingState.modelOutput},
-        getters: modelOutputGetters,
         mutations,
         actions
     };

--- a/src/app/static/src/app/store/plotData/plotData.ts
+++ b/src/app/static/src/app/store/plotData/plotData.ts
@@ -1,8 +1,14 @@
-import {CalibrateDataResponse, CalibratePlotData, InputTimeSeriesData, InputTimeSeriesRow} from "../../generated"
+import {
+    CalibrateDataResponse,
+    CalibratePlotData,
+    ComparisonPlotData,
+    InputTimeSeriesData,
+    InputTimeSeriesRow
+} from "../../generated"
 import { PlotName, plotNames } from "../plotSelections/plotSelections"
 import { mutations } from "./mutations"
 
-export type PlotData = CalibrateDataResponse["data"] | InputTimeSeriesData | CalibratePlotData;
+export type PlotData = CalibrateDataResponse["data"] | InputTimeSeriesData | CalibratePlotData | ComparisonPlotData;
 export type InputTimeSeriesKey = keyof InputTimeSeriesRow;
 export type PlotDataState = {
     [P in PlotName]: PlotData

--- a/src/app/static/src/app/store/plotSelections/getters.ts
+++ b/src/app/static/src/app/store/plotSelections/getters.ts
@@ -1,5 +1,5 @@
 import {ControlSelection, FilterSelection, PlotName, PlotSelectionsState} from "./plotSelections";
-import {CalibratePlotRow, ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
+import {ChoroplethIndicatorMetadata, FilterOption} from "../../generated";
 import {BarChartData, plotDataToChartData} from "../../components/plots/bar/utils";
 import {RootState} from "../../root";
 import {PlotData} from "../plotData/plotData";
@@ -37,7 +37,7 @@ export const getters = {
         // can just keep these as empty.
         let areaIdToLevelMap = {} as Dict<number>;
         let areaLevel = null;
-        if (plotName == "barchart") {
+        if (plotName === "barchart" || plotName === "comparison") {
             areaIdToLevelMap = rootGetters["baseline/areaIdToLevelMap"];
             areaLevel = filterSelections.find(f => f.filterId == "detail")?.selection[0]?.id;
         }

--- a/src/app/static/src/app/store/plotSelections/plotSelections.ts
+++ b/src/app/static/src/app/store/plotSelections/plotSelections.ts
@@ -1,6 +1,6 @@
 import {
     CalibrateMetadataResponse,
-    CalibratePlotResponse,
+    CalibratePlotResponse, ComparisonPlotResponse,
     Error,
     FilterOption,
     FilterRef,
@@ -10,18 +10,19 @@ import { mutations } from "./mutations";
 import { actions } from "./actions";
 import { getters } from "./getters";
 
-export type OutputPlotName = keyof CalibrateMetadataResponse["plotSettingsControl"]
+export type OutputPlotName = keyof CalibrateMetadataResponse["plotSettingsControl"] |
+    keyof ComparisonPlotResponse["metadata"]["plotSettingsControl"]
 export type InputPlotName = keyof ReviewInputFilterMetadataResponse["plotSettingsControl"]
 export type CalibratePlotName = keyof CalibratePlotResponse["metadata"]["plotSettingsControl"]
 
-export const outputPlotNames: OutputPlotName[] = ["barchart", "bubble", "choropleth", "table"];
+export const outputPlotNames: OutputPlotName[] = ["choropleth", "barchart", "table", "comparison", "bubble"];
 export const inputPlotNames: InputPlotName[] = ["timeSeries", "inputChoropleth"];
 export const calibratePlotName: CalibratePlotName = "calibrate";
 
 export type PlotName = OutputPlotName | InputPlotName | CalibratePlotName
 export const plotNames = [...outputPlotNames, ...inputPlotNames, calibratePlotName];
 
-export enum PlotDataType { Output, TimeSeries, Input, Calibrate}
+export enum PlotDataType { Output, TimeSeries, Input, Calibrate, Comparison}
 
 export const plotNameToDataType: Record<PlotName, PlotDataType> = {
     barchart: PlotDataType.Output,
@@ -31,6 +32,7 @@ export const plotNameToDataType: Record<PlotName, PlotDataType> = {
     timeSeries: PlotDataType.TimeSeries,
     inputChoropleth: PlotDataType.Input,
     calibrate: PlotDataType.Calibrate,
+    comparison: PlotDataType.Comparison
 }
 
 export type FilterSelection = {

--- a/src/app/static/src/app/store/plotSelections/utils.ts
+++ b/src/app/static/src/app/store/plotSelections/utils.ts
@@ -1,7 +1,11 @@
-import { OutputPlotName, PlotDataType, PlotName, outputPlotNames, plotNameToDataType } from "./plotSelections";
+import { OutputPlotName, PlotDataType, PlotName, plotNameToDataType } from "./plotSelections";
 import { PlotSelectionUpdate, PlotSelectionsMutations } from "./mutations";
 import { RootState } from "../../root";
-import {getCalibrateFilteredDataset, getFilteredData, getTimeSeriesFilteredDataset} from "./actions";
+import {
+    getCalibrateFilteredDataset,
+    getComparisonFilteredDataset,
+    getFilteredData,
+    getTimeSeriesFilteredDataset} from "./actions";
 import { PlotMetadataFrame } from "../metadata/metadata";
 import { Commit } from "vuex";
 import {
@@ -9,6 +13,7 @@ import {
     FilterTypes,
     PlotSettingEffect,
 } from "../../generated";
+
 
 export const filtersAfterUseShapeRegions = (filterTypes: FilterTypes[], rootState: RootState) => {
     const filters = [...filterTypes];
@@ -113,6 +118,8 @@ export const getPlotData = async (payload: PlotSelectionUpdate, commit: Commit, 
         await getTimeSeriesFilteredDataset(payload, commit, rootState);
     } else if (plotDataType === PlotDataType.Calibrate) {
         await getCalibrateFilteredDataset(payload, commit, rootState);
+    } else if (plotDataType === PlotDataType.Comparison) {
+        await getComparisonFilteredDataset(payload, commit, rootState);
     }
 }
 

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -473,14 +473,6 @@ export const mockCalibratePlotResponse = (props: Partial<CalibratePlotResponse> 
 
 export const mockComparisonPlotResponse = (props: Partial<ComparisonPlotResponse> = {}): ComparisonPlotResponse => {
     return {
-        plottingMetadata: {
-            barchart: {
-                indicators: [],
-                filters: [],
-                defaults: {} as any,
-                selections: []
-            }
-        },
         data: [{
             area_id: "MWI",
             area_name: "Test area",
@@ -495,6 +487,21 @@ export const mockComparisonPlotResponse = (props: Partial<ComparisonPlotResponse
             mode: 0.5,
             upper: 0.5
         }],
+        metadata: {
+            filterTypes: [],
+            indicators: [],
+            plotSettingsControl: {
+                comparison: {
+                    plotSettings: [
+                        {
+                            id: "1",
+                            label: "setting",
+                            options: []
+                        }
+                    ]
+                }
+            }
+        },
         ...props
     }
 };

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-new-calibrate-metadata
+comparison-metadata


### PR DESCRIPTION
## Description

Follows the same pattern as #965 
This PR adds the comparison plot back in. See the new metadata here https://github.com/mrc-ide/hintr/pull/513

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
