### PR TITLE
Add ability to specify default value for a plot control

### DIFF
--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -187,6 +187,7 @@ export interface CalibrateMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -230,6 +231,7 @@ export interface CalibrateMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -273,6 +275,7 @@ export interface CalibrateMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -316,6 +319,7 @@ export interface CalibrateMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -413,6 +417,7 @@ export interface CalibratePlotMetadata {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -500,6 +505,7 @@ export interface CalibratePlotResponse {
               };
             };
           }[];
+          value?: string;
           hidden?: boolean;
         }[];
       };
@@ -778,6 +784,7 @@ export interface ComparisonPlotMetadata {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -868,6 +875,7 @@ export interface ComparisonPlotResponse {
               };
             };
           }[];
+          value?: string;
           hidden?: boolean;
         }[];
       };
@@ -1550,6 +1558,7 @@ export interface PlotSetting {
       };
     };
   }[];
+  value?: string;
   hidden?: boolean;
 }
 export interface PlotSettingEffect {
@@ -1628,6 +1637,7 @@ export interface PlotSettingsControl {
         };
       };
     }[];
+    value?: string;
     hidden?: boolean;
   }[];
 }
@@ -1985,6 +1995,7 @@ export interface ReviewInputFilterMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };
@@ -2028,6 +2039,7 @@ export interface ReviewInputFilterMetadataResponse {
             };
           };
         }[];
+        value?: string;
         hidden?: boolean;
       }[];
     };

--- a/src/app/static/src/app/store/plotSelections/utils.ts
+++ b/src/app/static/src/app/store/plotSelections/utils.ts
@@ -12,6 +12,7 @@ import {
     FilterOption,
     FilterTypes,
     PlotSettingEffect,
+    PlotSettingOption,
 } from "../../generated";
 
 export const filtersAfterUseShapeRegions = (filterTypes: FilterTypes[], rootState: RootState) => {
@@ -75,7 +76,7 @@ export const filtersInfoFromEffects = (
         }
     });
 
-    return filterRefs!.map(f => {
+    return filterRefs.map(f => {
         const filter = filterTypes.find(filterType => filterType.id === f.filterId)!;
         const isMultiple = multiFilters.includes(f.stateFilterId);
         const isHidden = hiddenFilters.includes(f.stateFilterId);
@@ -85,11 +86,12 @@ export const filtersInfoFromEffects = (
             // we have specified fixed values
             const optionIds = filterValues[f.stateFilterId];
             const filterOptions = [];
+            const maxLength = isMultiple ? optionIds.length : 1;
             for (let i = 0; i < filter.options.length; i++) {
                 if (optionIds.includes(filter.options[i].id)) {
                     filterOptions.push(filter.options[i]);
                 }
-                if (filterOptions.length === optionIds.length) {
+                if (filterOptions.length === maxLength) {
                     break;
                 }
             }
@@ -139,7 +141,7 @@ export const commitPlotDefaultSelections = async (
         const effects = control.defaultEffect ? [control.defaultEffect] : [];
         const selectedSettingOptions: PlotSelectionUpdate["selections"]["controls"] = [];
         control.plotSettings.forEach(setting => {
-            const defaultOption = setting.options[0];
+            const defaultOption: PlotSettingOption = setting.options.find(op => op.id === setting.value) || setting.options[0];
             effects.push(defaultOption.effect);
             selectedSettingOptions.push({
                 id: setting.id,

--- a/src/config/hintr_version
+++ b/src/config/hintr_version
@@ -1,1 +1,1 @@
-table-metadata
+metadata-defaults


### PR DESCRIPTION
## Description

Corresponding metadata https://github.com/mrc-ide/hintr/pull/515

This PR does 2 things
* Add default value for bar chart, this is useful for e.g. barchart where we want to have a default with different x axis and disaggregate by
* Tidy up a bit of logic in data fetching. If the control is not a multiselect, only the first value will be used. Without this we were getting weird x-axis values. To see this, remove the change to plotSelections/utils.ts, open the barchart, change the x-axis to area. See the bars be really small but the x-axis max value high. This is because we were fetching the data for all selected age values, because changing the plot selection is updating "age" to a single-select but it doesn't do a commit and change the selection. So underlying this there are still multiple ages selected, just 1 is shown. I've fixed this by limiting the data fetch to 1 if it is a single select. But perhaps we should sort this by updating the selection in the store instead?

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
