### PR TITLE
Drop bearer in auth header for ADR calls, not required in new version of ADR

### DIFF
--- a/.github/workflows/test-adr-back-end.yml
+++ b/.github/workflows/test-adr-back-end.yml
@@ -28,3 +28,5 @@ jobs:
 
             - name: Test back end (ADR)
               run: src/gradlew -p src :app:test --tests org.imperial.mrc.hint.integration.adr* --parallel -x app:compileFrontEnd -x app:copyAssets
+              env:
+                ADR_TEST_KEY: ${{ secrets.ADR_TEST_KEY }}

--- a/.github/workflows/test-adr-front-end.yml
+++ b/.github/workflows/test-adr-front-end.yml
@@ -30,3 +30,5 @@ jobs:
 
             - name: Test front end (ADR)
               run: npm run adr-integration-test --prefix=src/app/static
+              env:
+                ADR_TEST_KEY: ${{ secrets.ADR_TEST_KEY }}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Ensure dependencies are running and then execute tests on the command line or th
 
 To run a specific test alone, add `--test` + the [fully qualified class name](https://docs.gradle.org/current/userguide/java_testing.html#full_qualified_name_pattern) to the command. For example, the command for running ProjectsControllerTests.kt would be: `./src/gradlew -p src :app:test --tests org.imperial.mrc.hint.unit.controllers.ProjectsControllerTests`
 
+To run the ADR tests you will need to setup and env var `ADR_TEST_KEY`. This should be a key for test user on the dev ADR system.
+
 ### Linting
 
 ```shell

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/ADRFuelClient.kt
@@ -40,7 +40,7 @@ class ADRClientBuilder(val appProperties: AppProperties,
 
         return ADRFuelClient(
             this.appProperties.oauth2ClientAdrServerUrl,
-            "Bearer $token",
+            token,
             this.logger
         )
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRController.kt
@@ -157,7 +157,7 @@ class ADRController(private val encryption: Encryption,
                     @RequestParam type: String? = null): ResponseEntity<String>
     {
         val adr = adrService.build()
-        var releasesResponse = adr.get("/dataset_version_list?dataset_id=${id}")
+        var releasesResponse = adr.get("dataset_version_list?dataset_id=${id}")
         if (type == "output") {
             val releases = objectMapper.readTree(releasesResponse.body!!)["data"]
             val filteredReleases = releases?.filter { release ->

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRPushController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/ADRPushController.kt
@@ -41,7 +41,7 @@ class ADRPushController(private val adrService: ADRService,
     {
         val adr = adrService.build()
         // checks for existing releases on ADR with the same name as the release being created
-        val releasesResponse = adr.get("/dataset_version_list?dataset_id=${id}")
+        val releasesResponse = adr.get("dataset_version_list?dataset_id=${id}")
         if (releasesResponse.statusCode != HttpStatus.OK)
         {
             return releasesResponse
@@ -52,13 +52,13 @@ class ADRPushController(private val adrService: ADRService,
         {
             val duplicateReleaseId = duplicateRelease["id"].asText()
             // if a release of the same name exists on ADR, request that it is deleted
-            val deleteResponse = adr.post("/version_delete", listOf("version_id" to duplicateReleaseId))
+            val deleteResponse = adr.post("version_delete", listOf("version_id" to duplicateReleaseId))
             if (deleteResponse.statusCode != HttpStatus.OK)
             {
                 return deleteResponse
             }
         }
-        return adr.post("/dataset_version_create", listOf("dataset_id" to id, "name" to name))
+        return adr.post("dataset_version_create", listOf("dataset_id" to id, "name" to name))
     }
 
     @PostMapping("/datasets/{id}/resource/{resourceType}/{downloadId}")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -20,7 +20,9 @@ import org.springframework.util.LinkedMultiValueMap
 // so are prone to flakiness when the ADR dev server goes down
 class ADRTests : SecureIntegrationTests()
 {
-    val ADR_KEY = "4c69b103-4532-4b30-8a37-27a15e56c0bb"
+    val ADR_KEY: String = System.getenv("ADR_TEST_KEY")
+        ?: error("ADR_TEST_KEY environment variable must be set to run ADR integration tests. " +
+                "Generate an API token for the test user on ${ConfiguredAppProperties().adrUrl}.")
     val ADR_TEST_DATASET_NAME = "antarctica-country-estimates-2026"
 
     @ParameterizedTest

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/ADRClientBuilderTests.kt
@@ -63,7 +63,7 @@ class ADRClientBuilderTests
         )
         val result = sut.buildSSO() as ADRFuelClient
         val headers = result.standardHeaders()
-        Assertions.assertThat(headers["Authorization"]).isEqualTo("Bearer FAKE_TOKEN")
+        Assertions.assertThat(headers["Authorization"]).isEqualTo("FAKE_TOKEN")
     }
 
     @Test
@@ -86,7 +86,7 @@ class ADRClientBuilderTests
         val result = sut.buildSSO() as ADRFuelClient
         val headers = result.standardHeaders()
         verify(mockLogger).info("There was a problem retrieving access token from Auth0")
-        Assertions.assertThat(headers["Authorization"]).isEqualTo("Bearer ")
+        Assertions.assertThat(headers["Authorization"]).isEqualTo("")
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRControllerTests.kt
@@ -353,7 +353,7 @@ class ADRControllerTests : HintrControllerTests()
     @Test
     fun `gets releases by id`()
     {
-        val expectedUrl = "/dataset_version_list?dataset_id=1234"
+        val expectedUrl = "dataset_version_list?dataset_id=1234"
         val mockClient = mock<ADRClient> {
             on { get(expectedUrl) } doReturn ResponseEntity
                     .ok()
@@ -391,7 +391,7 @@ class ADRControllerTests : HintrControllerTests()
                 mapOf("id" to "rel1", "package_id" to "1234"),
                 mapOf("id" to "rel2", "package_id" to "1234"))))
 
-        val getReleasesUrl = "/dataset_version_list?dataset_id=1234"
+        val getReleasesUrl = "dataset_version_list?dataset_id=1234"
         val getDatasetUrl1 = "package_show?id=1234&release=rel1"
         val getDatasetUrl2 = "package_show?id=1234&release=rel2"
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRPushControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/ADRPushControllerTests.kt
@@ -502,10 +502,10 @@ class ADRPushControllerTests
     {
         val data = mapOf("data" to listOf<Any>())
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
                     .ok()
                     .body(objectMapper.writeValueAsString(data))
-            on { post("/dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
+            on { post("dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
                     .ok()
                     .body("whatever")
         }
@@ -531,13 +531,13 @@ class ADRPushControllerTests
         val existingRelease = mapOf("name" to "release-1", "id" to "other-id")
         val data = mapOf("data" to listOf(existingRelease))
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
                     .ok()
                     .body(objectMapper.writeValueAsString(data))
-            on { post("/dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
+            on { post("dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
                     .ok()
                     .body("created release")
-            on { post("/version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity
+            on { post("version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity
                     .ok()
                     .body("deleted release")
         }
@@ -563,11 +563,11 @@ class ADRPushControllerTests
         val existingRelease = mapOf("name" to "release-1", "id" to "other-id")
         val data = mapOf("data" to listOf(existingRelease))
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
                     .ok()
                     .body(objectMapper.writeValueAsString(data))
-            on { post("/dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
-            on { post("/version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity
+            on { post("dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
+            on { post("version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity
                     .ok()
                     .body("whatever")
         }
@@ -594,10 +594,10 @@ class ADRPushControllerTests
         val existingRelease = mapOf("name" to "release-1", "id" to "other-id")
         val data = mapOf("data" to listOf(existingRelease))
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
                     .ok()
                     .body(objectMapper.writeValueAsString(data))
-            on { post("/version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
+            on { post("version_delete", listOf("version_id" to "other-id")) } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
         }
         val mockBuilder = mock<ADRService> {
             on { build() } doReturn mockClient
@@ -620,7 +620,7 @@ class ADRPushControllerTests
     fun `returns error if get releases endpoint fails while trying to create a release`()
     {
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway")
         }
         val mockBuilder = mock<ADRService> {
             on { build() } doReturn mockClient
@@ -645,10 +645,10 @@ class ADRPushControllerTests
         val existingRelease = mapOf("id" to "other-id")
         val data = mapOf("data" to listOf(existingRelease))
         val mockClient = mock<ADRClient> {
-            on { get("/dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
+            on { get("dataset_version_list?dataset_id=dataset-1") } doReturn ResponseEntity
                     .ok()
                     .body(objectMapper.writeValueAsString(data))
-            on { post("/dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
+            on { post("dataset_version_create", listOf("dataset_id" to "dataset-1", "name" to "release-1")) } doReturn ResponseEntity
                     .ok()
                     .body("whatever")
         }

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.14.14";
+export const currentHintVersion = "3.14.15";

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -25,8 +25,11 @@ describe("ADR dataset-related actions", () => {
 
     beforeAll(async () => {
         await login();
-        // this key is for a test user who has access to 1 fake dataset
-        const adrKey = "4c69b103-4532-4b30-8a37-27a15e56c0bb"
+        const adrKey = process.env.ADR_TEST_KEY;
+        if (!adrKey) {
+            throw new Error("ADR_TEST_KEY environment variable must be set to run ADR integration tests. " +
+                "Generate an API token for the test user on the dev ADR.");
+        }
         await adrActions.saveKey({commit: vi.fn(), rootState} as any, adrKey)
 
         const commit = vi.fn();
@@ -186,8 +189,9 @@ describe("ADR dataset-related actions", () => {
         await baselineActions.importPJNZ({commit, state, dispatch, rootState} as any,
             "https://raw.githubusercontent.com/hivtools/hint/main/src/app/testdata/Malawi2024.PJNZ");
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
-        expect(commit.mock.calls[1][0]["payload"]["filename"])
+        // calls 1-3 are reviewInput ClearDataset/ClearInputComparison commits
+        expect(commit.mock.calls[4][0]["type"]).toBe(BaselineMutation.PJNZUpdated);
+        expect(commit.mock.calls[4][0]["payload"]["filename"])
             .toBe("Malawi2024.PJNZ");
     }, 10000);
 
@@ -200,8 +204,9 @@ describe("ADR dataset-related actions", () => {
         await baselineActions.importShape({commit, dispatch, state, rootState} as any,
             "https://raw.githubusercontent.com/hivtools/hint/main/src/app/testdata/malawi.geojson");
 
-        expect(commit.mock.calls[1][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
-        expect(commit.mock.calls[1][0]["payload"]["filename"])
+        // calls 1-3 are reviewInput ClearDataset/ClearInputComparison commits
+        expect(commit.mock.calls[4][0]["type"]).toBe(BaselineMutation.ShapeUpdated);
+        expect(commit.mock.calls[4][0]["payload"]["filename"])
             .toBe("malawi.geojson");
 
     }, 10000);


### PR DESCRIPTION
## Description

This changed with move of CKAN to Azure. It now no longer requires the "Bearer" part in authorization token. This PR removes it. I wouldn't be too surprised if we need some follow up fix.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
