### PR TITLE
Ensure that review input data is refetched when PJNZ or shape file are updated

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation "org.jooq:jooq:3.14.16"
     implementation 'org.pac4j:spring-webmvc-pac4j:6.0.2'
     implementation 'org.pac4j:pac4j-http:5.4.5'
-    implementation 'org.pac4j:pac4j-jwt:5.4.5'
+    implementation 'org.pac4j:pac4j-jwt:5.7.9'
     implementation 'org.pac4j:pac4j-sql:5.4.5'
     implementation 'org.pac4j:pac4j-oauth:5.4.5'
     implementation 'org.postgresql:postgresql:42.7.7'

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.14.13";
+export const currentHintVersion = "3.14.14";

--- a/src/app/static/src/app/store/baseline/actions.ts
+++ b/src/app/static/src/app/store/baseline/actions.ts
@@ -1,4 +1,4 @@
-import {ActionContext, ActionTree, Dispatch} from 'vuex';
+import {ActionContext, ActionTree, Commit, Dispatch} from 'vuex';
 import {BaselineState} from "./baseline";
 import {api} from "../../apiService";
 import {PjnzResponse, PopulationResponse, ShapeResponse, ValidateBaselineResponse} from "../../generated";
@@ -6,6 +6,8 @@ import {BaselineMutation} from "./mutations";
 import {buildData, findResource, getFilenameFromImportUrl, getFilenameFromUploadFormData} from "../../utils";
 import {DatasetResourceSet, DatasetResource, ADRSchemas, UploadImportPayload} from "../../types";
 import {RootState} from "../../root";
+import { ReviewInputMutation } from '../reviewInput/mutations';
+import { DATASET_TYPE } from '../surveyAndProgram/actions';
 
 export interface BaselineActions {
     refreshDatasetMetadata: (store: ActionContext<BaselineState, RootState>) => void
@@ -30,15 +32,24 @@ const uploadCallback = async (dispatch: Dispatch, response: any) => {
     await dispatch("surveyAndProgram/validateSurveyAndProgramData", {}, {root: true});
 }
 
+function commitClearReviewInputDataset(commit: Commit, dataType: string) {
+    if (dataType == DATASET_TYPE.SHAPE || dataType == DATASET_TYPE.PJNZ) {
+        // These review input plots both use shape and PJNZ to create the plot
+        commit({type: `reviewInput/${ReviewInputMutation.ClearDataset}`, payload: DATASET_TYPE.ART}, {root: true});
+        commit({type: `reviewInput/${ReviewInputMutation.ClearDataset}`, payload: DATASET_TYPE.ANC}, {root: true});
+        commit({type: `reviewInput/${ReviewInputMutation.ClearInputComparison}`}, {root: true});
+    }
+}
+
 interface UploadImportOptions {
     url: string
     payload: FormData | UploadImportPayload
 }
 
-
 async function uploadOrImportPJNZ(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions, filename: string) {
     const {commit, dispatch} = context;
     commit({type: BaselineMutation.PJNZUpdated, payload: null});
+    commitClearReviewInputDataset(commit, DATASET_TYPE.PJNZ);
     await api<BaselineMutation, BaselineMutation>(context)
         .withSuccess(BaselineMutation.PJNZUpdated)
         .withError(BaselineMutation.PJNZUploadError)
@@ -71,6 +82,7 @@ async function uploadOrImportPopulation(context: ActionContext<BaselineState, Ro
 async function uploadOrImportShape(context: ActionContext<BaselineState, RootState>, options: UploadImportOptions, filename: string) {
     const {commit, dispatch} = context;
     commit({type: BaselineMutation.ShapeUpdated, payload: null});
+    commitClearReviewInputDataset(commit, DATASET_TYPE.SHAPE);
     await api<BaselineMutation, BaselineMutation>(context)
         .withSuccess(BaselineMutation.ShapeUpdated)
         .withError(BaselineMutation.ShapeUploadError)
@@ -163,6 +175,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
     async deletePJNZ(context) {
         const {commit, dispatch} = context;
+        commitClearReviewInputDataset(commit, DATASET_TYPE.PJNZ);
         await api<BaselineMutation, BaselineMutation>(context)
             .delete("/baseline/pjnz/")
             .then((response) => {
@@ -175,6 +188,7 @@ export const actions: ActionTree<BaselineState, RootState> & BaselineActions = {
 
     async deleteShape(context) {
         const {commit, dispatch} = context;
+        commitClearReviewInputDataset(commit, DATASET_TYPE.SHAPE);
         await api<BaselineMutation, BaselineMutation>(context)
             .delete("/baseline/shape/")
             .then((response) => {

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -30,11 +30,13 @@ export interface SurveyAndProgramActions {
     setAncResponse: (store: ActionContext<SurveyAndProgramState, RootState>, data: AncResponse) => void;
 }
 
-const enum DATASET_TYPE {
+export const enum DATASET_TYPE {
     ANC = "anc",
     ART = "programme",
     SURVEY = "survey",
-    VMMC = "vmmc"
+    VMMC = "vmmc",
+    PJNZ = "pjnz",
+    SHAPE = "shape"
 }
 
 function commitClearReviewInputDataset(commit: Commit, dataType: string) {

--- a/src/app/static/src/tests/baseline/actions.test.ts
+++ b/src/app/static/src/tests/baseline/actions.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../mocks";
 import {actions} from "../../app/store/baseline/actions";
 import {BaselineMutation} from "../../app/store/baseline/mutations";
-import {expectEqualsFrozen, testUploadErrorCommitted} from "../testHelpers";
+import {expectClearReviewInputCommits, expectEqualsFrozen, testUploadErrorCommitted} from "../testHelpers";
 import {ADRSchemas} from "../../app/types";
 import {Mock} from "vitest";
 
@@ -206,9 +206,10 @@ describe("Baseline actions", () => {
     });
 
     const checkPJNZImportUpload = (commit: Mock, dispatch: Mock) => {
-        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls.length).toBe(5);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: BaselineMutation.PJNZUpdated, payload: null});
-        expectEqualsFrozen(commit.mock.calls[1][0], {
+        expectClearReviewInputCommits(commit, 1);
+        expectEqualsFrozen(commit.mock.calls[4][0], {
             type: BaselineMutation.PJNZUpdated,
             payload: {data: {country: "Malawi", iso3: "MWI"}}
         });
@@ -244,10 +245,11 @@ describe("Baseline actions", () => {
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/validateSurveyAndProgramData")
 
-        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls.length).toBe(6);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "PJNZUpdated", payload: null});
-        expect(commit.mock.calls[1][0]).toStrictEqual({type: "PJNZUploadError", payload: mockError("test error")});
-        expect(commit.mock.calls[2][0]).toStrictEqual({type: "PJNZErroredFile", payload: "some-file.txt"});
+        expectClearReviewInputCommits(commit, 1);
+        expect(commit.mock.calls[4][0]).toStrictEqual({type: "PJNZUploadError", payload: mockError("test error")});
+        expect(commit.mock.calls[5][0]).toStrictEqual({type: "PJNZErroredFile", payload: "some-file.txt"});
     });
 
     testUploadErrorCommitted("/baseline/pjnz/",
@@ -256,7 +258,8 @@ describe("Baseline actions", () => {
         BaselineMutation.PJNZErroredFile,
         "file.txt",
         mockFormData,
-        actions.uploadPJNZ);
+        actions.uploadPJNZ,
+        true);
 
     it("commits response and validates after shape file upload", async () => {
 
@@ -283,10 +286,11 @@ describe("Baseline actions", () => {
         expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0][0]).toBe("surveyAndProgram/validateSurveyAndProgramData");
 
-        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls.length).toBe(6);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: "ShapeUpdated", payload: null});
-        expect(commit.mock.calls[1][0]).toStrictEqual({type: "ShapeUploadError", payload: mockError("test error")});
-        expect(commit.mock.calls[2][0]).toStrictEqual({type: "ShapeErroredFile", payload: "some-file.txt"});
+        expectClearReviewInputCommits(commit, 1);
+        expect(commit.mock.calls[4][0]).toStrictEqual({type: "ShapeUploadError", payload: mockError("test error")});
+        expect(commit.mock.calls[5][0]).toStrictEqual({type: "ShapeErroredFile", payload: "some-file.txt"});
     });
 
     it("commits response and validates after shape file import", async () => {
@@ -313,16 +317,19 @@ describe("Baseline actions", () => {
         "ShapeErroredFile",
         "file.txt",
         mockFormData,
-        actions.uploadShape);
+        actions.uploadShape,
+        true);
 
     const checkShapeImportUpload = (commit: Mock, dispatch: Mock, mockShape: any) => {
-        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls.length).toBe(5);
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: BaselineMutation.ShapeUpdated,
             payload: null
         });
 
-        expectEqualsFrozen(commit.mock.calls[1][0], {
+        expectClearReviewInputCommits(commit, 1);
+
+        expectEqualsFrozen(commit.mock.calls[4][0], {
             type: BaselineMutation.ShapeUpdated,
             payload: mockShape
         });
@@ -519,7 +526,9 @@ describe("Baseline actions", () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         await actions.deletePJNZ({commit, dispatch, rootState} as any);
-        expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
+        expect(commit.mock.calls.length).toBe(4);
+        expectClearReviewInputCommits(commit, 0);
+        expect(commit.mock.calls[3][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
         expectValidationActionsDispatched(dispatch)
     });
 
@@ -531,7 +540,9 @@ describe("Baseline actions", () => {
         const commit = vi.fn();
         const dispatch = vi.fn();
         await actions.deleteShape({commit, dispatch, rootState} as any);
-        expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
+        expect(commit.mock.calls.length).toBe(4);
+        expectClearReviewInputCommits(commit, 0);
+        expect(commit.mock.calls[3][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
         expectValidationActionsDispatched(dispatch)
     });
 

--- a/src/app/static/src/tests/integration/baseline.itest.ts
+++ b/src/app/static/src/tests/integration/baseline.itest.ts
@@ -19,8 +19,8 @@ describe("Baseline actions", () => {
 
         await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, formData);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
-        expect(commit.mock.calls[1][0]["payload"]["filename"])
+        expect(commit.mock.calls[4][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
+        expect(commit.mock.calls[4][0]["payload"]["filename"])
             .toBe("Botswana2018.PJNZ");
     });
 
@@ -41,8 +41,8 @@ describe("Baseline actions", () => {
         const formData = getFormData("malawi.geojson");
         await actions.uploadShape({commit, dispatch, rootState} as any, formData);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
-        expect(commit.mock.calls[1][0]["payload"]["filename"])
+        expect(commit.mock.calls[4][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
+        expect(commit.mock.calls[4][0]["payload"]["filename"])
             .toBe("malawi.geojson");
 
     }, 10000);
@@ -79,7 +79,7 @@ describe("Baseline actions", () => {
 
         // delete
         await actions.deletePJNZ({commit, dispatch, rootState} as any);
-        expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
+        expect(commit.mock.calls[3][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
 
         commit.mockReset();
 
@@ -100,7 +100,7 @@ describe("Baseline actions", () => {
 
         // delete
         await actions.deleteShape({commit, dispatch, rootState} as any);
-        expect(commit.mock.calls[0][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
+        expect(commit.mock.calls[3][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
 
         commit.mockReset();
 

--- a/src/app/static/src/tests/integration/translation.itest.ts
+++ b/src/app/static/src/tests/integration/translation.itest.ts
@@ -19,8 +19,8 @@ describe("hintr translations", () => {
 
         await actions.uploadPJNZ({commit, state, dispatch, rootState} as any, formData);
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PJNZUploadError);
-        expect(commit.mock.calls[1][0]["payload"]["detail"])
+        expect(commit.mock.calls[4][0]["type"]).toBe(BaselineMutation.PJNZUploadError);
+        expect(commit.mock.calls[4][0]["payload"]["detail"])
             .toBe("Le fichier doit être de type PJNZ, zip, mais il est du type geojson.");
     });
 });

--- a/src/app/static/src/tests/testHelpers.ts
+++ b/src/app/static/src/tests/testHelpers.ts
@@ -16,13 +16,23 @@ export function expectEqualsFrozen(args: PayloadWithType<any>, expected: Payload
     expect(args).toStrictEqual(expected);
 }
 
+export function expectClearReviewInputCommits(commit: Mock, startIndex: number) {
+    expect(commit.mock.calls[startIndex][0]).toStrictEqual({type: "reviewInput/ClearDataset", payload: "programme"});
+    expect(commit.mock.calls[startIndex][1]).toStrictEqual({root: true});
+    expect(commit.mock.calls[startIndex + 1][0]).toStrictEqual({type: "reviewInput/ClearDataset", payload: "anc"});
+    expect(commit.mock.calls[startIndex + 1][1]).toStrictEqual({root: true});
+    expect(commit.mock.calls[startIndex + 2][0]).toStrictEqual({type: "reviewInput/ClearInputComparison"});
+    expect(commit.mock.calls[startIndex + 2][1]).toStrictEqual({root: true});
+}
+
 export function testUploadErrorCommitted(url: string,
                                          expectedErrorType: string,
                                          expectedSuccessType: string,
                                          expectedErroredFileType: string,
                                          expectedErroredFilename: string,
                                          formData: any,
-                                         action: (store: ActionContext<any, any>, formData: FormData) => void) {
+                                         action: (store: ActionContext<any, any>, formData: FormData) => void,
+                                         clearsReviewInput = false) {
 
     it(`commits error message when ${url} fails`, async () => {
 
@@ -41,13 +51,18 @@ export function testUploadErrorCommitted(url: string,
             payload: null
         });
 
+        const errorIndex = clearsReviewInput ? 4 : 1;
+        if (clearsReviewInput) {
+            expectClearReviewInputCommits(commit, 1);
+        }
+
         // then a call to set the error
-        expect(commit.mock.calls[1][0]).toStrictEqual({
+        expect(commit.mock.calls[errorIndex][0]).toStrictEqual({
             type: expectedErrorType,
             payload: mockError("Something went wrong")
         });
 
-        expect(commit.mock.calls[2][0]).toStrictEqual({
+        expect(commit.mock.calls[errorIndex + 1][0]).toStrictEqual({
             type: expectedErroredFileType,
             payload: expectedErroredFilename
         });

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(":app")
     implementation "com.offbytwo:docopt:0.6.0.20150202"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.pac4j:pac4j-jwt:5.4.5'
+    implementation 'org.pac4j:pac4j-jwt:5.7.9'
     implementation 'org.pac4j:pac4j-sql:5.4.5'
     implementation 'org.pac4j:pac4j-core:5.4.5'
     implementation "org.jooq:jooq:3.14.16"


### PR DESCRIPTION
## Description

When a PJNZ or shape file is updated we're not refetching review input data. But we should do as we use these to build the aggregated data.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
