### PR TITLE
Stop project version state being updated too frequently

### DIFF
--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -94,7 +94,7 @@ const persistState = (store: Store<RootState>): void => {
         const {dispatch} = store;
         const type = stripNamespace(mutation.type);
         if (type[0] !== "projects" && type[0] !== "errors") {
-            dispatch("projects/queueVersionStateUpload", null,{root: true});
+            dispatch("projects/queueVersionStateUpload", null, {root: true});
         }
     })
 };

--- a/src/app/static/src/app/root.ts
+++ b/src/app/static/src/app/root.ts
@@ -94,7 +94,7 @@ const persistState = (store: Store<RootState>): void => {
         const {dispatch} = store;
         const type = stripNamespace(mutation.type);
         if (type[0] !== "projects" && type[0] !== "errors") {
-            dispatch("projects/queueVersionStateUpload", {root: true});
+            dispatch("projects/queueVersionStateUpload", null,{root: true});
         }
     })
 };

--- a/src/app/static/vue.config.js
+++ b/src/app/static/vue.config.js
@@ -1,5 +1,7 @@
 const path = require("path");
 const { defineConfig } = require("@vue/cli-service");
+const webpack = require('webpack');
+
 
 module.exports = defineConfig({
     transpileDependencies: true,
@@ -35,5 +37,12 @@ module.exports = defineConfig({
             hints: false
         },
         devtool: 'eval-source-map',
+        plugins: [
+            new webpack.DefinePlugin({
+                // Vue CLI is in maintenance mode, and probably won't this PR to fix this in their tooling
+                // https://github.com/vuejs/vue-cli/pull/7443
+                __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+            })
+        ],
     }
 });

--- a/src/app/static/vue.config.js
+++ b/src/app/static/vue.config.js
@@ -39,8 +39,8 @@ module.exports = defineConfig({
         devtool: 'eval-source-map',
         plugins: [
             new webpack.DefinePlugin({
-                // Vue CLI is in maintenance mode, and probably won't this PR to fix this in their tooling
-                // https://github.com/vuejs/vue-cli/pull/7443
+                // Vue CLI is in maintenance mode, and probably won't fix this in their tooling
+                // see PR for more context https://github.com/vuejs/vue-cli/pull/7443
                 __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
             })
         ],


### PR DESCRIPTION
## Description

This PR fixes two issues
1. We were seeing version update occur much more frequently than on production, this is because the `dispatch` was being called with `timeout` arg set instead of the options :see_no_evil: have fixed this now so it sets the options. Can see this working nicely.
2. Also configure some setup to avoid a warning about "__VUE_PROD_HYDRATION_MISMATCH_DETAILS__" not being explicitly defined in the JS console

## Type of version change

None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
