### PR TITLE
Remove selected data type from state, mutations and actions

### DIFF
--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -11,7 +11,6 @@ export const serialiseState = (state: RootState): Partial<RootState> => {
         selectedRelease: state.baseline.selectedRelease
     } as any;
     const surveyAndProgram = {
-        selectedDataType: state.surveyAndProgram.selectedDataType,
         warnings: state.surveyAndProgram.warnings
     } as any;
     const metadata =  {...state.metadata, reviewInputMetadataError: null};

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -118,7 +118,6 @@ const resetState = (store: Store<RootState>): void => {
                 }
 
                 if (BaselineUpdates.includes(type[1] as BaselineMutation)) {
-                    store.commit(RootMutation.ResetSelectedDataType);
                     /** If data has been updated without changing the selected dataset,
                      *  retain model options, but reset their valid status to false in order to force revalidation
                      */
@@ -128,7 +127,6 @@ const resetState = (store: Store<RootState>): void => {
             }
 
             if (type[0] == "surveyAndProgram" && SurveyAndProgramUpdates.includes(type[1] as SurveyAndProgramMutation)) {
-                store.commit(RootMutation.ResetSelectedDataType);
                 store.commit({type: `modelOptions/${ModelOptionsMutation.UnValidate}`}, {root:true});
                 store.commit(RootMutation.ResetOutputs);
             }

--- a/src/app/static/src/app/store/adr/actions.ts
+++ b/src/app/static/src/app/store/adr/actions.ts
@@ -75,7 +75,7 @@ export const actions: ActionTree<ADRState, RootState> & ADRActions = {
 
     async getReleases(context, selectedDatasetId) {
         await api<ADRMutation, BaselineMutation>(context)
-            .withError(BaselineMutation.BaselineError)
+            .withError(`baseline/${BaselineMutation.BaselineError}` as BaselineMutation, true)
             .withSuccess(ADRMutation.SetReleases)
             .get(`/adr/datasets/${selectedDatasetId}/releases/`)
     },

--- a/src/app/static/src/app/store/root/actions.ts
+++ b/src/app/static/src/app/store/root/actions.ts
@@ -62,8 +62,6 @@ export const actions: ActionTree<RootState, RootState> & RootActions = {
             }
 
             commit({type: RootMutation.Reset, payload: maxValidStep});
-
-            commit({type: RootMutation.ResetSelectedDataType});
         }
     },
 

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -7,7 +7,7 @@ import {initialLoadState} from "../load/state";
 import {initialMetadataState} from "../metadata/metadata";
 import {initialErrorsState} from "../errors/errors";
 import {initialBaselineState} from "../baseline/baseline";
-import {DataType, initialSurveyAndProgramState} from "../surveyAndProgram/surveyAndProgram";
+import {initialSurveyAndProgramState} from "../surveyAndProgram/surveyAndProgram";
 import {PayloadWithType, PollingState, Project} from "../../types";
 import {mutations as languageMutations} from "../language/mutations";
 import {initialProjectsState} from "../projects/projects";
@@ -23,7 +23,6 @@ import {initialPlotState} from "../plotState/plotState";
 
 export enum RootMutation {
     Reset = "Reset",
-    ResetSelectedDataType = "ResetSelectedDataType",
     ResetOptions = "ResetOptions",
     ResetOutputs = "ResetOutputs",
     SetProject = "SetProject",
@@ -111,34 +110,6 @@ export const mutations: MutationTree<RootState> = {
 
         if (router.currentRoute.value.path !== "/") {
             router.push("/");
-        }
-    },
-
-    [RootMutation.ResetSelectedDataType](state: RootState) {
-        //TODO: Should this move to SAP since we're removing output from DataType?
-        const dataAvailable = (dataType: DataType | null) => {
-            if (dataType == null) {
-                return true
-            }
-            switch (dataType) {
-                case DataType.ANC:
-                    return !!state.surveyAndProgram.anc;
-                case DataType.Program:
-                    return !!state.surveyAndProgram.program;
-                case DataType.Survey:
-                    return !!state.surveyAndProgram.survey;
-                case DataType.Vmmc:
-                    return !!state.surveyAndProgram.vmmc;
-            }
-        };
-
-        if (!dataAvailable(state.surveyAndProgram.selectedDataType)) {
-
-            const availableData: number[] = Object.keys(DataType)
-                .filter(k => !isNaN(Number(k)) && dataAvailable(Number(k)))
-                .map(k => Number(k));
-
-            state.surveyAndProgram.selectedDataType = availableData.length > 0 ? availableData[0] : null;
         }
     },
 

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -1,5 +1,5 @@
 import {ActionContext, ActionTree, Commit} from 'vuex';
-import {DataType, SurveyAndProgramState} from "./surveyAndProgram";
+import {FileType, SurveyAndProgramState} from "./surveyAndProgram";
 import {api} from "../../apiService";
 import {AncResponse, ProgrammeResponse, SurveyResponse} from "../../generated";
 import {SurveyAndProgramMutation} from "./mutations";
@@ -24,7 +24,6 @@ export interface SurveyAndProgramActions {
     deleteANC: (store: ActionContext<SurveyAndProgramState, RootState>) => void
     deleteVmmc: (store: ActionContext<SurveyAndProgramState, RootState>) => void
     deleteAll: (store: ActionContext<SurveyAndProgramState, RootState>) => void
-    selectDataType: (store: ActionContext<SurveyAndProgramState, RootState>, payload: DataType) => void
     validateSurveyAndProgramData: (store: ActionContext<SurveyAndProgramState, RootState>) => void;
     setSurveyResponse: (store: ActionContext<SurveyAndProgramState, RootState>, data: SurveyResponse) => void;
     setProgramResponse: (store: ActionContext<SurveyAndProgramState, RootState>, data: ProgrammeResponse) => void;
@@ -36,10 +35,6 @@ const enum DATASET_TYPE {
     ART = "art",
     SURVEY = "survey",
     VMMC = "vmmc"
-}
-
-function commitSelectedDataTypeUpdated(commit: Commit, dataType: DataType) {
-    commit({type: SurveyAndProgramMutation.SelectedDataTypeUpdated, payload: dataType})
 }
 
 function commitClearGenericChartDataset(commit: Commit, dataType: string) {
@@ -55,7 +50,7 @@ async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, R
                                  filename: string) {
     const {commit, dispatch} = context;
     commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
-    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.ANC, warnings: []}});
+    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.ANC, warnings: []}});
     commitClearGenericChartDataset(commit, DATASET_TYPE.ANC);
 
     await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -67,9 +62,8 @@ async function uploadOrImportANC(context: ActionContext<SurveyAndProgramState, R
                 await dispatch("setAncResponse", response.data)
                 commit({
                     type: SurveyAndProgramMutation.WarningsFetched,
-                    payload: {type: DataType.ANC, warnings: response.data.warnings}
+                    payload: {type: FileType.ANC, warnings: response.data.warnings}
                 })
-                commitSelectedDataTypeUpdated(commit, DataType.ANC);
             } else {
                 commit({type: SurveyAndProgramMutation.ANCErroredFile, payload: filename});
             }
@@ -80,7 +74,7 @@ async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramStat
                                      filename: string) {
     const {commit, dispatch} = context;
     commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
-    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Program, warnings: []}});
+    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Programme, warnings: []}});
     commitClearGenericChartDataset(commit, DATASET_TYPE.ART);
 
     await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -92,9 +86,8 @@ async function uploadOrImportProgram(context: ActionContext<SurveyAndProgramStat
                 await dispatch("setProgramResponse", response.data)
                 commit({
                     type: SurveyAndProgramMutation.WarningsFetched,
-                    payload: {type: DataType.Program, warnings: response.data.warnings}
+                    payload: {type: FileType.Programme, warnings: response.data.warnings}
                 })
-                commitSelectedDataTypeUpdated(commit, DataType.Program);
             } else {
                 commit({type: SurveyAndProgramMutation.ProgramErroredFile, payload: filename});
             }
@@ -105,7 +98,7 @@ async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState
                                     filename: string) {
     const {commit, dispatch} = context;
     commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
-    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Survey, warnings: []}});
+    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Survey, warnings: []}});
 
     await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
         .withError(SurveyAndProgramMutation.SurveyError)
@@ -116,9 +109,8 @@ async function uploadOrImportSurvey(context: ActionContext<SurveyAndProgramState
                 await dispatch("setSurveyResponse", response.data)
                 commit({
                     type: SurveyAndProgramMutation.WarningsFetched,
-                    payload: {type: DataType.Survey, warnings: response.data.warnings}
+                    payload: {type: FileType.Survey, warnings: response.data.warnings}
                 })
-                commitSelectedDataTypeUpdated(commit, DataType.Survey);
             } else {
                 commit({type: SurveyAndProgramMutation.SurveyErroredFile, payload: filename});
             }
@@ -129,7 +121,7 @@ async function uploadOrImportVmmc(context: ActionContext<SurveyAndProgramState, 
                                   options: UploadImportOptions, filename: string) {
     const {commit} = context;
     commit({type: SurveyAndProgramMutation.VmmcUpdated, payload: null});
-    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Vmmc, warnings: []}});
+    commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Vmmc, warnings: []}});
     commitClearGenericChartDataset(commit, DATASET_TYPE.VMMC);
 
     await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -141,7 +133,7 @@ async function uploadOrImportVmmc(context: ActionContext<SurveyAndProgramState, 
             if (response) {
                 commit({
                     type: SurveyAndProgramMutation.WarningsFetched,
-                    payload: {type: DataType.Vmmc, warnings: response.data.warnings}
+                    payload: {type: FileType.Vmmc, warnings: response.data.warnings}
                 })
             } else {
                 commit({type: SurveyAndProgramMutation.VmmcErroredFile, payload: filename});
@@ -150,11 +142,6 @@ async function uploadOrImportVmmc(context: ActionContext<SurveyAndProgramState, 
 }
 
 export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndProgramActions = {
-
-    selectDataType(context, payload) {
-        const {commit} = context;
-        commitSelectedDataTypeUpdated(commit, payload);
-    },
 
     async importSurvey(context, url) {
         if (url) {
@@ -209,74 +196,45 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
     },
 
     async deleteSurvey(context) {
-        const {commit, state} = context;
+        const {commit} = context;
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/survey/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.SurveyUpdated, payload: null});
-                if (state.selectedDataType == DataType.Survey) {
-                    if (state.program) {
-                        commitSelectedDataTypeUpdated(commit, DataType.Program)
-                    } else if (state.anc) {
-                        commitSelectedDataTypeUpdated(commit, DataType.ANC)
-                    }
-                }
-                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Survey, warnings: []}});
+                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Survey, warnings: []}});
             });
     },
 
     async deleteProgram(context) {
-        const {commit, state} = context;
+        const {commit} = context;
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/programme/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ProgramUpdated, payload: null});
-                if (state.selectedDataType == DataType.Program) {
-                    if (state.survey) {
-                        commitSelectedDataTypeUpdated(commit, DataType.Survey)
-                    } else if (state.anc) {
-                        commitSelectedDataTypeUpdated(commit, DataType.ANC)
-                    }
-                }
                 commitClearGenericChartDataset(commit, DATASET_TYPE.ART)
-                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Program, warnings: []}});
+                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Programme, warnings: []}});
             });
     },
 
     async deleteANC(context) {
-        const {commit, state} = context;
+        const {commit} = context;
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/anc/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.ANCUpdated, payload: null});
-                if (state.selectedDataType == DataType.ANC) {
-                    if (state.program) {
-                        commitSelectedDataTypeUpdated(commit, DataType.Program)
-                    } else if (state.survey) {
-                        commitSelectedDataTypeUpdated(commit, DataType.Survey)
-                    }
-                }
                 commitClearGenericChartDataset(commit, DATASET_TYPE.ANC)
-                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.ANC, warnings: []}});
+                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.ANC, warnings: []}});
             });
     },
 
     async deleteVmmc(context) {
-        const {commit, state} = context;
+        const {commit} = context;
         await api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
             .delete("/disease/vmmc/")
             .then(() => {
                 commit({type: SurveyAndProgramMutation.VmmcUpdated, payload: null});
-                if (state.selectedDataType == DataType.Vmmc) {
-                    if (state.program) {
-                        // TODO: do we need this?
-                        commitSelectedDataTypeUpdated(commit, DataType.Program)
-                    } else if (state.survey) {
-                        commitSelectedDataTypeUpdated(commit, DataType.Survey)
-                    }
-                }
                 commitClearGenericChartDataset(commit, DATASET_TYPE.VMMC)
-                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: DataType.Vmmc, warnings: []}});
+                commit({type: SurveyAndProgramMutation.WarningsFetched, payload: {type: FileType.Vmmc, warnings: []}});
             });
     },
 
@@ -331,9 +289,7 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
     },
 
     async validateSurveyAndProgramData(context) {
-        const {commit, rootState, dispatch} = context;
-        const successfulDataTypes: DataType[] = []
-        const initialSelectedDataType = rootState.surveyAndProgram.selectedDataType
+        const {commit, dispatch} = context;
 
         await Promise.all(
             [
@@ -344,7 +300,6 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
                     .then(async (response) => {
                         if (response && response.data) {
                             await dispatch("setSurveyResponse", response.data)
-                            successfulDataTypes.push(DataType.Survey)
                         }
                     }),
                 api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -354,7 +309,6 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
                     .then(async (response) => {
                         if (response && response.data) {
                             await dispatch("setProgramResponse", response.data)
-                            successfulDataTypes.push(DataType.Program)
                         }
                     }),
                 api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -364,7 +318,6 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
                     .then(async (response) => {
                         if (response && response.data) {
                             await dispatch("setAncResponse", response.data)
-                            successfulDataTypes.push(DataType.ANC)
                         }
                     }),
                 api<SurveyAndProgramMutation, SurveyAndProgramMutation>(context)
@@ -372,17 +325,7 @@ export const actions: ActionTree<SurveyAndProgramState, RootState> & SurveyAndPr
                     .withSuccess(SurveyAndProgramMutation.VmmcUpdated)
                     .freezeResponse()
                     .get<AncResponse>(getUrlWithQuery("/disease/vmmc/"))
-                    .then((response) => {
-                        if (response && response.data) {
-                            successfulDataTypes.push(DataType.Vmmc)
-                        }
-                    })
             ]);
-        const selectedTypeSucceeded = successfulDataTypes.some(data => data === initialSelectedDataType)
-        if (!selectedTypeSucceeded) {
-            const newSelectedDataType = successfulDataTypes.length ? successfulDataTypes[0] : null
-            commitSelectedDataTypeUpdated(commit, newSelectedDataType!)
-        }
         commit({type: SurveyAndProgramMutation.Ready, payload: true});
     },
 

--- a/src/app/static/src/app/store/surveyAndProgram/mutations.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/mutations.ts
@@ -1,11 +1,10 @@
 import {MutationTree} from 'vuex';
-import {DataType, SAPWarnings, SurveyAndProgramState} from "./surveyAndProgram";
+import {SAPWarnings, SurveyAndProgramState} from "./surveyAndProgram";
 import {PayloadWithType} from "../../types";
 import {AncResponse, ProgrammeResponse, SurveyResponse, VmmcResponse, Error, Warning} from "../../generated";
 import {ReadyState} from "../../root";
 
 export enum SurveyAndProgramMutation {
-    SelectedDataTypeUpdated = "SelectedDataTypeUpdated",
     SurveyUpdated = "SurveyUpdated",
     SurveyError = "SurveyError",
     SurveyErroredFile = "SurveyErroredFile",
@@ -30,10 +29,6 @@ export const SurveyAndProgramUpdates = [
 ];
 
 export const mutations: MutationTree<SurveyAndProgramState> = {
-    [SurveyAndProgramMutation.SelectedDataTypeUpdated](state: SurveyAndProgramState, action: PayloadWithType<DataType>) {
-        state.selectedDataType = action.payload;
-    },
-
     [SurveyAndProgramMutation.SurveyUpdated](state: SurveyAndProgramState, action: PayloadWithType<SurveyResponse>) {
         state.survey = action.payload;
         state.surveyError = null;

--- a/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/surveyAndProgram.ts
@@ -6,13 +6,12 @@ import {AncResponse, ProgrammeResponse, SurveyResponse, VmmcResponse, Error, War
 import {getters} from "./getters";
 import {RootState} from "../../root";
 
-export enum DataType { ANC, Program, Survey, Vmmc}
-
 export enum FileType {
     ANC = "anc",
     Programme = "programme",
     Survey = "survey",
-    Shape = "shape"
+    Shape = "shape",
+    Vmmc = "vmmc"
 }
 
 export interface SAPWarnings {
@@ -21,7 +20,6 @@ export interface SAPWarnings {
 }
 
 export interface SurveyAndProgramState extends ReadyState, WarningsState {
-    selectedDataType: DataType | null
     survey: SurveyResponse | null
     surveyError: Error | null
     surveyErroredFile: string | null
@@ -39,7 +37,6 @@ export interface SurveyAndProgramState extends ReadyState, WarningsState {
 
 export const initialSurveyAndProgramState = (): SurveyAndProgramState => {
     return {
-        selectedDataType: null,
         survey: null,
         surveyError: null,
         surveyErroredFile: null,

--- a/src/app/static/src/app/types.ts
+++ b/src/app/static/src/app/types.ts
@@ -362,11 +362,6 @@ export interface PollingState {
     statusPollId: number
 }
 
-export interface CalibrateResultWithType {
-    data: CalibrateDataResponse["data"];
-    indicatorId: string;
-}
-
 // TODO: Remove this in favour of plotting metadata?
 export enum ModelOutputTabs {
     Map = "map",

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -8,7 +8,6 @@ import {
     DynamicFormData,
     DynamicFormMeta
 } from "@reside-ic/vue-next-dynamic-form";
-import {DataType} from "./store/surveyAndProgram/surveyAndProgram";
 import {RootState} from "./root";
 import {initialStepperState} from "./store/stepper/stepper";
 import {initialModelRunState} from "./store/modelRun/modelRun";
@@ -465,7 +464,6 @@ export const constructRehydrateProjectState = (data: ProjectRehydrateResultRespo
             hash: files.anc.hash,
             filename: files.anc.filename
         },
-        selectedDataType: DataType.Survey,
     } as any
 
     const baseline = {

--- a/src/app/static/src/tests/adr/actions.test.ts
+++ b/src/app/static/src/tests/adr/actions.test.ts
@@ -176,7 +176,7 @@ describe("ADR actions", () => {
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0])
             .toStrictEqual({
-                type: BaselineMutation.BaselineError,
+                type: `baseline/${BaselineMutation.BaselineError}`,
                 payload: mockError("error")
             });
     });

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -176,7 +176,7 @@ describe("Baseline actions", () => {
         (console.log as Mock).mockClear();
     });
 
-    it("sets country and iso3 after PJNZ file upload, and fetches plotting metadata, and validates", async () => {
+    it("sets country and iso3 after PJNZ file upload and validates", async () => {
 
         mockAxios.onPost(`/baseline/pjnz/`)
             .reply(200, mockSuccess({data: {country: "Malawi", iso3: "MWI"}}));
@@ -190,7 +190,7 @@ describe("Baseline actions", () => {
         checkPJNZImportUpload(commit, dispatch)
     });
 
-    it("sets country and iso3 after PJNZ import, and fetches plotting metadata, and validates", async () => {
+    it("sets country and iso3 after PJNZ import and validates", async () => {
         const url = "/adr/pjnz/"
         mockAxios.onPost(url)
             .reply(200, mockSuccess({data: {country: "Malawi", iso3: "MWI"}}));
@@ -219,7 +219,7 @@ describe("Baseline actions", () => {
         expect(dispatch.mock.calls[1][0]).toBe("surveyAndProgram/validateSurveyAndProgramData");
     }
 
-    it("upload PJNZ does not fetch plotting metadata or validate if error occurs", async () => {
+    it("upload PJNZ does not validate if error occurs", async () => {
         mockAxios.onPost(`/baseline/pjnz/`)
             .reply(400, mockFailure("test error"));
 
@@ -491,7 +491,7 @@ describe("Baseline actions", () => {
         });
     });
 
-    it("fails silently and marks state ready and does not get plotting metadata if getting baseline data fails", async () => {
+    it("fails silently and marks state ready if getting baseline data fails", async () => {
 
         mockAxios.onGet(`/baseline/pjnz/`)
             .reply(500);

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -164,11 +164,10 @@ describe("App", () => {
                 "baseline", BaselineMutation.PJNZUpdated),
             {payload: null});
 
-        expect(spy.mock.calls[1][0]).toBe(RootMutation.ResetSelectedDataType);
-        expect(spy.mock.calls[2][0].type).toBe("modelOptions/UnValidate");
-        expect(spy.mock.calls[3][0]).toBe(RootMutation.ResetOutputs);
+        expect(spy.mock.calls[1][0].type).toBe("modelOptions/UnValidate");
+        expect(spy.mock.calls[2][0]).toBe(RootMutation.ResetOutputs);
 
-        expect(spy).toBeCalledTimes(5);
+        expect(spy).toBeCalledTimes(4);
     });
 
 
@@ -179,11 +178,10 @@ describe("App", () => {
                 "surveyAndProgram", SurveyAndProgramMutation.SurveyUpdated),
             {payload: null});
 
-        expect(spy.mock.calls[1][0]).toBe(RootMutation.ResetSelectedDataType);
-        expect(spy.mock.calls[2][0].type).toBe("modelOptions/UnValidate");
-        expect(spy.mock.calls[3][0]).toBe(RootMutation.ResetOutputs);
+        expect(spy.mock.calls[1][0].type).toBe("modelOptions/UnValidate");
+        expect(spy.mock.calls[2][0]).toBe(RootMutation.ResetOutputs);
 
-        expect(spy).toBeCalledTimes(5);
+        expect(spy).toBeCalledTimes(4);
     });
 
     it("resets outputs if modelOptions update mutation is called and state is ready", () => {

--- a/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
+++ b/src/app/static/src/tests/components/uploadInputs/fileUploads.ts
@@ -38,7 +38,6 @@ export function testUploadComponent(name: string, position: number) {
             deleteAll: vi.fn(),
             deleteVmmc: vi.fn(),
             getSurveyAndProgramData: vi.fn(),
-            selectDataType: vi.fn(),
             validateSurveyAndProgramData: vi.fn(),
             setSurveyResponse: vi.fn(),
             setProgramResponse: vi.fn(),

--- a/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
+++ b/src/app/static/src/tests/components/uploadInputs/uploadInputs.test.ts
@@ -20,7 +20,7 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {expectTranslatedWithStoreType, mountWithTranslate, shallowMountWithTranslate} from "../../testHelpers";
 import {SurveyAndProgramActions} from "../../../app/store/surveyAndProgram/actions";
 import {getters} from "../../../app/store/surveyAndProgram/getters";
-import {DataType, SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
+import {SurveyAndProgramState} from "../../../app/store/surveyAndProgram/surveyAndProgram";
 import {testUploadComponent} from "./fileUploads";
 import {Mocked, MockInstance} from 'vitest';
 import {flushPromises, VueWrapper} from '@vue/test-utils';
@@ -46,7 +46,7 @@ describe("UploadInputs upload component", () => {
 
     const createSut = (baselineState?: Partial<BaselineState>,
                        metadataState?: Partial<MetadataState>,
-                       surveyAndProgramState: Partial<SurveyAndProgramState> = {selectedDataType: DataType.Survey},
+                       surveyAndProgramState: Partial<SurveyAndProgramState> = {},
                        isGuest = false) => {
 
         actions = {

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -3,7 +3,6 @@ import {actions as baselineActions} from "../../app/store/baseline/actions"
 import {login, rootState} from "./integrationTest";
 import {getFormData} from "./helpers";
 import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
-import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
 
 describe("Survey and programme actions", () => {
 
@@ -94,7 +93,7 @@ describe("Survey and programme actions", () => {
         commit.mockReset();
 
         // delete
-        await actions.deleteSurvey({commit, rootState, state: {selectedDataType: DataType.Survey}} as any);
+        await actions.deleteSurvey({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.SurveyUpdated);
 
         dispatch.mockReset();
@@ -116,7 +115,7 @@ describe("Survey and programme actions", () => {
         commit.mockReset();
 
         // delete
-        await actions.deleteProgram({commit, rootState, state: {selectedDataType: DataType.Survey}} as any);
+        await actions.deleteProgram({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
         expect(commit.mock.calls[1][0]["type"]).toBe("genericChart/ClearDataset");
 
@@ -139,7 +138,7 @@ describe("Survey and programme actions", () => {
         commit.mockReset();
 
         // delete
-        await actions.deleteANC({commit, rootState, state: {selectedDataType: DataType.Survey}} as any);
+        await actions.deleteANC({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
         expect(commit.mock.calls[1][0]["type"]).toBe("genericChart/ClearDataset");
 
@@ -162,7 +161,7 @@ describe("Survey and programme actions", () => {
         commit.mockReset();
 
         // delete
-        await actions.deleteVmmc({commit, rootState, state: {selectedDataType: DataType.Vmmc}} as any);
+        await actions.deleteVmmc({commit, rootState} as any);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.VmmcUpdated);
         expect(commit.mock.calls[1][0]["type"]).toBe("genericChart/ClearDataset");
 

--- a/src/app/static/src/tests/localStorageManager.test.ts
+++ b/src/app/static/src/tests/localStorageManager.test.ts
@@ -28,7 +28,6 @@ import {
 } from "./mocks";
 import {localStorageManager, serialiseState} from "../app/localStorageManager";
 import {RootState} from "../app/root";
-import {DataType} from "../app/store/surveyAndProgram/surveyAndProgram";
 import {currentHintVersion} from "../app/hintVersion";
 import {Language} from "../app/store/translations/locales";
 import registerTranslations from "../app/store/translations/registerTranslations";
@@ -108,7 +107,6 @@ describe("LocalStorageManager", () => {
             plotSelections: mockPlotSelections(),
             plotState: mockPlotState(),
             surveyAndProgram: mockSurveyAndProgramState({
-                selectedDataType: DataType.Survey,
                 warnings: [{text: "test warning", locations: ["review_inputs"]}]
             }),
             projects: mockProjectsState(),
@@ -131,7 +129,6 @@ describe("LocalStorageManager", () => {
             stepper: mockStepperState(),
             metadata: mockMetadataState(),
             surveyAndProgram: {
-                selectedDataType: DataType.Survey,
                 warnings: [{text: "test warning", locations: ["review_inputs"]}]
             },
             hintrVersion: mockHintrVersionState()

--- a/src/app/static/src/tests/modelCalibrate/actions.test.ts
+++ b/src/app/static/src/tests/modelCalibrate/actions.test.ts
@@ -168,7 +168,7 @@ describe("ModelCalibrate actions", () => {
         expect(dispatch.mock.calls[0][0]).toBe("getResult");
     });
 
-    it("getResult commits metadata and warnings, sets default plotting selections, and dispatches actions to get data", async () => {
+    it("getResult commits metadata and warnings, sets default plot selections, and dispatches actions to get data", async () => {
         switches.modelCalibratePlot = true;
 
         const testResult = mockCalibrateMetadataResponse()

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -160,9 +160,8 @@ describe("root actions", () => {
             "Rolled back project to last valid step. The invalid steps were: Review inputs, Model options");
         expect(mockContext.dispatch.mock.calls[1][0]).toBe("surveyAndProgram/deleteAll");
 
-        expect(mockContext.commit).toHaveBeenCalledTimes(2);
+        expect(mockContext.commit).toHaveBeenCalledTimes(1);
         expect(mockContext.commit.mock.calls[0][0]).toStrictEqual({type: "Reset", payload: 1});
-        expect(mockContext.commit.mock.calls[1][0]).toStrictEqual({type: "ResetSelectedDataType"});
     });
 
     it("rollbackInvalidState does not create new version if guest user", async () => {
@@ -182,10 +181,8 @@ describe("root actions", () => {
         expect(mockContext.dispatch).toHaveBeenCalledTimes(1);
         expect(mockContext.dispatch.mock.calls[0][0]).toBe("surveyAndProgram/deleteAll");
 
-        expect(mockContext.commit).toHaveBeenCalledTimes(2);
+        expect(mockContext.commit).toHaveBeenCalledTimes(1);
         expect(mockContext.commit.mock.calls[0][0]).toStrictEqual({type: "Reset", payload: 1});
-        expect(mockContext.commit.mock.calls[1][0]).toStrictEqual({type: "ResetSelectedDataType"});
-
     });
 
     it("rollbackInvalidState dispatches delete baseline and surveyAndProgram action if baseline step is not valid", async () => {
@@ -232,9 +229,8 @@ describe("root actions", () => {
         expect(mockContext.dispatch).toHaveBeenCalledTimes(1);
         expect(mockContext.dispatch.mock.calls[0][0]).toBe("projects/newVersion");
 
-        expect(mockContext.commit).toHaveBeenCalledTimes(2);
+        expect(mockContext.commit).toHaveBeenCalledTimes(1);
         expect(mockContext.commit.mock.calls[0][0]).toStrictEqual({type: "Reset", payload: 2});
-        expect(mockContext.commit.mock.calls[1][0]).toStrictEqual({type: "ResetSelectedDataType"});
     });
 
     it("rollbackInvalidState does nothing if no invalid steps", async () => {

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -19,9 +19,7 @@ import {
     mockRootState,
     mockStepperState,
     mockSurveyAndProgramState,
-    mockSurveyResponse
 } from "../mocks";
-import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {RootState} from "../../app/root";
 import {initialMetadataState} from "../../app/store/metadata/metadata";
 import {initialModelOutputState} from "../../app/store/modelOutput/modelOutput";
@@ -185,44 +183,6 @@ describe("Root mutations", () => {
 
         testOnlyExpectedModulesArePopulated(["baseline", "metadata", "surveyAndProgram", "genericChart", "modelOptions", "modelRun", "modelCalibrate"], state);
         expect(state.stepper.activeStep).toBe(5);
-    });
-
-    it("sets selected data type to null if no valid type available", () => {
-
-        const state = mockRootState({
-            surveyAndProgram: mockSurveyAndProgramState({
-                selectedDataType: DataType.ANC
-            })
-        });
-
-        mutations.ResetSelectedDataType(state);
-        expect(state.surveyAndProgram.selectedDataType).toBe(null);
-    });
-
-    it("sets selected data type to available type if there is one", () => {
-
-        const state = mockRootState({
-            surveyAndProgram: mockSurveyAndProgramState({
-                survey: mockSurveyResponse(),
-                selectedDataType: DataType.ANC
-            })
-        });
-
-        mutations.ResetSelectedDataType(state);
-        expect(state.surveyAndProgram.selectedDataType).toBe(DataType.Survey);
-    });
-
-    it("leaves selected data type as is if valid", () => {
-
-        const state = mockRootState({
-            surveyAndProgram: mockSurveyAndProgramState({
-                anc: mockAncResponse(),
-                selectedDataType: DataType.ANC
-            })
-        });
-
-        mutations.ResetSelectedDataType(state);
-        expect(state.surveyAndProgram.selectedDataType).toBe(DataType.ANC);
     });
 
     it("can reset model options state", () => {

--- a/src/app/static/src/tests/stepper/stepperState.test.ts
+++ b/src/app/static/src/tests/stepper/stepperState.test.ts
@@ -4,9 +4,7 @@ const existingState = {
     stepper: {
         activeStep: 4
     },
-    surveyAndProgram: {
-        selectedDataType: null
-    },
+    surveyAndProgram: {},
     baseline: {}
 } as any;
 

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../mocks";
 import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
 import {expectEqualsFrozen} from "../testHelpers";
-import {DataType} from "../../app/store/surveyAndProgram/surveyAndProgram";
+import {FileType} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {expectValidAdrImportPayload} from "../baseline/actions.test";
 import {Mock} from "vitest";
 
@@ -79,16 +79,13 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Survey, warnings: []}
+            payload: {type: FileType.Survey, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
             type: "WarningsFetched",
-            payload: {type: 2, warnings: "TEST WARNINGS"}
+            payload: {type: FileType.Survey, warnings: "TEST WARNINGS"}
         });
-
-        //Should also have set selectedDataType
-        expect(commit.mock.calls[3][0]).toStrictEqual({type: "SelectedDataTypeUpdated", payload: DataType.Survey});
 
         expect(dispatch.mock.calls[0][0]).toStrictEqual("setSurveyResponse");
         expect(dispatch.mock.calls[0][1]).toStrictEqual({data: "SOME DATA", warnings: "TEST WARNINGS"})
@@ -125,7 +122,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Survey, warnings: []}
+            payload: {type: FileType.Survey, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -201,7 +198,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Program, warnings: []}
+            payload: {type: FileType.Programme, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -212,14 +209,7 @@ describe("Survey and programme actions", () => {
         expect(commit.mock.calls[3][0]).toStrictEqual(
             {
                 type: "WarningsFetched",
-                payload: {type: 1, warnings: "TEST WARNINGS"}
-            });
-
-        //Should also have set selectedDataType
-        expect(commit.mock.calls[4][0]).toStrictEqual(
-            {
-                type: "SelectedDataTypeUpdated",
-                payload: DataType.Program
+                payload: {type: FileType.Programme, warnings: "TEST WARNINGS"}
             });
 
         expect(dispatch.mock.calls[0][0]).toStrictEqual("setProgramResponse");
@@ -258,7 +248,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Program, warnings: []}
+            payload: {type: FileType.Programme, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -312,7 +302,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.ANC, warnings: []}
+            payload: {type: FileType.ANC, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -323,14 +313,7 @@ describe("Survey and programme actions", () => {
         expect(commit.mock.calls[3][0]).toStrictEqual(
             {
                 type: "WarningsFetched",
-                payload: {type: 0, warnings: "TEST WARNINGS"}
-            });
-
-        //Should also have set selectedDataType
-        expect(commit.mock.calls[4][0]).toStrictEqual(
-            {
-                type: "SelectedDataTypeUpdated",
-                payload: DataType.ANC
+                payload: {type: FileType.ANC, warnings: "TEST WARNINGS"}
             });
 
         expect(dispatch.mock.calls[0][0]).toStrictEqual("setAncResponse");
@@ -369,7 +352,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.ANC, warnings: []}
+            payload: {type: FileType.ANC, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -423,7 +406,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Vmmc, warnings: []}
+            payload: {type: FileType.Vmmc, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -439,7 +422,7 @@ describe("Survey and programme actions", () => {
         expect(commit.mock.calls[4][0]).toStrictEqual(
             {
                 type: "WarningsFetched",
-                payload: {type: 3, warnings: "TEST WARNINGS"}
+                payload: {type: FileType.Vmmc, warnings: "TEST WARNINGS"}
             });
     }
 
@@ -475,7 +458,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[1][0]).toStrictEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Vmmc, warnings: []}
+            payload: {type: FileType.Vmmc, warnings: []}
         });
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
@@ -552,7 +535,7 @@ describe("Survey and programme actions", () => {
         expect(commitCalls).toContain(SurveyAndProgramMutation.Ready);
 
         const payloads = commit.mock.calls.map((callArgs) => callArgs[0]["payload"]);
-        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(3);
+        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(2);
         //ready payload is true, which is frozen by definition
     });
 
@@ -584,7 +567,7 @@ describe("Survey and programme actions", () => {
         expect(commitCalls).toContain(SurveyAndProgramMutation.Ready);
 
         const payloads = commit.mock.calls.map((callArgs) => callArgs[0]["payload"]);
-        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(3);
+        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(2);
         //ready payload is true, which is frozen by definition
     });
 
@@ -611,10 +594,9 @@ describe("Survey and programme actions", () => {
         expect(calls).toContain(SurveyAndProgramMutation.ANCError);
         expect(calls).toContain(SurveyAndProgramMutation.VmmcError);
         expect(calls).toContain(SurveyAndProgramMutation.Ready);
-        expect(commit.mock.calls[4][0]).toStrictEqual({type: "SelectedDataTypeUpdated", payload: null});
 
         const payloads = commit.mock.calls.map((callArgs) => callArgs[0]["payload"]);
-        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(2);
+        expect(payloads.filter(p => Object.isFrozen(p)).length).toBe(1);
         //ready payload is true, which is frozen by definition
     });
 
@@ -639,38 +621,24 @@ describe("Survey and programme actions", () => {
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.Ready);
     });
 
-    it("deletes survey and resets selected data type", async () => {
+    it("deletes survey", async () => {
         mockAxios.onDelete("/disease/survey/")
             .reply(200, mockSuccess(true));
 
         const commit = vi.fn();
         await actions.deleteSurvey({
             commit, rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Survey, program: mockProgramResponse()})
+            state: mockSurveyAndProgramState({program: mockProgramResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(3);
+        expect(commit).toBeCalledTimes(2);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.SurveyUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Program
-        });
-        expect(commit.mock.calls[2][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Survey, warnings: []}
-        });
-        commit.mockReset();
-        await actions.deleteSurvey({
-            commit, rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Survey, anc: mockAncResponse()})
-        } as any);
-        expect(commit).toBeCalledTimes(3);
-        expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.ANC
+            payload: {type: FileType.Survey, warnings: []}
         });
     });
 
-    it("deletes program and resets selected data type", async () => {
+    it("deletes program", async () => {
         mockAxios.onDelete("/disease/programme/")
             .reply(200, mockSuccess(true));
 
@@ -678,33 +646,17 @@ describe("Survey and programme actions", () => {
         await actions.deleteProgram({
             commit,
             rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Program, survey: mockSurveyResponse()})
+            state: mockSurveyAndProgramState({survey: mockSurveyResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(4);
+        expect(commit).toBeCalledTimes(3);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Survey
-        });
-        expect(commit.mock.calls[2][0]).toEqual({
             type: "genericChart/ClearDataset",
             payload: "art"
         })
-        expect(commit.mock.calls[3][0]).toEqual({
+        expect(commit.mock.calls[2][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Program, warnings: []}
-        });
-
-        commit.mockReset();
-        await actions.deleteProgram({
-            commit,
-            rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Program, anc: mockAncResponse()})
-        } as any);
-        expect(commit).toBeCalledTimes(4);
-        expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.ANC
+            payload: {type: FileType.Programme, warnings: []}
         });
     });
 
@@ -716,37 +668,21 @@ describe("Survey and programme actions", () => {
         await actions.deleteANC({
             commit,
             rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.ANC, program: mockProgramResponse()})
+            state: mockSurveyAndProgramState({program: mockProgramResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(4);
+        expect(commit).toBeCalledTimes(3);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Program
-        });
-        expect(commit.mock.calls[2][0]).toEqual({
             type: "genericChart/ClearDataset",
             payload: "anc"
         });
-        expect(commit.mock.calls[3][0]).toEqual({
+        expect(commit.mock.calls[2][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.ANC, warnings: []}
-        });
-
-        commit.mockReset();
-        await actions.deleteANC({
-            commit,
-            rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.ANC, survey: mockSurveyResponse()})
-        } as any);
-        expect(commit).toBeCalledTimes(4);
-        expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Survey
+            payload: {type: FileType.ANC, warnings: []}
         });
     });
 
-    it("deletes VMMC and resets selected data type", async () => {
+    it("deletes VMMC", async () => {
         mockAxios.onDelete("/disease/vmmc/")
             .reply(200, mockSuccess(true));
 
@@ -754,33 +690,17 @@ describe("Survey and programme actions", () => {
         await actions.deleteVmmc({
             commit,
             rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Vmmc, program: mockProgramResponse()})
+            state: mockSurveyAndProgramState({program: mockProgramResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(4);
+        expect(commit).toBeCalledTimes(3);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.VmmcUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Program
-        });
-        expect(commit.mock.calls[2][0]).toEqual({
             type: "genericChart/ClearDataset",
             payload: "vmmc"
         });
-        expect(commit.mock.calls[3][0]).toEqual({
+        expect(commit.mock.calls[2][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
-            payload: {type: DataType.Vmmc, warnings: []}
-        });
-
-        commit.mockReset();
-        await actions.deleteVmmc({
-            commit,
-            rootState,
-            state: mockSurveyAndProgramState({selectedDataType: DataType.Vmmc, survey: mockSurveyResponse()})
-        } as any);
-        expect(commit).toBeCalledTimes(4);
-        expect(commit.mock.calls[1][0]).toEqual({
-            type: SurveyAndProgramMutation.SelectedDataTypeUpdated,
-            payload: DataType.Survey
+            payload: {type: FileType.Vmmc, warnings: []}
         });
     });
 
@@ -814,14 +734,6 @@ describe("Survey and programme actions", () => {
             "genericChart/ClearDataset",
             SurveyAndProgramMutation.WarningsFetched
         ]);
-    });
-
-    it("selects data type", () => {
-        const commit = vi.fn();
-        actions.selectDataType({commit} as any, DataType.ANC);
-        expect(commit).toBeCalledTimes(1);
-        expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.SelectedDataTypeUpdated);
-        expect(commit.mock.calls[0][0]["payload"]).toBe(DataType.ANC);
     });
 
     it("commits survey data without area level", () => {

--- a/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/mutations.test.ts
@@ -1,4 +1,4 @@
-import {DataType, SurveyAndProgramState} from "../../app/store/surveyAndProgram/surveyAndProgram";
+import {SurveyAndProgramState} from "../../app/store/surveyAndProgram/surveyAndProgram";
 import {getters as surveyAndProgramGetters} from "../../app/store/surveyAndProgram/getters";
 import {mutations, SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutations";
 import {mockError, mockRootState, mockSurveyAndProgramState, mockSurveyResponse, mockWarning} from "../mocks";
@@ -132,12 +132,6 @@ describe("Survey and programme mutations", () => {
         const testState = mockSurveyAndProgramState();
         mutations.Ready(testState);
         expect(testState.ready).toBe(true);
-    });
-
-    it("sets selected DataType", () => {
-        const testState = mockSurveyAndProgramState({selectedDataType: DataType.Survey});
-        mutations[SurveyAndProgramMutation.SelectedDataTypeUpdated](testState, {payload: DataType.Program});
-        expect(testState.selectedDataType).toBe(DataType.Program);
     });
 
     it("sets and clears warnings", () => {


### PR DESCRIPTION
## Description

We we're previously using this to save what input plot the user had open. So that if they went back to review inputs they could return to the same plot. We're not using this anymore so was just being set everywhere in a fairly complicated way. This PR just removes it and all the tests.

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
